### PR TITLE
fix: remove vulnerability management and fix CI coverage merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,24 +167,87 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
       - name: Download all coverage artifacts
         uses: actions/download-artifact@v6
         with:
           pattern: coverage-*
           path: coverage-artifacts/
 
+      - name: List downloaded artifacts
+        run: |
+          echo "Downloaded coverage artifacts:"
+          ls -la coverage-artifacts/
+          echo ""
+          echo "Contents of each artifact:"
+          for dir in coverage-artifacts/*/; do
+            echo "=== $dir ==="
+            ls -la "$dir"
+          done
+
       - name: Merge coverage reports
         run: |
+          # Install nyc globally for coverage merging
+          npm install -g nyc
+          
+          # Create output directory
           mkdir -p coverage
-          # Copy the first coverage report as base
-          if [ -d "coverage-artifacts/coverage-integration" ]; then
-            cp -r coverage-artifacts/coverage-integration/* coverage/
-          elif [ -d "coverage-artifacts/coverage-server-api" ]; then
-            cp -r coverage-artifacts/coverage-server-api/* coverage/
-          elif [ -d "coverage-artifacts/coverage-schema" ]; then
-            cp -r coverage-artifacts/coverage-schema/* coverage/
+          
+          # Find and merge all coverage-final.json files
+          echo "Merging coverage reports from all test layers..."
+          
+          # Copy all coverage-final.json files to a temp directory
+          mkdir -p .nyc_output
+          find coverage-artifacts -name 'coverage-final.json' -type f | while read file; do
+            layer=$(echo "$file" | sed 's|coverage-artifacts/coverage-||' | sed 's|/.*||')
+            echo "Found coverage from: $layer"
+            cp "$file" ".nyc_output/coverage-${layer}.json"
+          done
+          
+          # List what we're merging
+          echo ""
+          echo "Coverage files to merge:"
+          ls -la .nyc_output/
+          
+          # Merge all coverage files
+          if [ -n "$(ls -A .nyc_output/*.json 2>/dev/null)" ]; then
+            echo ""
+            echo "Merging coverage reports..."
+            nyc merge .nyc_output coverage/coverage-final.json
+            
+            # Generate reports in multiple formats
+            echo ""
+            echo "Generating coverage reports..."
+            nyc report \
+              --temp-dir .nyc_output \
+              --report-dir coverage \
+              --reporter=json-summary \
+              --reporter=json \
+              --reporter=lcov \
+              --reporter=html \
+              --reporter=text
+            
+            echo ""
+            echo "✅ Coverage reports merged successfully"
+            
+            # Show summary
+            if [ -f "coverage/coverage-summary.json" ]; then
+              echo ""
+              echo "Coverage Summary:"
+              cat coverage/coverage-summary.json | grep -A 10 '"total"' || true
+            fi
+          else
+            echo "❌ No coverage files found to merge"
+            exit 1
           fi
-          echo "Coverage artifacts merged"
 
       - name: Report Coverage
         uses: davelosert/vitest-coverage-report-action@v2

--- a/schema/fixtures/audit-trail-examples.cypher
+++ b/schema/fixtures/audit-trail-examples.cypher
@@ -86,7 +86,7 @@ ORDER BY a.timestamp DESC;
 
 // Get all SBOM-related operations
 MATCH (a:AuditLog)
-WHERE a.operation IN ['SBOM_UPLOAD', 'COMPONENT_DISCOVERED', 'VULNERABILITY_DETECTED']
+WHERE a.operation IN ['SBOM_UPLOAD', 'COMPONENT_DISCOVERED']
 RETURN a
 ORDER BY a.timestamp DESC;
 

--- a/schema/migrations/common/20251102_180000_enhance_component_for_sbom.up.cypher
+++ b/schema/migrations/common/20251102_180000_enhance_component_for_sbom.up.cypher
@@ -142,8 +142,19 @@ FOR (e:ExternalReference)
 ON (e.url);
 
 // ============================================================================
-// VULNERABILITY NODE TYPE
+// VULNERABILITY NODE TYPE (SUPERSEDED - SEE NOTE BELOW)
 // ============================================================================
+
+// NOTE: This vulnerability schema was removed by migration 20251125_074808
+// and is no longer part of Polaris. See ADR-0003 for the architectural decision
+// to exclude CVE/vulnerability management from Polaris.
+//
+// Polaris focuses on technology governance and SBOM tracking.
+// Vulnerability management is handled by specialized security tools
+// (Dependabot, Trivy, Grype, etc.) that operate alongside Polaris.
+//
+// The following schema elements are kept here for historical reference but
+// are immediately removed by migration 20251125_074808:
 
 // Create Vulnerability node type
 CREATE CONSTRAINT vulnerability_id_unique IF NOT EXISTS

--- a/schema/migrations/common/20251201_071900_remove_vulnerability_from_sbom_migration.down.cypher
+++ b/schema/migrations/common/20251201_071900_remove_vulnerability_from_sbom_migration.down.cypher
@@ -1,0 +1,29 @@
+/*
+ * Migration Rollback: Remove Vulnerability Schema from SBOM Enhancement Migration
+ * Version: 2025.12.01.071900
+ * Author: Ona
+ * 
+ * Description:
+ * Rollback for the consolidation migration. This is a no-op rollback since the
+ * forward migration was also a no-op (documentation only).
+ *
+ * To restore vulnerability schema, you would need to:
+ * 1. Rollback migration 20251125_074808_remove_vulnerability_node
+ * 2. Re-apply migration 20251102_180000_enhance_component_for_sbom
+ *
+ * However, this is NOT recommended as it contradicts ADR-0003.
+ */
+
+// ============================================================================
+// NO-OP ROLLBACK
+// ============================================================================
+
+// This rollback is intentionally empty since the forward migration was a no-op.
+// The vulnerability schema removal was handled by migration 20251125_074808.
+
+// ============================================================================
+// REMOVE MIGRATION TRACKING
+// ============================================================================
+
+MATCH (m:Migration {version: '20251201_071900'})
+DELETE m;

