### PR TITLE
feat: add color mode switcher and clean up dependencies

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -4,10 +4,18 @@
     <aside class="w-64 border-r border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 flex flex-col">
       <!-- Logo -->
       <div class="p-4 border-b border-gray-200 dark:border-gray-800">
-        <NuxtLink to="/" class="flex items-center gap-2">
-          <UIcon name="i-lucide-zap" class="w-6 h-6 text-primary" />
-          <span class="text-xl font-bold">Polaris</span>
-        </NuxtLink>
+        <div class="flex items-center justify-between">
+          <NuxtLink to="/" class="flex items-center gap-2">
+            <UIcon name="i-lucide-zap" class="w-6 h-6 text-primary" />
+            <span class="text-xl font-bold">Polaris</span>
+          </NuxtLink>
+          <ClientOnly>
+            <UColorModeButton color="neutral" variant="ghost" />
+            <template #fallback>
+              <div class="w-8 h-8" />
+            </template>
+          </ClientOnly>
+        </div>
       </div>
 
       <!-- Navigation -->
@@ -66,6 +74,8 @@
           class="w-full"
         />
       </nav>
+
+
     </aside>
 
     <!-- Main Content -->

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,9 +26,7 @@ export default defineNuxtConfig({
     '@nuxt/ui'
   ],
 
-  ui: {
-    colorMode: false
-  },
+
 
   auth: {
     // baseURL will be auto-detected from request origin if not set

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,13 @@
         "@nuxt/image": "^2.0.0",
         "@nuxt/test-utils": "^3.23.0",
         "@nuxt/ui": "^4.4.0",
-        "@nuxtjs/color-mode": "^4.0.0",
+        "@sidebase/nuxt-auth": "^1.1.1",
         "ajv": "^8.17.1",
         "better-sqlite3": "^12.6.0",
         "eslint": "^9.39.2",
         "mermaid": "^11.12.2",
-        "nuxt": "^4.0.0",
+        "next-auth": "4.21.1",
+        "nuxt": "4.0.0",
         "nuxt-neo4j": "^0.0.4",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
@@ -33,13 +34,11 @@
         "@cucumber/messages": "^32.0.1",
         "@cyclonedx/cdxgen": "^12.0.0",
         "@playwright/test": "^1.57.0",
-        "@sidebase/nuxt-auth": "^1.1.1",
         "@types/node": "^25.0.6",
         "@types/swagger-jsdoc": "^6.0.4",
         "@vitest/coverage-v8": "^4.0.16",
         "@vitest/ui": "^4.0.16",
         "markdownlint-cli": "^0.47.0",
-        "next-auth": "4.22.1",
         "patch-package": "^8.0.1",
         "swagger-jsdoc": "^6.2.8",
         "tsx": "^4.21.0",
@@ -869,7 +868,6 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
       "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3429,15 +3427,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@netlify/dev-utils/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/@netlify/dev-utils/node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -4320,15 +4309,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@netlify/zip-it-and-ship-it/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/@netlify/zip-it-and-ship-it/node_modules/path-scurry": {
@@ -6915,17 +6895,94 @@
       }
     },
     "node_modules/@nuxtjs/color-mode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@nuxtjs/color-mode/-/color-mode-4.0.0.tgz",
-      "integrity": "sha512-xyaVR/TPLdMuRa2VOgH6b75jvmFEsn9QKL6ISldaAw38ooFJfWY1ts2F3ye43wcT/goCbcuvPuskF2f8yUZhlw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@nuxtjs/color-mode/-/color-mode-3.5.2.tgz",
+      "integrity": "sha512-cC6RfgZh3guHBMLLjrBB2Uti5eUoGM9KyauOaYS9ETmxNWBMTvpgjvSiSJp1OFljIXPIqVTJ3xtJpSNZiO3ZaA==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/kit": "^4.2.1",
+        "@nuxt/kit": "^3.13.2",
+        "pathe": "^1.1.2",
+        "pkg-types": "^1.2.1",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.0.tgz",
+      "integrity": "sha512-KMTLK/dsGaQioZzkYUvgfN9le4grNW54aNcA1jqzgVZLcFVy4jJfrJr5WZio9NT2EMfajdoZ+V28aD7BRr4Zfw==",
+      "license": "MIT",
+      "dependencies": {
+        "c12": "^3.3.3",
+        "consola": "^3.4.2",
+        "defu": "^6.1.4",
+        "destr": "^2.0.5",
+        "errx": "^0.1.0",
         "exsolve": "^1.0.8",
+        "ignore": "^7.0.5",
+        "jiti": "^2.6.1",
+        "klona": "^2.0.6",
+        "knitwork": "^1.3.0",
+        "mlly": "^1.8.0",
+        "ohash": "^2.0.11",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.0",
-        "semver": "^7.7.3"
+        "rc9": "^2.1.2",
+        "scule": "^1.3.0",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ufo": "^1.6.3",
+        "unctx": "^2.5.0",
+        "untyped": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
       }
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/@nuxt/kit/node_modules/pkg-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
+      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.2.2",
+        "exsolve": "^1.0.7",
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "license": "MIT"
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/pkg-types/node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
+    "node_modules/@nuxtjs/color-mode/node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
     },
     "node_modules/@nuxtjs/mdc": {
       "version": "0.20.0",
@@ -7711,7 +7768,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
       "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -8133,7 +8189,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-alias/-/plugin-alias-6.0.0.tgz",
       "integrity": "sha512-tPCzJOtS7uuVZd+xPhoy5W4vThe6KWXNmsFCNktaAh5RTqcLiSfT4huPQIXkgJ6YCOjJHvecOAzQxLFhPxKr+g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
@@ -8151,7 +8206,6 @@
       "version": "29.0.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-29.0.0.tgz",
       "integrity": "sha512-U2YHaxR2cU/yAiwKJtJRhnyLk7cifnQw0zUpISsocBDoHDJn+HTV74ABqnwr5bEgWUwFZC9oFL6wLe21lHu5eQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^5.0.1",
@@ -8178,7 +8232,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-inject": {
@@ -8737,7 +8790,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@sidebase/nuxt-auth/-/nuxt-auth-1.1.1.tgz",
       "integrity": "sha512-vFQvQnwZ3a5D4U95OohRrAWLnyccRLab1bNjFn4lSkHLaoAE6ZoPC2TGL8lG/dTW/m1qfQvfgh5LqlNZSxpUBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.17.6",
@@ -8761,7 +8813,6 @@
       "version": "3.21.0",
       "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.0.tgz",
       "integrity": "sha512-KMTLK/dsGaQioZzkYUvgfN9le4grNW54aNcA1jqzgVZLcFVy4jJfrJr5WZio9NT2EMfajdoZ+V28aD7BRr4Zfw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.3",
@@ -8818,7 +8869,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9232,48 +9282,48 @@
       }
     },
     "node_modules/@tiptap/core": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.17.1.tgz",
