### PR TITLE
fix(ci): add missing service and repository test layers to matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,13 @@ jobs:
         # Test layers aligned with new test directory structure
         # integration - Complex business workflows (test:integration)
         # server-api - API endpoint integration tests (test:server:api)
+        # server-services - Service layer unit tests (test:server:services)
+        # server-repositories - Repository layer unit tests (test:server:repositories)
         # server-utils - Server utility tests (test:server:utils)
         # schema - Database schema and migration tests (test:schema)
         # app-e2e - Frontend E2E tests (test:app:e2e)
         # smoke - Critical smoke tests across all layers (test:smoke)
-        test-layer: [integration, server-api, server-utils, schema, app-e2e, smoke]
+        test-layer: [integration, server-api, server-services, server-repositories, server-utils, schema, app-e2e, smoke]
 
     services:
       neo4j:


### PR DESCRIPTION
## Motivation

CI coverage was ~6% while local coverage was ~52%. The `server-services` and `server-repositories` test layers were missing from the CI matrix, so all service and repository files showed 0% coverage.

## Changes

Add `server-services` and `server-repositories` to the test matrix in `.github/workflows/ci.yml`. These map to the existing `test:server:services` and `test:server:repositories` npm scripts.