### PR TITLE
fix: components endpoint correctness, performance, and UI improvements

### DIFF
--- a/server/database/queries/components/count-unmapped.cypher
+++ b/server/database/queries/components/count-unmapped.cypher
@@ -1,0 +1,3 @@
+MATCH (c:Component)
+WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
+RETURN count(c) as total

--- a/server/database/queries/components/find-all.cypher
+++ b/server/database/queries/components/find-all.cypher
@@ -1,10 +1,20 @@
+// Phase 1: filter on component properties, then join and apply join filters
 MATCH (c:Component)
+{{COMPONENT_WHERE}}
 OPTIONAL MATCH (c)-[:IS_VERSION_OF]->(tech:Technology)
+{{LICENSE_MATCH}}
+{{JOIN_WHERE}}
+WITH collect({c: c, tech: tech}) as allRows, count(c) as total
+UNWIND allRows as row
+WITH row.c as c, row.tech as tech, total
+ORDER BY c.packageManager, c.name, c.version
+{{PAGINATION}}
+// Phase 2: fetch related data only for the paginated subset
 OPTIONAL MATCH (sys:System)-[:USES]->(c)
 OPTIONAL MATCH (c)-[:HAS_HASH]->(h:Hash)
 OPTIONAL MATCH (c)-[:HAS_LICENSE]->(l:License)
 OPTIONAL MATCH (c)-[:HAS_REFERENCE]->(ref:ExternalReference)
-WITH c, tech,
+WITH c, tech, total,
      count(DISTINCT sys) as systemCount,
      collect(DISTINCT {algorithm: h.algorithm, value: h.value}) as hashes,
      collect(DISTINCT {id: l.id, name: l.name, url: l.url, text: l.text}) as licenses,
@@ -16,20 +26,21 @@ RETURN c.name as name,
        c.cpe as cpe,
        c.bomRef as bomRef,
        c.type as type,
-       c.group as group,
+       c.group as `group`,
        c.scope as scope,
-       hashes,
-       licenses,
+       [hash IN hashes WHERE hash.algorithm IS NOT NULL | hash] as hashes,
+       [lic IN licenses WHERE lic.id IS NOT NULL | lic] as licenses,
        c.copyright as copyright,
        c.supplier as supplier,
        c.author as author,
        c.publisher as publisher,
        c.description as description,
        c.homepage as homepage,
-       externalReferences,
+       [er IN externalReferences WHERE er.type IS NOT NULL | er] as externalReferences,
        c.releaseDate as releaseDate,
        c.publishedDate as publishedDate,
        c.modifiedDate as modifiedDate,
        tech.name as technologyName,
-       systemCount
-ORDER BY c.packageManager, c.name
+       systemCount,
+       total
+ORDER BY c.packageManager, c.name, c.version

--- a/server/database/queries/components/find-unmapped.cypher
+++ b/server/database/queries/components/find-unmapped.cypher
@@ -13,8 +13,9 @@ RETURN c.name as name,
        c.cpe as cpe,
        c.type as type,
        c.group as group,
-       hashes,
-       licenses,
+       [hash IN hashes WHERE hash.algorithm IS NOT NULL | hash] as hashes,
+       [lic IN licenses WHERE lic.id IS NOT NULL | lic] as licenses,
        systems,
        size(systems) as systemCount
 ORDER BY size(systems) DESC, c.name
+SKIP toInteger($offset) LIMIT toInteger($limit)