-      "integrity": "sha512-f8hB9MzXqsuXoF9qXEDEH5Fb3VgwhEFMBMfk9EKN88l5adri6oM8mt2XOWVxVVssjpEW0177zXSLPKWzoS/vrw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.18.0.tgz",
+      "integrity": "sha512-Gczd4GbK1DNgy/QUPElMVozoa0GW9mW8E31VIi7Q4a9PHHz8PcrxPmuWwtJ2q0PF8MWpOSLuBXoQTWaXZRPRnQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.17.1.tgz",
-      "integrity": "sha512-X4jU/fllJQ8QbjCHUafU4QIHBobyXP3yGBoOcXxUaKlWbLvUs0SQTREM3n6/86m2YyAxwTPG1cn3Xypf42DMAQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.18.0.tgz",
+      "integrity": "sha512-1HjEoM5vZDfFnq2OodNpW13s56a9pbl7jolUv1V9FrE3X5s7n0HCfDzIVpT7z1HgTdPtlN5oSt5uVyBwuwSUfA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-bold": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.17.1.tgz",
-      "integrity": "sha512-PZmrljcVBziJkQDXT/QJv4ESxVVQ0iRH+ruTzPda56Kk4h2310cSXGjI33W7rlCikGPoBAAjY/inujm46YB4bw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.18.0.tgz",
+      "integrity": "sha512-xUgOvHCdGXh9Lfxd7DtgsSr0T/egIwBllWHIBWDjQEQQ0b+ICn+0+i703btHMB4hjdduZtgVDrhK8jAW3U6swA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.17.1.tgz",
-      "integrity": "sha512-z3E8biLiWlzZJwNHnB6j/ZyBdFrJmpl1lqKHc72JqahUHZvidZHdCOYssvR3fc6IaI7MXV13XY1DXUdFbatnaw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.18.0.tgz",
+      "integrity": "sha512-9kYG1fVYQcA3Kp5Bq96lrKCp9oLpQqceDsK688r7iT1yymQlBPMunaqaqb5ZLQGhnNYbhfG+8xcQsvEKjklErA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
@@ -9283,83 +9333,83 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.17.1.tgz",
-      "integrity": "sha512-2zw17XHruOJQK7ntLVq0PmOLajFhvQ+U4/qTfJnV3VOsHkm+2GPAksFe7I7+X0XmSmDru0pcT339Yywx/6Aykw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.18.0.tgz",
+      "integrity": "sha512-8sEpY0nxAGGFDYlF+WVFPKX00X2dAAjmoi0+2eWvK990PdQqwXrQsRs7pkUbpE2mDtATV8+GlDXk9KDkK/ZXhA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.17.1"
+        "@tiptap/extension-list": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-code": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.17.1.tgz",
-      "integrity": "sha512-4W0x1ZZqSnIVzQV0/b5VR0bktef2HykH5I/Czzir9yqoZ5zV2cLrMVuLvdFNgRIckU60tQLmHrfKWLF50OY0ew==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.18.0.tgz",
+      "integrity": "sha512-0SU53O0NRmdtRM2Hgzm372dVoHjs2F40o/dtB7ls4kocf4W89FyWeC2R6ZsFQqcXisNh9RTzLtYfbNyizGuZIw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-code-block": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.17.1.tgz",
-      "integrity": "sha512-h4i+Y/cN7nMi0Tmlp6V1w4dI7NTqrUFSr1W/vMqnq4vn+c6jvm35KubKU5ry/1qQp8KfndDA02BtVQiMx6DmpA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.18.0.tgz",
+      "integrity": "sha512-fCx1oT95ikGfoizw+XCjeglQxlLK4lWgUcB4Dcn5TdaCoFBQMEaZs7Q0jVajxxxULnyArkg60uarc1ac/IF2Hw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-collaboration": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.17.1.tgz",
-      "integrity": "sha512-4ehZ5LL7M3nFfcogCG7bWRHIR/8366i1vz5i0PaaoArJga2N5sXnWcuBGXG7ykC8owbgrfL3agFxjHlhTl4sNw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.18.0.tgz",
+      "integrity": "sha512-2wTgp41F5ab58buXrPBeerOf0VaW/c1LEx4kAzr72Z6zw0CcDGQYuSZTqE7RLGXxDga6VUi+Ts/U0HvxWpzIWw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1",
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0",
         "@tiptap/y-tiptap": "^3.0.2",
         "yjs": "^13"
       }
     },
     "node_modules/@tiptap/extension-document": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.17.1.tgz",
