### PR TITLE
feat: Add Licenses to navigation menu

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -72,6 +72,17 @@
           </NuxtLink>
 
           <NuxtLink
+            to="/licenses"
+            class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+            active-class="bg-primary-50 text-primary-600 dark:bg-primary-900/20 dark:text-primary-400"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+            </svg>
+            <span>Licenses</span>
+          </NuxtLink>
+
+          <NuxtLink
             to="/policies"
             class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
             active-class="bg-primary-50 text-primary-600 dark:bg-primary-900/20 dark:text-primary-400"


### PR DESCRIPTION
## Description

Adds a Licenses menu item to the sidebar navigation to make the license inventory page easily discoverable.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Related to #106 - Completes the license compliance UI by adding navigation

## Changes Made

### Navigation Enhancement
- Add "Licenses" menu item to sidebar navigation
- Position between "Components" and "Policies" for logical grouping
- Use scale/balance icon to represent licenses
- Maintain consistent styling with other menu items
- Active state highlighting when on /licenses page

### Visual Design
- Icon: Scale/balance SVG icon (represents legal/compliance)
- Styling: Matches existing navigation items
- Hover state: Gray background on hover
- Active state: Primary color background and text when active
- Dark mode: Full dark mode support

## Benefits

- **Discoverability**: Users can easily find the license inventory page
- **Consistency**: Follows existing navigation patterns
- **UX**: Logical placement between related features (Components → Licenses → Policies)
- **Accessibility**: Clear icon and label for screen readers

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

### Dependencies
- Depends on #106 (License compliance UI) - PR #110
- Requires /licenses page to exist

### Test Results
- All linting checks passing
- Navigation tested in light and dark modes
- Active state verified on /licenses page
- Hover effects working correctly

Co-authored-by: Ona <no-reply@ona.com>