--- a/schema/migrations/common/20251201_071900_remove_vulnerability_from_sbom_migration.up.cypher
+++ b/schema/migrations/common/20251201_071900_remove_vulnerability_from_sbom_migration.up.cypher
@@ -1,0 +1,57 @@
+/*
+ * Migration: Remove Vulnerability Schema from SBOM Enhancement Migration
+ * Version: 2025.12.01.071900
+ * Author: Ona
+ * 
+ * Description:
+ * This migration consolidates the removal of vulnerability-related schema that was
+ * originally added in migration 20251102_180000_enhance_component_for_sbom.up.cypher
+ * and later removed in migration 20251125_074808_remove_vulnerability_node.up.cypher.
+ * 
+ * This is a no-op migration that documents the decision to exclude vulnerability
+ * management from Polaris (see ADR-0003). The vulnerability schema was already
+ * removed by migration 20251125_074808, so this migration serves as documentation
+ * and ensures consistency in the migration history.
+ *
+ * Background:
+ * - Migration 20251102_180000 added Vulnerability node type with constraints/indexes
+ * - Migration 20251125_074808 removed all Vulnerability nodes and schema
+ * - ADR-0003 documents the decision to exclude CVE/vulnerability management
+ * - Polaris focuses on technology governance; security tools handle vulnerabilities
+ *
+ * Dependencies:
+ * - 20251125_074808_remove_vulnerability_node.up.cypher (already applied)
+ *
+ * Rollback: See corresponding .down.cypher file
+ */
+
+// ============================================================================
+// NO-OP MIGRATION - VULNERABILITY SCHEMA ALREADY REMOVED
+// ============================================================================
+
+// This migration is intentionally empty. The vulnerability schema was already
+// removed by migration 20251125_074808_remove_vulnerability_node.up.cypher.
+// 
+// This migration exists to:
+// 1. Document the consolidation of vulnerability removal
+// 2. Provide a clear migration history
+// 3. Reference ADR-0003 for the architectural decision
+//
+// The following schema elements were removed by migration 20251125_074808:
+// - CONSTRAINT vulnerability_id_unique
+// - INDEX vulnerability_severity
+// - INDEX vulnerability_cvss_score
+// - INDEX vulnerability_published_date
+// - All Vulnerability nodes and relationships
+
+// ============================================================================
+// MIGRATION TRACKING
+// ============================================================================
+
+CREATE (m:Migration {
+  version: '20251201_071900',
+  name: 'remove_vulnerability_from_sbom_migration',
+  appliedAt: datetime(),
+  description: 'Consolidates vulnerability schema removal (no-op, already removed by 20251125_074808)',
+  references: 'ADR-0003: Exclude CVE and Vulnerability Management'
+});

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -331,11 +331,6 @@ This API implements **RMM Level 2** with proper use of HTTP methods and status c
             systemCount: { 
               type: 'integer',
               description: 'Number of systems using this component'
-            },
-            vulnerabilityCount: { 
-              type: 'integer',
-              nullable: true,
-              description: 'Number of known vulnerabilities'
             }
           }
         },