-      "integrity": "sha512-F7Q5HoAU383HWFa6AXZQ5N6t6lTJzVjYM8z93XrtH/2GzDFwy1UmDSrsXqvgznedBLAOgCNVTNh9PjXpLoOUbg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.18.0.tgz",
+      "integrity": "sha512-e0hOGrjTMpCns8IC5p+c5CEiE1BBmFBFL+RpIxU/fjT2SaZ7q2xsFguBu94lQDT0cD6fdZokFRpGwEMxZNVGCg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-drag-handle": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.17.1.tgz",
-      "integrity": "sha512-RKrhs+z5ki4/WPKA8P+G9bRWoWAGXI3NjwrJtIA27PO19tZAwTZs6oKFcyTtp6FtMKgny3n0qm+UZxxRppDRUQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.18.0.tgz",
+      "integrity": "sha512-2nR/SNolRtr+Ix3iRhr8xu2JaLJl61jbyn1X80SYi0pydoLmM2v47ZdVyP6lkQ+UeYluBHl3Quj+ylwOJqmwwg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.6.13"
@@ -9369,46 +9419,46 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/extension-collaboration": "^3.17.1",
-        "@tiptap/extension-node-range": "^3.17.1",
-        "@tiptap/pm": "^3.17.1",
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/extension-collaboration": "^3.18.0",
+        "@tiptap/extension-node-range": "^3.18.0",
+        "@tiptap/pm": "^3.18.0",
         "@tiptap/y-tiptap": "^3.0.2"
       }
     },
     "node_modules/@tiptap/extension-drag-handle-vue-3": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.17.1.tgz",
-      "integrity": "sha512-y5p0CYoTwvnqdf5FXJm1GZscEmSPdv2iKk4Pui/dhsnNIIkhMhB71bDpFBYez/von2NSReW4N9T/Oyju1XQ/rQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.18.0.tgz",
+      "integrity": "sha512-WqviXqMRRAZSmMjvUki5fSI+G9XfzUX7TDxnntN9B3ZyJDMFoJetUVc1+DFpmEQNTD9NmnO3M3o//ugexpT0RA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-drag-handle": "^3.17.1",
-        "@tiptap/pm": "^3.17.1",
-        "@tiptap/vue-3": "^3.17.1",
+        "@tiptap/extension-drag-handle": "^3.18.0",
+        "@tiptap/pm": "^3.18.0",
+        "@tiptap/vue-3": "^3.18.0",
         "vue": "^3.0.0"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.17.1.tgz",
