### PR TITLE
feat: license enable/disable with audit logging and violation detection

### DIFF
--- a/app/pages/audit.vue
+++ b/app/pages/audit.vue
@@ -91,9 +91,10 @@ import type { TableColumn } from '@nuxt/ui'
 interface AuditEntry {
   id: string
   entityType: string
-  entityName: string
+  entityId: string
+  entityLabel: string | null
   operation: string
-  performedBy: string
+  userId: string | null
   timestamp: string
 }
 
@@ -113,6 +114,11 @@ function getOperationColor(operation: string): 'success' | 'warning' | 'error' |
     CREATE: 'success',
     UPDATE: 'warning',
     DELETE: 'error',
+    ENABLE: 'success',
+    DISABLE: 'error',
+    ACTIVATE: 'success',
+    ARCHIVE: 'warning',
+    DEACTIVATE: 'error',
     DENY_LICENSE: 'error',
     ALLOW_LICENSE: 'success'
   }
@@ -141,13 +147,21 @@ const columns: TableColumn<AuditEntry>[] = [
     cell: ({ row }) => h('span', { class: 'font-medium' }, row.getValue('entityType') as string)
   },
   {
-    accessorKey: 'entityName',
+    accessorKey: 'entityLabel',
     header: 'Entity',
-    cell: ({ row }) => row.getValue('entityName') as string
+    cell: ({ row }) => {
+      const label = row.original.entityLabel || row.original.entityId
+      return label || '—'
+    }
   },
   {
-    accessorKey: 'performedBy',
-    header: 'Performed By'
+    accessorKey: 'userId',
+    header: 'Performed By',
+    cell: ({ row }) => {
+      const userId = row.getValue('userId') as string | null
+      if (!userId) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return userId
+    }
   },
   {
     accessorKey: 'timestamp',

--- a/server/api/admin/licenses/whitelist.put.ts
+++ b/server/api/admin/licenses/whitelist.put.ts
@@ -81,7 +81,7 @@ interface WhitelistUpdateResponse {
  */
 export default defineEventHandler(async (event): Promise<WhitelistUpdateResponse> => {
   // Require superuser access
-  await requireSuperuser(event)
+  const user = await requireSuperuser(event)
 
   try {
     const body = await readBody<WhitelistUpdateRequest>(event)
@@ -116,7 +116,7 @@ export default defineEventHandler(async (event): Promise<WhitelistUpdateResponse
     // Handle single license update
     if (body.licenseId) {
       try {
-        await licenseService.updateWhitelistStatus(body.licenseId, body.whitelisted)
+        await licenseService.updateWhitelistStatus(body.licenseId, body.whitelisted, user.id)
         setResponseStatus(event, 200)
         return {
           success: true,
@@ -140,7 +140,7 @@ export default defineEventHandler(async (event): Promise<WhitelistUpdateResponse
 
     // Handle bulk license update
     if (body.licenseIds) {
-      const result = await licenseService.bulkUpdateWhitelistStatus(body.licenseIds, body.whitelisted)
+      const result = await licenseService.bulkUpdateWhitelistStatus(body.licenseIds, body.whitelisted, user.id)
       
       if (result.success) {
         setResponseStatus(event, 200)

--- a/server/database/queries/policies/find-disabled-license-violations.cypher
+++ b/server/database/queries/policies/find-disabled-license-violations.cypher
@@ -1,0 +1,25 @@
+// Find components using disabled (non-whitelisted) licenses
+// A license with whitelisted=false is considered disabled and any usage is a violation
+
+MATCH (system:System)<-[:OWNS]-(team:Team)
+MATCH (system)-[:USES]->(component:Component)-[:HAS_LICENSE]->(license:License)
+WHERE license.whitelisted = false
+{{AND_CONDITIONS}}
+RETURN team.name as teamName,
+       system.name as systemName,
+       component.name as componentName,
+       component.version as componentVersion,
+       component.purl as componentPurl,
+       license.id as licenseId,
+       license.name as licenseName,
+       license.category as licenseCategory,
+       license.osiApproved as licenseOsiApproved,
+       'Disabled License' as policyName,
+       'License has been disabled by an administrator' as policyDescription,
+       'error' as severity,
+       'license-disabled' as ruleType,
+       null as enforcedBy
+ORDER BY
+  team.name,
+  system.name,
+  component.name

--- a/server/repositories/policy.repository.ts
+++ b/server/repositories/policy.repository.ts
@@ -671,6 +671,33 @@ export class PolicyRepository extends BaseRepository {
     return records.map(record => this.mapToLicenseViolation(record))
   }
 
+  async findDisabledLicenseViolations(filters: ViolationFilters): Promise<LicenseViolation[]> {
+    const query = await loadQuery('policies/find-disabled-license-violations.cypher')
+
+    const params: Record<string, string> = {}
+    const conditions: string[] = []
+
+    if (filters.team) {
+      conditions.push('team.name = $team')
+      params.team = filters.team
+    }
+
+    if (filters.system) {
+      conditions.push('system.name = $system')
+      params.system = filters.system
+    }
+
+    if (filters.license) {
+      conditions.push('license.id = $license')
+      params.license = filters.license
+    }
+
+    const finalQuery = injectWhereConditions(query, conditions)
+    const { records } = await this.executeQuery(finalQuery, params)
+
+    return records.map(record => this.mapToLicenseViolation(record))
+  }
+
   /**
    * Map Neo4j record to PolicyViolation domain object
    */

--- a/server/services/license.service.ts
+++ b/server/services/license.service.ts
@@ -110,15 +110,15 @@ export class LicenseService {
    * @param whitelisted - New whitelist status
    * @returns True if license was updated successfully
    */
-  async updateWhitelistStatus(id: string, whitelisted: boolean): Promise<boolean> {
+  async updateWhitelistStatus(id: string, whitelisted: boolean, userId?: string): Promise<boolean> {
     // Verify license exists
     const license = await this.licenseRepo.findById(id)
     if (!license) {
       throw new Error(`License '${id}' not found`)
     }
     
-    // Update whitelist status
-    const updated = await this.licenseRepo.updateWhitelistStatus(id, whitelisted)
+    // Update whitelist status and create audit log
+    const updated = await this.licenseRepo.updateWhitelistStatus(id, whitelisted, userId)
     
     if (!updated) {
       throw new Error(`Failed to update whitelist status for license '${id}'`)
@@ -140,7 +140,7 @@ export class LicenseService {
    * @param whitelisted - New whitelist status
    * @returns Operation summary with success status, updated count, and any errors
    */
-  async bulkUpdateWhitelistStatus(licenseIds: string[], whitelisted: boolean): Promise<{
+  async bulkUpdateWhitelistStatus(licenseIds: string[], whitelisted: boolean, userId?: string): Promise<{
     success: boolean
     updated: number
     errors: string[]
@@ -190,7 +190,7 @@ export class LicenseService {
       }
 
       // All licenses exist, proceed with atomic bulk update
-      const updated = await this.licenseRepo.bulkUpdateWhitelistStatus(licenseIds, whitelisted)
+      const updated = await this.licenseRepo.bulkUpdateWhitelistStatus(licenseIds, whitelisted, userId)
       
       // Check if all licenses were updated (should not happen with atomic transaction, but safety check)
       if (updated < licenseIds.length) {


### PR DESCRIPTION
## Motivation

Superusers need to enable/disable licenses from the UI, with changes tracked in the audit log and disabled licenses surfaced as violations.

## Changes

### License actions (`/licenses`)
- Action dropdown on each row with "View Components" link
- Superusers see an "Enable" or "Disable" toggle that calls `PUT /api/admin/licenses/whitelist`
- New "Status" column showing enabled/disabled badge

### Audit logging
- `updateWhitelistStatus` and `bulkUpdateWhitelistStatus` now create `AuditLog` nodes in the same Cypher transaction
- Records operation (ENABLE/DISABLE), previous/new status, and user ID
- User ID passed from API endpoint through service to repository

### Violation detection (`/violations/licenses`)
- New Cypher query `find-disabled-license-violations.cypher` finds components using non-whitelisted licenses
- Service merges policy-based and disabled-license violations, deduplicating by component+license key
- Disabled license violations appear with severity "error" and rule type "license-disabled"

### Audit log page (`/audit`)
- Fixed empty Entity column: `entityName` → `entityLabel` (falls back to `entityId`)
- Fixed empty Performed By column: `performedBy` → `userId`
- Added operation color mappings for ENABLE, DISABLE, ACTIVATE, ARCHIVE, DEACTIVATE