--- a/test/server/api/components-validation.spec.ts
+++ b/test/server/api/components-validation.spec.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+
+/**
+ * Tests for /components endpoint input validation.
+ *
+ * Requires a running server. Skipped automatically if unavailable.
+ * Run with: npm run test -- --run test/server/api/components-validation.spec.ts
+ */
+
+const BASE_URL = process.env.NUXT_TEST_BASE_URL || 'http://localhost:3000'
+
+let serverAvailable: boolean | null = null
+
+async function ensureServerCheck(): Promise<boolean> {
+  if (serverAvailable !== null) return serverAvailable
+
+  try {
+    const response = await fetch(`${BASE_URL}/api/health`, { signal: AbortSignal.timeout(2000) })
+    serverAvailable = response.ok
+  } catch {
+    serverAvailable = false
+  }
+
+  if (!serverAvailable) {
+    console.warn('\n⚠️  Server not available at', BASE_URL)
+    console.warn('   Validation tests will be skipped.\n')
+  }
+
+  return serverAvailable
+}
+
+describe('Components API - Input Validation', () => {
+  beforeAll(async () => {
+    await ensureServerCheck()
+  })
+
+  describe('GET /api/components', () => {
+    it('should return 400 for non-numeric limit', async () => {
+      if (!serverAvailable) return
+
+      const response = await fetch(`${BASE_URL}/api/components?limit=abc`)
+
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.success).toBe(false)
+      expect(body.error).toBeDefined()
+    })
+
+    it('should return 400 for non-numeric offset', async () => {
+      if (!serverAvailable) return
+
+      const response = await fetch(`${BASE_URL}/api/components?offset=xyz`)
+
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.success).toBe(false)
+    })
+
+    it('should clamp negative limit to 1', async () => {
+      if (!serverAvailable) return
+
+      const response = await fetch(`${BASE_URL}/api/components?limit=-5`)
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+    })
+
+    it('should clamp limit above 200 to 200', async () => {
+      if (!serverAvailable) return
+
+      const response = await fetch(`${BASE_URL}/api/components?limit=999`)
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+      expect(body.data.length).toBeLessThanOrEqual(200)
+    })
+
+    it('should clamp negative offset to 0', async () => {
+      if (!serverAvailable) return
+
+      const response = await fetch(`${BASE_URL}/api/components?offset=-10`)
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+    })
+  })
+
+  describe('GET /api/components/unmapped', () => {
+    it('should return 400 for non-numeric limit', async () => {
+      if (!serverAvailable) return
+
+      const response = await fetch(`${BASE_URL}/api/components/unmapped?limit=abc`)
+
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.success).toBe(false)
+    })
+
+    it('should return 400 for non-numeric offset', async () => {
+      if (!serverAvailable) return
+
+      const response = await fetch(`${BASE_URL}/api/components/unmapped?offset=xyz`)
+
+      expect(response.status).toBe(400)
+      const body = await response.json()
+      expect(body.success).toBe(false)
+    })
+
+    it('should clamp negative limit to 1', async () => {
+      if (!serverAvailable) return
+
+      const response = await fetch(`${BASE_URL}/api/components/unmapped?limit=-5`)
+
+      expect(response.status).toBe(200)
+      const body = await response.json()
+      expect(body.success).toBe(true)
+    })
+  })
+})