-      "integrity": "sha512-EKJYPb7OSk3p9mX1SmHt4ccw89w1P1d55hC8aPtZJ6jxAUd5MSuVwvEEVz7LGldUZD9HZz9WFQ0Sv9U73Bpkmw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.18.0.tgz",
+      "integrity": "sha512-pIW/K9fGth221dkfA5SInHcqfnCr0aG9LGkRiEh4gwM4cf6ceUBrvcD+QlemSZ4q9oktNGJmXT+sEXVOQ8QoeQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.17.1"
+        "@tiptap/extensions": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.17.1.tgz",
-      "integrity": "sha512-zYkoYsxp+cZ8tBDODm4E8hnSaMTdDWKJuCQWY2Ep14oMPkAkSJr8sCLL1tOnNSAnhGwLJQtRLkZ41nvUEP6xKA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.18.0.tgz",
+      "integrity": "sha512-a2cBQi0I/X0o3a9b+adwJvkdxLzQzJIkP9dc/v25qGTSCjC1+ycois5WQOn8T4T8t4g/fAH1UOXEWnkWyTxLIg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -9416,93 +9466,93 @@
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.17.1.tgz",
-      "integrity": "sha512-xItmJZTi+Z6UbLBhpBBL9RZDNbDXf+ntWVgblAmxtpyEyNh5k5tkM6IP9SJRhk92uVfnFpH9qkGo66a537I8QA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.18.0.tgz",
+      "integrity": "sha512-covioXPPHX3SnlTwC/1rcHUHAc7/JFd4vN0kZQmZmvGHlxqq2dPmtrPh8D7TuDuhG0k/3Z6i8dJFP0phfRAhuA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.17.1"
+        "@tiptap/extensions": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.17.1.tgz",
-      "integrity": "sha512-28FZPUho1Q2AB3ka5SVEVib5f9dMKbE1kewLZeRIOQ5FuFNholGIPL5X1tKcwGW7G3A7Y0fGxeNmIZJ3hrqhzA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.18.0.tgz",
+      "integrity": "sha512-IXLiOHEmbU2Wn1jFRZC6apMxiJQvSRWhwoiubAvRxyiPSnFTeaEgT8Qgo5DjwB39NckP+o7XX7RrgzlkwdFPQQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-heading": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.17.1.tgz",
-      "integrity": "sha512-rT+Su/YnHdlikg8f78t6RXlc1sVSfp7B0fdJdtFgS2e6BBYJQoDMp5L9nt54RR9Yy953aDW2sko7NArUCb8log==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.18.0.tgz",
+      "integrity": "sha512-MTamVnYsFWVndLSq5PRQ7ZmbF6AExsFS9uIvGtUAwuhzvR4of/WHh6wpvWYjA+BLXTWRrfuGHaZTl7UXBN13fg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.17.1.tgz",
-      "integrity": "sha512-CHG6LBtxV+3qj5EcCRVlpvSW5udKD6KbnXIGhP+Tvy+OabLGzO4HNxz3+duDE0pMR4eKX1libsnqffj0vq7mnQ==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.18.0.tgz",
+      "integrity": "sha512-fEq7DwwQZ496RHNbMQypBVNqoWnhDEERbzWMBqlmfCfc/0FvJrHtsQkk3k4lgqMYqmBwym3Wp0SrRYiyKCPGTw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-image": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.17.1.tgz",
-      "integrity": "sha512-VbSSZ//5qijm8F0lQQ6K+DGnZgjLKYQY2c+O56QNEoN8BaCFrJlsVgF1ttrSRUmoG4XBNIMlAS07kZXvMZQr0g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.18.0.tgz",
+      "integrity": "sha512-Hc8riY43yPlQDKIpJf/aZ3kw1WNYjJrBH7UZKGQ9cfmUfnKQgN6+bfWgyvtQezDfhvVL6RNKSGNfoYHkV+rJaA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-italic": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.17.1.tgz",
-      "integrity": "sha512-unfRLmvf680Y0UkBToUcrDkSEKO/wAjd3nQ7CNPMfAc8m+ZMReXkcgLpeVvnDEiHNsJ0PlYSW7a45tnQD9HQdg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.18.0.tgz",
+      "integrity": "sha512-1C4nB08psiRo0BPxAbpYq8peUOKnjQWtBCLPbE6B9ToTK3vmUk0AZTqLO11FvokuM1GF5l2Lg3sKrKFuC2hcjQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-link": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.17.1.tgz",
-      "integrity": "sha512-5kdN7vms5hMXtjiophUkgvzy8dNGvGSmol1Sawh30TEPrgXc93Ayj7YyGZlbimInKZcD8q+Od/FFc+wkrof3nA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.18.0.tgz",
+      "integrity": "sha512-1J28C4+fKAMQi7q/UsTjAmgmKTnzjExXY98hEBneiVzFDxqF69n7+Vb7nVTNAIhmmJkZMA0DEcMhSiQC/1/u4A==",
       "license": "MIT",
       "dependencies": {
         "linkifyjs": "^4.3.2"
@@ -9512,192 +9562,192 @@
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-list": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.17.1.tgz",
-      "integrity": "sha512-LHKIxmXe5Me+vJZKhiwMBGHlApaBIAduNMRUpm5mkY7ER/m96zKR0VqrJd4LjVVH2iDvck5h1Ka4396MHWlKNg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.18.0.tgz",
+      "integrity": "sha512-9lQBo45HNqIFcLEHAk+CY3W51eMMxIJjWbthm2CwEWr4PB3+922YELlvq8JcLH1nVFkBVpmBFmQe/GxgnCkzwQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-list-item": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.17.1.tgz",
-      "integrity": "sha512-Qjj4oIa44cTX0E6aw/4+wleqX21t5jMDxeSqP5uQ8Q3IdD1GoR5+yo+41XAHELaeZOXLHLkAIbzIxik3pOqO8w==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.18.0.tgz",
+      "integrity": "sha512-auTSt+NXoUnT0xofzFa+FnXsrW1TPdT1OB3U1OqQCIWkumZqL45A8OK9kpvyQsWj/xJ8fy1iZwFlKXPtxjLd2w==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.17.1"
+        "@tiptap/extension-list": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.17.1.tgz",
-      "integrity": "sha512-zRidxbkJNe/j3nZpOGLnPeVdyciUM8MM+NHhxcjVKoNDA+/zEBfjXJ1dKC4UBsnSr4AS/3SCWBYHGXOoSqdUaA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.18.0.tgz",
+      "integrity": "sha512-ZzO5r/cW7G0zpL/eM69WPnMpzb0YsSjtI60CYGA0iQDRJnK9INvxu0RU0ewM2faqqwASmtjuNJac+Fjk6scdXg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.17.1"
+        "@tiptap/extension-list": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-mention": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.17.1.tgz",
-      "integrity": "sha512-rggEOD7cnuglVtc7zvVYx/2u7w7XpkdR6BTSXNWohsCJDwpKx5MBfuQMXULlRKY9/N49FgwHzP8ipkSvgOtiEw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.18.0.tgz",
+      "integrity": "sha512-2obPAXksR4I2OwKZKYEoMwKGFEnsANlE83hAILNYGb5oSnDkHj8KHxQKcIutv6G25OLDTfMMh7VE/YUq2iempw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1",
-        "@tiptap/suggestion": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0",
+        "@tiptap/suggestion": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-node-range": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.17.1.tgz",
-      "integrity": "sha512-tGt/Yr7aALKsrerAldQG5iBUFmml2i25nrjLIU+SR1Bzm+OWxTSXxOWunkowdquh2f/Lft5GnnSIs3e3Jr20Bg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.18.0.tgz",
+      "integrity": "sha512-aw9m4i1qznQ/HA+bPIZ7CVUOmVUcIBkTNt3IXHMNAuK8NTJr141gnKDtgF4UUCAnpKBXq8F8++VKdBUszvpZZA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.17.1.tgz",
-      "integrity": "sha512-pahAXbVajqX0Y51Zge9jKZlCtPV1oiq5Fbzs7gHF80KICIKf44i/AsUvfdJyT2N5/8kZrAMQHEiU/UgTMrhM3w==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.18.0.tgz",
+      "integrity": "sha512-5bUAfklYLS5o6qvLLfreGyGvD1JKXqOQF0YntLyPuCGrXv7+XjPWQL2BmEf59fOn2UPT2syXLQ1WN5MHTArRzg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extension-list": "^3.17.1"
+        "@tiptap/extension-list": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.17.1.tgz",
-      "integrity": "sha512-Vl+xAlINaPtX8XTPvPmeveYMEIMLs8gA7ItcKpyyo4cCzAfVCY3DKuWzOkQGUf7DKrhyJQZhpgLNMaq+h5sTSw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.18.0.tgz",
+      "integrity": "sha512-uvFhdwiur4NhhUdBmDsajxjGAIlg5qga55fYag2DzOXxIQE2M7/aVMRkRpuJzb88GY4EHSh8rY34HgMK2FJt2Q==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-placeholder": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.17.1.tgz",
-      "integrity": "sha512-cE8Rij5/1t4KnWE7GaDewhBek9DKNB+97yrxyggMegILg6v195hOmOkRZkyfnFMYZoBDlrfSAtX9wBvbZBqIsg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.18.0.tgz",
+      "integrity": "sha512-jhN1Xa+MpfrTcCYZsFSvZYpUuMutPTC20ms0IsH1yN0y9tbAS+T6PHPC+dsvyAinYdA8yKElM6OO+jpyz4X1cw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/extensions": "^3.17.1"
+        "@tiptap/extensions": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-strike": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.17.1.tgz",
-      "integrity": "sha512-c6fS6YIhxoU55etlJgM0Xqker+jn7I1KC7GVu6ljmda8I00K3/lOLZgvFUNPmgp8EJWtyTctj+3D3D+PaZaFAA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.18.0.tgz",
+      "integrity": "sha512-kl/fa68LZg8NWUqTkRTfgyCx+IGqozBmzJxQDc1zxurrIU+VFptDV9UuZim587sbM2KGjCi/PNPjPGk1Uu0PVg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-text": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.17.1.tgz",
-      "integrity": "sha512-rGml96vokQbvPB+w6L3+WKyYJWwqELaLdFUr1WMgg+py5uNYGJYAExYNAbDb5biWJBrX9GgMlCaNeiJj849L1w==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.18.0.tgz",
+      "integrity": "sha512-9TvctdnBCwK/zyTi9kS7nGFNl5OvGM8xE0u38ZmQw5t79JOqJHgOroyqMjw8LHK/1PWrozfNCmsZbpq4IZuKXw==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extension-underline": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.17.1.tgz",
-      "integrity": "sha512-6RdBzmkg6DYs0EqPyoqLGkISXzCnPqM/q3A6nh3EmFmORcIDfuNmcidvA6EImebK8KQGmtZKsRhQSnK4CNQ39g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.18.0.tgz",
+      "integrity": "sha512-009IeXURNJ/sm1pBqbj+2YQgjQaBtNlJR3dbl6xu49C+qExqCmI7klhKQuwsVVGLR7ahsYlp7d9RlftnhCXIcQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1"
+        "@tiptap/core": "^3.18.0"
       }
     },
     "node_modules/@tiptap/extensions": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.17.1.tgz",