--- a/test/integration/audit-trail.spec.ts
+++ b/test/integration/audit-trail.spec.ts
@@ -538,48 +538,6 @@ describeFeature(feature, ({ Background, Scenario }) => {
     })
   })
 
-  Scenario('Tracking vulnerability detection', ({ When, Then }) => {
-    When('I create an audit log for vulnerability detection:', async () => {
-      const session = driver.session()
-      try {
-        auditLogId = `audit-${Date.now()}-${Math.random().toString(36).substring(2, 11)}`
-        const result = await session.run(`
-          CREATE (a:AuditLog {
-            id: $id,
-            timestamp: datetime(),
-            operation: $operation,
-            entityType: $entityType,
-            entityId: $entityId,
-            userId: 'system',
-            source: 'SYSTEM',
-            metadata: $metadata
-          })
-          RETURN a
-        `, {
-          id: auditLogId,
-          operation: 'VULNERABILITY_DETECTED',
-          entityType: 'Component',
-          entityId: 'lodash@4.17.20',
-          metadata: JSON.stringify({
-            vulnerabilityId: 'CVE-2024-12345',
-            severity: 'HIGH'
-          })
-        })
-
-        auditLog = result.records[0].get('a').properties
-      } finally {
-        await session.close()
-      }
-    })
-
-    Then('the audit log should capture the vulnerability details', () => {
-      expect(auditLog.operation).toBe('VULNERABILITY_DETECTED')
-      const metadata = JSON.parse(auditLog.metadata)
-      expect(metadata.vulnerabilityId).toBe('CVE-2024-12345')
-      expect(metadata.severity).toBe('HIGH')
-    })
-  })
-
   Scenario('Using session and correlation IDs', ({ When, Then, And }) => {
     let session: neo4j.Session
 

--- a/test/integration/features/audit-trail.feature
+++ b/test/integration/features/audit-trail.feature
@@ -72,16 +72,6 @@ Feature: Audit Trail Schema @model @unit
     Then the audit log should capture the SBOM details
     And the metadata should include component count
 
-  Scenario: Tracking vulnerability detection
-    When I create an audit log for vulnerability detection:
-      | field              | value                           |
-      | operation          | VULNERABILITY_DETECTED          |
-      | entityType         | Component                       |
-      | entityId           | react@18.2.0                    |
-      | vulnerabilityId    | CVE-2024-12345                  |
-      | severity           | HIGH                            |
-    Then the audit log should capture the vulnerability details
-
   Scenario: Using session and correlation IDs
     When I create multiple audit logs with the same sessionId
     Then I should be able to query all logs for that session

--- a/test/server/api/components.spec.ts
+++ b/test/server/api/components.spec.ts
@@ -30,8 +30,7 @@ const mockComponents: Component[] = [
     publishedDate: null,
     modifiedDate: null,
     technologyName: 'React',
-    systemCount: 5,
-    vulnerabilityCount: 0
+    systemCount: 5
   }
 ]
 

--- a/test/server/services/component.service.spec.ts
+++ b/test/server/services/component.service.spec.ts
@@ -34,8 +34,7 @@ describe('ComponentService', () => {
       publishedDate: null,
       modifiedDate: null,
       technologyName: 'React',
-      systemCount: 5,
-      vulnerabilityCount: 0
+      systemCount: 5
     },
     {
       name: 'vue',
@@ -60,8 +59,7 @@ describe('ComponentService', () => {
       publishedDate: null,
       modifiedDate: null,
       technologyName: 'Vue',
-      systemCount: 3,
-      vulnerabilityCount: 0
+      systemCount: 3
     }
   ]
 

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -86,7 +86,6 @@ export interface Component {
   // === RELATIONSHIPS (computed) ===
   technologyName: string | null  // Linked Technology name
   systemCount: number            // Number of systems using this
-  vulnerabilityCount?: number    // Number of known vulnerabilities
 }
 
 export interface UnmappedComponent {
@@ -195,73 +194,6 @@ export interface Violation {
   status: string
   resolvedAt: string | null
   notes: string | null
-}
-
-// ============================================================================
-// VULNERABILITY TYPES
-// ============================================================================
-
-export type VulnerabilitySeverity = 
-  | 'critical'
-  | 'high'
-  | 'medium'
-  | 'low'
-  | 'info'
-  | 'none'
-  | 'unknown'
-
-export type VulnerabilityAnalysisState = 
-  | 'exploitable'
-  | 'in_triage'
-  | 'false_positive'
-  | 'not_affected'
-  | 'resolved'
-
-export type VulnerabilityResponse = 
-  | 'can_not_fix'
-  | 'will_not_fix'
-  | 'update'
-  | 'rollback'
-  | 'workaround_available'
-
-export interface VulnerabilityRating {
-  score: number              // CVSS score (0-10)
-  severity: VulnerabilitySeverity
-  method: string             // CVSSv2, CVSSv3, CVSSv31, OWASP, etc.
-  vector: string | null      // CVSS vector string
-}
-
-export interface VulnerabilityAnalysis {
-  state: VulnerabilityAnalysisState
-  justification: string | null
-  response: VulnerabilityResponse | null
-  detail: string | null
-}
-
-export interface Vulnerability {
-  id: string                 // CVE-2024-1234, GHSA-xxxx-xxxx-xxxx
-  source: string             // NVD, GitHub, OSV, etc.
-  description: string | null
-  recommendation: string | null
-  
-  // Ratings
-  ratings: VulnerabilityRating[]
-  cwes: number[]             // CWE IDs
-  
-  // Temporal
-  createdDate: string | null
-  publishedDate: string | null
-  updatedDate: string | null
-  
-  // Analysis
-  analysis: VulnerabilityAnalysis | null
-  
-  // References
-  advisories: string[]       // URLs to advisories
-  
-  // Relationships (computed)
-  affectedComponents: string[]  // Component purls
-  affectedSystemCount: number
 }
 
 export interface User {


### PR DESCRIPTION
## Description

This PR completes the implementation of ADR-0003 (Exclude CVE and Vulnerability Management) by removing all remaining vulnerability-related code from the codebase. It also fixes the CI coverage merge issue that was causing discrepancies between local and CI coverage reports.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Configuration or build changes

## Related Issues

Relates to ADR-0003: Exclude CVE and Vulnerability Management
Fixes coverage discrepancy between local and CI environments

## Changes Made

### Vulnerability Management Removal (ADR-0003)
- Removed all vulnerability-related types from `types/api.d.ts`:
  - `VulnerabilitySeverity`
  - `VulnerabilityAnalysisState`
  - `VulnerabilityResponse`
  - `VulnerabilityRating`
  - `VulnerabilityAnalysis`
  - `Vulnerability` interface
- Removed `vulnerabilityCount` property from `Component` interface
- Removed `vulnerabilityCount` from OpenAPI schema (`server/openapi.ts`)
- Removed vulnerability detection scenario from integration tests
- Removed `VULNERABILITY_DETECTED` from audit trail examples
- Updated test mocks to remove `vulnerabilityCount` references
- Added consolidation migration documenting vulnerability removal
- Added note to SBOM enhancement migration about superseded vulnerability schema

### CI Coverage Merge Fix
- Replaced broken coverage merge logic that only copied first report
- Implemented proper coverage merging using `nyc merge`
- Added Node.js setup and dependency installation to coverage-report job
- Added detailed logging for debugging coverage merge process
- Generate multiple report formats (json-summary, json, lcov, html, text)
- Added error handling for missing coverage files
- Coverage now properly aggregates from all 6 test layers:
  - integration (165 tests)
  - server-api (100 tests)
  - server-utils (57 tests)
  - schema tests
  - app-e2e tests
  - smoke tests

## Test Results

All tests passing:
- ✅ Unit tests: 163 passed
- ✅ Server tests: 263 passed
- ✅ Integration tests: 165 passed
- ✅ TypeScript compilation: No errors
- ✅ Linting: No errors

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

### Why This Matters

**Vulnerability Management Removal:**
- Aligns codebase with ADR-0003 architectural decision
- Polaris focuses on technology governance and SBOM tracking
- Vulnerability management is handled by specialized security tools (Dependabot, Trivy, Grype)
- Removes 65 lines of unused type definitions
- Simplifies the data model

**Coverage Merge Fix:**
- Resolves discrepancy where CI showed lower coverage than local
- CI was only using 1 of 6 coverage reports (missing 5/6 of data)
- Now properly merges all test layer coverage reports
- CI coverage should now match local `npm run test:coverage` results
- Better visibility into actual test coverage

### Migration Notes

The new migration `20251201_071900_remove_vulnerability_from_sbom_migration` is a no-op documentation migration. The actual vulnerability schema was already removed by migration `20251125_074808_remove_vulnerability_node`. This migration exists to:
1. Document the consolidation of vulnerability removal
2. Provide clear migration history
3. Reference ADR-0003 for the architectural decision

### Verification

After merge, verify CI coverage report job shows:
- "Found coverage from: integration"
- "Found coverage from: server-api"
- "Found coverage from: server-utils"
- "Found coverage from: schema"
- "Found coverage from: app-e2e"
- "Found coverage from: smoke"
- "✅ Coverage reports merged successfully"

Co-authored-by: Ona <no-reply@ona.com>