--- a/test/server/api/components.spec.ts
+++ b/test/server/api/components.spec.ts
@@ -55,7 +55,8 @@ describeFeature(feature, ({ Background, Scenario }) => {
       // Mock successful service response
       vi.mocked(ComponentService.prototype.findAll).mockResolvedValue({
         data: mockComponents,
-        count: mockComponents.length
+        count: mockComponents.length,
+        total: mockComponents.length
       })
 
       // Simulate API endpoint logic
@@ -108,7 +109,8 @@ describeFeature(feature, ({ Background, Scenario }) => {
       // Mock successful service response
       vi.mocked(ComponentService.prototype.findAll).mockResolvedValue({
         data: mockComponents,
-        count: mockComponents.length
+        count: mockComponents.length,
+        total: mockComponents.length
       })
 
       const componentService = new ComponentService()
@@ -169,7 +171,8 @@ describeFeature(feature, ({ Background, Scenario }) => {
       // Mock empty service response
       vi.mocked(ComponentService.prototype.findAll).mockResolvedValue({
         data: [],
-        count: 0
+        count: 0,
+        total: 0
       })
 
       const componentService = new ComponentService()

--- a/test/server/services/component.service.spec.ts
+++ b/test/server/services/component.service.spec.ts
@@ -83,32 +83,43 @@ describe('ComponentService', () => {
   })
 
   describe('findAll()', () => {
-    it('should return all components with correct count', async () => {
-      vi.mocked(ComponentRepository.prototype.findAll).mockResolvedValue(mockComponents)
+    it('should return all components with correct count and total', async () => {
+      vi.mocked(ComponentRepository.prototype.findAll).mockResolvedValue({
+        data: mockComponents,
+        total: 2
+      })
 
       const result = await service.findAll()
 
       expect(ComponentRepository.prototype.findAll).toHaveBeenCalledOnce()
       expect(result).toEqual({
         data: mockComponents,
-        count: 2
+        count: 2,
+        total: 2
       })
     })
 
     it('should return empty array when no components exist', async () => {
-      vi.mocked(ComponentRepository.prototype.findAll).mockResolvedValue([])
+      vi.mocked(ComponentRepository.prototype.findAll).mockResolvedValue({
+        data: [],
+        total: 0
+      })
 
       const result = await service.findAll()
 
-      expect(result).toEqual({ data: [], count: 0 })
+      expect(result).toEqual({ data: [], count: 0, total: 0 })
     })
 
     it('should calculate count correctly for single component', async () => {
-      vi.mocked(ComponentRepository.prototype.findAll).mockResolvedValue([mockComponents[0]])
+      vi.mocked(ComponentRepository.prototype.findAll).mockResolvedValue({
+        data: [mockComponents[0]],
+        total: 10
+      })
 
       const result = await service.findAll()
 
       expect(result.count).toBe(1)
+      expect(result.total).toBe(10)
       expect(result.data).toHaveLength(1)
     })
 
@@ -120,7 +131,10 @@ describe('ComponentService', () => {
     })
 
     it('should return components with all required properties', async () => {
-      vi.mocked(ComponentRepository.prototype.findAll).mockResolvedValue(mockComponents)
+      vi.mocked(ComponentRepository.prototype.findAll).mockResolvedValue({
+        data: mockComponents,
+        total: 2
+      })
 
       const result = await service.findAll()
 
@@ -135,24 +149,28 @@ describe('ComponentService', () => {
   })
 
   describe('findUnmapped()', () => {
-    it('should return all unmapped components with correct count', async () => {
+    it('should return unmapped components with correct count and total', async () => {
       vi.mocked(ComponentRepository.prototype.findUnmapped).mockResolvedValue(mockUnmappedComponents)
+      vi.mocked(ComponentRepository.prototype.countUnmapped).mockResolvedValue(5)
 
-      const result = await service.findUnmapped()
+      const result = await service.findUnmapped(50, 0)
 
-      expect(ComponentRepository.prototype.findUnmapped).toHaveBeenCalledOnce()
+      expect(ComponentRepository.prototype.findUnmapped).toHaveBeenCalledWith(50, 0)
+      expect(ComponentRepository.prototype.countUnmapped).toHaveBeenCalledOnce()
       expect(result).toEqual({
         data: mockUnmappedComponents,
-        count: 1
+        count: 1,
+        total: 5
       })
     })
 
     it('should return empty array when no unmapped components exist', async () => {
       vi.mocked(ComponentRepository.prototype.findUnmapped).mockResolvedValue([])
+      vi.mocked(ComponentRepository.prototype.countUnmapped).mockResolvedValue(0)
 
       const result = await service.findUnmapped()
 
-      expect(result).toEqual({ data: [], count: 0 })
+      expect(result).toEqual({ data: [], count: 0, total: 0 })
     })
 
     it('should propagate repository errors', async () => {


### PR DESCRIPTION
## Description

Fixes multiple bugs, performance issues, and UX problems in the `/components` and `/components/unmapped` endpoints and their corresponding UI page.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Changes Made

### Bug Fixes
- Error responses now return proper HTTP 400/500 status codes instead of 200
- `limit` and `offset` query parameters are validated (reject NaN, clamp to safe ranges)
- Contradictory `license` + `hasLicense=false` filter combination no longer produces an impossible query — `hasLicense` is ignored when a specific license is set
- Fixed Cypher WHERE clause scoping: component-level conditions (search, packageManager, type) are now placed before OPTIONAL MATCHes to avoid being scoped to the optional pattern
- Hashes and external references now read from relationship nodes (matching the SBOM import model) instead of non-existent component properties

### Performance
- `/components/unmapped` now uses database-level SKIP/LIMIT instead of loading all rows into memory and slicing in JS
- `/components` data and total count are fetched in a single query using collect/unwind pattern, eliminating an extra database round-trip
- License MATCH clause is only included in the filter phase when needed, avoiding unnecessary row multiplication

### Maintainability
- Inline Cypher in the repository replaced with `.cypher` template files using placeholder injection (`{{COMPONENT_WHERE}}`, `{{LICENSE_MATCH}}`, etc.)
- Filter condition building extracted into shared `buildFilterConditions` method with split component vs join conditions
- Removed unused `count.cypher` and the separate `count()` repository method

### UI
- Name column now displays `group/name` when a group exists (e.g., `@nuxt/cli` instead of `cli`)
- Search includes the component group field so searching "nuxt" matches `@nuxt/*` packages
- All applicable columns have sortable headers (Name, Version, Package Manager, Type, Systems)
- Server-side name filter with 300ms debounce replaces client-side column filter

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run test` — all 743 tests pass
- [x] I have run `npm run mdlint` — no issues