-      "integrity": "sha512-aQ4WA5bdRpv9yPQ6rRdiqwlMZ1eJw1HyEaNPQhOr2HVhQ0EqSDIOEXF4ymCveGAHxXbxNvtQ+4t1ymQEikGfXA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.18.0.tgz",
+      "integrity": "sha512-uSRIE9HGshBN6NRFR3LX2lZqBLvX92SgU5A9AvUbJD4MqU63E+HdruJnRjsVlX3kPrmbIDowxrzXlUcg3K0USQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/markdown": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.17.1.tgz",
-      "integrity": "sha512-GyjSTF0TabmlVryf2o98QNYCtqbfPn2CpKdGeNONF6npvT7+aHRE1j7LR8jK34nkQmHYUVuSfoYRzKfIsJ/vBA==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.18.0.tgz",
+      "integrity": "sha512-F4gAr8QXc61dwOi/fwumx/mTqX0CjHiYvN/A4btPf0TpwXRcEVvlN1iz8A/8heXppbyyM6EliSMFFWN2sgVT+w==",
       "license": "MIT",
       "dependencies": {
-        "marked": "^15.0.12"
+        "marked": "^17.0.1"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/pm": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.17.1.tgz",
-      "integrity": "sha512-UyVLkN8axV/zop6Se2DCBJRu5DM21X0XEQvwEC5P/vk8eC9OcQZ3FLtxeYy2ZjpAZUzBGLw0/BGsmEip/n7olw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.18.0.tgz",
+      "integrity": "sha512-8RoI5gW0xBVCsuxahpK8vx7onAw6k2/uR3hbGBBnH+HocDMaAZKot3nTyY546ij8ospIC1mnQ7k4BhVUZesZDQ==",
       "license": "MIT",
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
@@ -9725,35 +9775,35 @@
       }
     },
     "node_modules/@tiptap/starter-kit": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.17.1.tgz",
