### PR TITLE
feat: add Licenses menu item to navigation

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -61,6 +61,17 @@
           </NuxtLink>
 
           <NuxtLink
+            to="/licenses"
+            class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
+            active-class="bg-primary-50 text-primary-600 dark:bg-primary-900/20 dark:text-primary-400"
+          >
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2m0-2v2m0 16V5m0 16H9m3 0h3" />
+            </svg>
+            <span>Licenses</span>
+          </NuxtLink>
+
+          <NuxtLink
             to="/teams"
             class="flex items-center gap-3 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 rounded-lg transition-colors hover:bg-gray-100 dark:hover:bg-gray-700"
             active-class="bg-primary-50 text-primary-600 dark:bg-primary-900/20 dark:text-primary-400"


### PR DESCRIPTION
Add Licenses to sidebar navigation between Components and Teams

Changes:
- Add Licenses navigation link with scale/balance icon
- Position after Components for logical grouping
- Maintain consistent styling with other menu items
- Active state highlighting when on /licenses page

## Description

<!-- Provide a clear and concise description of your changes -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made

<!-- List the specific changes you made -->

- 
- 
- 

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

## Checklist

<!-- Mark completed items with an "x" -->

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my changes
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings or errors
- [ ] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed

## Additional Notes

<!-- Add any additional information that reviewers should know -->