-      "integrity": "sha512-3vBGqag9mwuQoWTrfQlULtHeoFs7k/2Q8CREf3Y79hv2fqAXTvTOKlWYPSgZhiGVMp6Dti7BDiE9Y1QpvAat2g==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.18.0.tgz",
+      "integrity": "sha512-LctpCelqI/5nHEeZgCPiwI1MmTjGr6YCIBGWmS5s4DJE7NfevEkwomR/C05QKdVUwPhpCXIMeS1+h/RYqRo1KA==",
       "license": "MIT",
       "dependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/extension-blockquote": "^3.17.1",
-        "@tiptap/extension-bold": "^3.17.1",
-        "@tiptap/extension-bullet-list": "^3.17.1",
-        "@tiptap/extension-code": "^3.17.1",
-        "@tiptap/extension-code-block": "^3.17.1",
-        "@tiptap/extension-document": "^3.17.1",
-        "@tiptap/extension-dropcursor": "^3.17.1",
-        "@tiptap/extension-gapcursor": "^3.17.1",
-        "@tiptap/extension-hard-break": "^3.17.1",
-        "@tiptap/extension-heading": "^3.17.1",
-        "@tiptap/extension-horizontal-rule": "^3.17.1",
-        "@tiptap/extension-italic": "^3.17.1",
-        "@tiptap/extension-link": "^3.17.1",
-        "@tiptap/extension-list": "^3.17.1",
-        "@tiptap/extension-list-item": "^3.17.1",
-        "@tiptap/extension-list-keymap": "^3.17.1",
-        "@tiptap/extension-ordered-list": "^3.17.1",
-        "@tiptap/extension-paragraph": "^3.17.1",
-        "@tiptap/extension-strike": "^3.17.1",
-        "@tiptap/extension-text": "^3.17.1",
-        "@tiptap/extension-underline": "^3.17.1",
-        "@tiptap/extensions": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/extension-blockquote": "^3.18.0",
+        "@tiptap/extension-bold": "^3.18.0",
+        "@tiptap/extension-bullet-list": "^3.18.0",
+        "@tiptap/extension-code": "^3.18.0",
+        "@tiptap/extension-code-block": "^3.18.0",
+        "@tiptap/extension-document": "^3.18.0",
+        "@tiptap/extension-dropcursor": "^3.18.0",
+        "@tiptap/extension-gapcursor": "^3.18.0",
+        "@tiptap/extension-hard-break": "^3.18.0",
+        "@tiptap/extension-heading": "^3.18.0",
+        "@tiptap/extension-horizontal-rule": "^3.18.0",
+        "@tiptap/extension-italic": "^3.18.0",
+        "@tiptap/extension-link": "^3.18.0",
+        "@tiptap/extension-list": "^3.18.0",
+        "@tiptap/extension-list-item": "^3.18.0",
+        "@tiptap/extension-list-keymap": "^3.18.0",
+        "@tiptap/extension-ordered-list": "^3.18.0",
+        "@tiptap/extension-paragraph": "^3.18.0",
+        "@tiptap/extension-strike": "^3.18.0",
+        "@tiptap/extension-text": "^3.18.0",
+        "@tiptap/extension-underline": "^3.18.0",
+        "@tiptap/extensions": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       },
       "funding": {
         "type": "github",
@@ -9761,36 +9811,36 @@
       }
     },
     "node_modules/@tiptap/suggestion": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.17.1.tgz",
-      "integrity": "sha512-a188uVYjlLsUiwK3Ki7KsaWVWC0u28KsqGEAqCk9ECYmtVY99Hrb+rcAwGpMjA7tn8WAwThOxiLISoMdpuqXwg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.18.0.tgz",
+      "integrity": "sha512-AxJfM34e6wFPKVsfyXSvHN1wBBiXIm65hUmY+newop+DMeOjsvkO7M6j7tzUR2Nnrh1AQEsVr6iR0UzO91PBSA==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "peerDependencies": {
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1"
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0"
       }
     },
     "node_modules/@tiptap/vue-3": {
-      "version": "3.17.1",
-      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.17.1.tgz",
-      "integrity": "sha512-0NaAY3+S1KZuSY9Sl6e0zvgcX8JvKKwDamY+YOl/ZO4GRaA1VnVkS/OJtofuTAODJmoXWL8wS9NwOgAzKeAvkw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.18.0.tgz",
+      "integrity": "sha512-3JUMYqFYXEOKk2zOtPp6wuEzHAHrHdrswaRhHVVDR8olO9PpbuJ6qu83RJUB8OZVnP7dv3yxIakDf1AHMxLQXg==",
       "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
       },
       "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.17.1",
-        "@tiptap/extension-floating-menu": "^3.17.1"
+        "@tiptap/extension-bubble-menu": "^3.18.0",
+        "@tiptap/extension-floating-menu": "^3.18.0"
       },
       "peerDependencies": {
         "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "^3.17.1",
-        "@tiptap/pm": "^3.17.1",
+        "@tiptap/core": "^3.18.0",
+        "@tiptap/pm": "^3.18.0",
         "vue": "^3.0.0"
       }
     },
@@ -10793,7 +10843,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@vercel/nft/-/nft-1.3.0.tgz",
       "integrity": "sha512-i4EYGkCsIjzu4vorDUbqglZc5eFtQI2syHb++9ZUDm6TU4edVywGpVnYDein35x9sevONOn9/UabfQXuNXtuzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mapbox/node-pre-gyp": "^2.0.0",
@@ -10820,14 +10869,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@vercel/nft/node_modules/resolve-from": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10870,9 +10917,9 @@
       }
     },
     "node_modules/@vitejs/plugin-vue-jsx/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.1.tgz",
-      "integrity": "sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==",
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.2.tgz",
+      "integrity": "sha512-izyXV/v+cHiRfozX62W9htOAvwMo4/bXKDrQ+vom1L1qRuexPock/7VZDAhnpHCLNejd3NJ6hiab+tO0D44Rgw==",
       "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
@@ -13459,7 +13506,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
       "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -14893,7 +14939,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
       "integrity": "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^5.0.0"
@@ -14909,7 +14954,6 @@
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.4.2.tgz",
       "integrity": "sha512-FLEenlVYf7Zcd34ISMLo3ZzRE1gRjY1nMDTp+bQRBiPsaKyIW8K3Zr99ioHDUgA9OGuGGJPyYpNcffGmBhJfGg==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -15962,6 +16006,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/eslint/node_modules/yocto-queue": {
@@ -17427,7 +17480,6 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
       "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "minimatch": "^10.1.1",
@@ -17554,7 +17606,6 @@
       "version": "16.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.0.tgz",
       "integrity": "sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -17575,7 +17626,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -17588,7 +17638,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
       "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -19025,7 +19074,6 @@
       "version": "4.15.9",
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
       "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -20086,7 +20134,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.1.tgz",
       "integrity": "sha512-xrHS24IxaLrvuo613F719wvOIv9xPHFWQHuvGUBmPnCA/3MQxKI3b+r7n1jAoDHmsbC5bRhTZYR77invLAxVnw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.28.5",
@@ -20307,15 +20354,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
+      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/matcher": {
@@ -21865,10 +21912,9 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.22.1.tgz",
-      "integrity": "sha512-NTR3f6W7/AWXKw8GSsgSyQcDW6jkslZLH8AiZa5PQ09w1kR8uHtR9rez/E9gAq/o17+p0JYHE8QjF3RoniiObA==",
-      "dev": true,
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.21.1.tgz",
+      "integrity": "sha512-NYkU4jAPSVxWhCblE8dDFAnKM7kOoO/QEobQ0RoEVP9Wox99A3PKHwOAsWhSg8ahJG/iKIWk2Bo1xHvsS4R39Q==",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
@@ -21897,7 +21943,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -21907,7 +21952,6 @@
       "version": "2.13.1",
       "resolved": "https://registry.npmjs.org/nitropack/-/nitropack-2.13.1.tgz",
       "integrity": "sha512-2dDj89C4wC2uzG7guF3CnyG+zwkZosPEp7FFBGHB3AJo11AywOolWhyQJFHDzve8COvGxJaqscye9wW2IrUsNw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "^0.4.2",
@@ -22001,14 +22045,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-2.0.0.tgz",
       "integrity": "sha512-RAj4E421UYRgqokKUmotqAwuplYw15qtdXfY+hGzgCJ/MBjCVZcSoHK/kH9kocfjRjcDME7IiDWR/1WX1TM2Pg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nitropack/node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
       "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -22021,7 +22063,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",
       "integrity": "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa"
       ],
@@ -23633,7 +23674,6 @@
       "version": "0.9.15",
       "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/object-assign": {
@@ -23656,7 +23696,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
       "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -23715,7 +23754,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.2.0.tgz",
       "integrity": "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^10.13.0 || >=12.0.0"
@@ -23856,7 +23894,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
       "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "jose": "^4.15.9",
@@ -23872,7 +23909,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
@@ -23885,7 +23921,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/optionator": {
@@ -24458,12 +24493,12 @@
       "license": "MIT"
     },
     "node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/path-is-absolute": {
@@ -24495,7 +24530,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
       "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -25147,7 +25181,6 @@
       "version": "10.28.2",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
       "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -25158,7 +25191,6 @@
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
       "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pretty-format": "^3.8.0"
@@ -25259,7 +25291,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
       "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -25272,7 +25303,6 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/proc-log": {
@@ -26354,7 +26384,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/requrl/-/requrl-3.0.2.tgz",
       "integrity": "sha512-f3gjR6d8MhOpn46PP+DSJywbmxi95fxQm3coXBFwognjFLla9X6tr8BdNyaIKNOEkaRbRcm0/zYAqN19N1oyhg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/reserved-identifiers": {
@@ -28192,7 +28221,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
       "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -69,21 +69,17 @@
     "@nuxt/image": "^2.0.0",
     "@nuxt/test-utils": "^3.23.0",
     "@nuxt/ui": "^4.4.0",
-    "@nuxtjs/color-mode": "^4.0.0",
     "@sidebase/nuxt-auth": "^1.1.1",
     "ajv": "^8.17.1",
     "better-sqlite3": "^12.6.0",
     "eslint": "^9.39.2",
     "mermaid": "^11.12.2",
     "next-auth": "4.21.1",
-    "nuxt": "^4.0.0",
+    "nuxt": "4.0.0",
     "nuxt-neo4j": "^0.0.4",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "vue": "^3.5.26"
-  },
-  "overrides": {
-    "@nuxtjs/color-mode": "^4.0.0"
   },
   "devDependencies": {
     "@amiceli/vitest-cucumber": "^6.2.0",


### PR DESCRIPTION
## Description

Add a color mode switcher to the sidebar header and clean up redundant dependencies.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Relates to dependency management and UI improvements

## Changes Made

- Add `UColorModeButton` to sidebar header for light/dark theme switching
- Remove redundant `@nuxtjs/color-mode` direct dependency (automatically provided by `@nuxt/ui`)
- Remove `overrides` section from package.json (no longer needed)
- Remove `ui: { colorMode: false }` from nuxt.config.ts to enable color mode integration
- Pin `nuxt` to `4.0.0` to avoid compatibility issues with `@nuxt/icon` in nuxt 4.3.0

## Screenshots

The color mode button appears as a sun/moon icon in the sidebar header next to the Polaris logo.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`

## Additional Notes

The nuxt version is pinned to 4.0.0 because nuxt 4.3.0 introduces a compatibility issue with `@nuxt/icon` (bundled with `@nuxt/ui`), causing a runtime error: `Package import specifier "#imports" is not defined`. This is a known upstream issue.