### PR TITLE
feat: technology CRUD and component actions dropdown

### DIFF
--- a/app/pages/technologies/[name].vue
+++ b/app/pages/technologies/[name].vue
@@ -15,19 +15,18 @@
       </template>
     </UAlert>
 
-    <template v-else-if="data?.data">
+    <template v-else-if="tech">
       <div class="flex justify-between items-center">
         <UPageHeader
-          :title="data.data.name"
-          :description="data.data.description"
+          :title="tech.name"
           :links="[{ label: 'Back to Technologies', to: '/technologies', icon: 'i-lucide-arrow-left', variant: 'outline' as const }]"
         />
         <div class="flex gap-2">
-          <UBadge v-if="data.data.type" color="neutral" variant="subtle">
-            {{ data.data.type }}
+          <UBadge v-if="tech.category" color="neutral" variant="subtle">
+            {{ tech.category }}
           </UBadge>
-          <UBadge v-if="data.data.timeCategory" :color="getTimeCategoryColor(data.data.timeCategory)" variant="subtle">
-            {{ data.data.timeCategory }}
+          <UBadge v-if="timeCategory" :color="getTimeCategoryColor(timeCategory)" variant="subtle">
+            {{ timeCategory }}
           </UBadge>
         </div>
       </div>
@@ -36,31 +35,31 @@
         <UCard>
           <div class="text-center">
             <p class="text-sm text-(--ui-text-muted)">Versions</p>
-            <p class="text-2xl font-bold mt-1">{{ data.data.versionCount || 0 }}</p>
+            <p class="text-2xl font-bold mt-1">{{ tech.versions?.length || 0 }}</p>
           </div>
         </UCard>
         <UCard>
           <div class="text-center">
             <p class="text-sm text-(--ui-text-muted)">Components</p>
-            <p class="text-2xl font-bold mt-1">{{ data.data.componentCount || 0 }}</p>
+            <p class="text-2xl font-bold mt-1">{{ tech.components?.length || 0 }}</p>
           </div>
         </UCard>
         <UCard>
           <div class="text-center">
             <p class="text-sm text-(--ui-text-muted)">Systems</p>
-            <p class="text-2xl font-bold mt-1">{{ data.data.systemCount || 0 }}</p>
+            <p class="text-2xl font-bold mt-1">{{ tech.systems?.length || 0 }}</p>
           </div>
         </UCard>
         <UCard>
           <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Steward</p>
+            <p class="text-sm text-(--ui-text-muted)">Owner</p>
             <p class="text-2xl font-bold mt-1">
               <NuxtLink
-                v-if="data.data.stewardTeam"
-                :to="`/teams/${encodeURIComponent(data.data.stewardTeam)}`"
+                v-if="tech.ownerTeamName"
+                :to="`/teams/${encodeURIComponent(tech.ownerTeamName)}`"
                 class="hover:underline"
               >
-                {{ data.data.stewardTeam }}
+                {{ tech.ownerTeamName }}
               </NuxtLink>
               <span v-else class="text-(--ui-text-muted)">—</span>
             </p>
@@ -75,24 +74,23 @@
           </template>
           <div class="space-y-3">
             <div>
-              <span class="text-sm text-(--ui-text-muted)">Type</span>
-              <p class="font-medium">{{ data.data.type || '—' }}</p>
+              <span class="text-sm text-(--ui-text-muted)">Category</span>
+              <p class="font-medium">{{ tech.category || '—' }}</p>
             </div>
             <div>
-              <span class="text-sm text-(--ui-text-muted)">TIME Category</span>
+              <span class="text-sm text-(--ui-text-muted)">Vendor</span>
+              <p class="font-medium">{{ tech.vendor || '—' }}</p>
+            </div>
+            <div>
+              <span class="text-sm text-(--ui-text-muted)">Approved Version Range</span>
               <p class="font-medium">
-                <UBadge v-if="data.data.timeCategory" :color="getTimeCategoryColor(data.data.timeCategory)" variant="subtle">
-                  {{ data.data.timeCategory }}
-                </UBadge>
+                <code v-if="tech.approvedVersionRange">{{ tech.approvedVersionRange }}</code>
                 <span v-else class="text-(--ui-text-muted)">—</span>
               </p>
             </div>
             <div>
-              <span class="text-sm text-(--ui-text-muted)">Version Range</span>
-              <p class="font-medium">
-                <code v-if="data.data.versionRange">{{ data.data.versionRange }}</code>
-                <span v-else class="text-(--ui-text-muted)">—</span>
-              </p>
+              <span class="text-sm text-(--ui-text-muted)">Last Reviewed</span>
+              <p class="font-medium">{{ tech.lastReviewed ? formatDate(tech.lastReviewed) : '—' }}</p>
             </div>
           </div>
         </UCard>
@@ -103,39 +101,67 @@
           </template>
           <div class="space-y-3">
             <div>
-              <span class="text-sm text-(--ui-text-muted)">Steward Team</span>
-              <p v-if="data.data.stewardTeam" class="font-medium">
-                <NuxtLink :to="`/teams/${encodeURIComponent(data.data.stewardTeam)}`" class="hover:underline">
-                  {{ data.data.stewardTeam }}
+              <span class="text-sm text-(--ui-text-muted)">Owner Team</span>
+              <p v-if="tech.ownerTeamName" class="font-medium">
+                <NuxtLink :to="`/teams/${encodeURIComponent(tech.ownerTeamName)}`" class="hover:underline">
+                  {{ tech.ownerTeamName }}
                 </NuxtLink>
+                <span v-if="tech.ownerTeamEmail" class="text-sm text-(--ui-text-muted) ml-2">{{ tech.ownerTeamEmail }}</span>
               </p>
-              <p v-else class="text-(--ui-text-muted)">No steward assigned</p>
+              <p v-else class="text-(--ui-text-muted)">No owner assigned</p>
             </div>
             <div>
               <span class="text-sm text-(--ui-text-muted)">Risk Level</span>
-              <p class="font-medium">{{ data.data.riskLevel || '—' }}</p>
+              <p class="font-medium">{{ tech.riskLevel || '—' }}</p>
+            </div>
+            <div>
+              <span class="text-sm text-(--ui-text-muted)">TIME Category</span>
+              <p class="font-medium">
+                <UBadge v-if="timeCategory" :color="getTimeCategoryColor(timeCategory)" variant="subtle">
+                  {{ timeCategory }}
+                </UBadge>
+                <span v-else class="text-(--ui-text-muted)">—</span>
+              </p>
             </div>
           </div>
         </UCard>
       </div>
 
-      <UCard v-if="data.data.versions && data.data.versions.length > 0">
+      <!-- Technology Approvals -->
+      <UCard v-if="tech.technologyApprovals && tech.technologyApprovals.length > 0">
         <template #header>
-          <h2 class="text-lg font-semibold">Versions ({{ data.data.versions.length }})</h2>
+          <h2 class="text-lg font-semibold">Approvals ({{ tech.technologyApprovals.length }})</h2>
         </template>
-        <UTable :data="data.data.versions" :columns="versionColumns" class="flex-1" />
+        <UTable :data="tech.technologyApprovals" :columns="approvalColumns" class="flex-1" />
       </UCard>
 
-      <UCard v-if="data.data.policies && data.data.policies.length > 0">
+      <!-- Versions -->
+      <UCard v-if="tech.versions && tech.versions.length > 0">
         <template #header>
-          <h2 class="text-lg font-semibold">Policies ({{ data.data.policies.length }})</h2>
+          <h2 class="text-lg font-semibold">Versions ({{ tech.versions.length }})</h2>
+        </template>
+        <UTable :data="tech.versions" :columns="versionColumns" class="flex-1" />
+      </UCard>
+
+      <!-- Components -->
+      <UCard v-if="tech.components && tech.components.length > 0">
+        <template #header>
+          <h2 class="text-lg font-semibold">Components ({{ tech.components.length }})</h2>
+        </template>
+        <UTable :data="tech.components" :columns="componentColumns" class="flex-1" />
+      </UCard>
+
+      <!-- Systems -->
+      <UCard v-if="tech.systems && tech.systems.length > 0">
+        <template #header>
+          <h2 class="text-lg font-semibold">Systems ({{ tech.systems.length }})</h2>
         </template>
         <div class="flex flex-wrap gap-2">
           <UButton
-            v-for="policy in data.data.policies"
-            :key="policy"
-            :label="policy"
-            :to="`/policies/${encodeURIComponent(policy)}`"
+            v-for="system in tech.systems"
+            :key="system"
+            :label="system"
+            :to="`/systems/${encodeURIComponent(system)}`"
             variant="subtle"
             color="neutral"
             size="sm"
@@ -143,20 +169,27 @@
         </div>
       </UCard>
 
-      <UCard v-if="data.data.approvedByTeams && data.data.approvedByTeams.length > 0">
+      <!-- Policies -->
+      <UCard v-if="tech.policies && tech.policies.length > 0">
         <template #header>
-          <h2 class="text-lg font-semibold">Approved By Teams ({{ data.data.approvedByTeams.length }})</h2>
+          <h2 class="text-lg font-semibold">Policies ({{ tech.policies.length }})</h2>
         </template>
         <div class="flex flex-wrap gap-2">
           <UButton
-            v-for="team in data.data.approvedByTeams"
-            :key="team"
-            :label="team"
-            :to="`/teams/${encodeURIComponent(team)}`"
+            v-for="policy in tech.policies"
+            :key="policy.name"
+            :label="policy.name"
+            :to="`/policies/${encodeURIComponent(policy.name)}`"
             variant="subtle"
             color="neutral"
             size="sm"
-          />
+          >
+            <template #trailing>
+              <UBadge :color="getSeverityColor(policy.severity)" variant="subtle" size="xs">
+                {{ policy.severity }}
+              </UBadge>
+            </template>
+          </UButton>
         </div>
       </UCard>
     </template>
@@ -166,35 +199,52 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { TechnologyApproval } from '~~/types/api'
 
 const route = useRoute()
 
-interface Version {
+interface VersionDetail {
   version: string
   releaseDate: string | null
-  endOfLife: string | null
-  status: string
+  eolDate: string | null
+  approved: boolean
+  cvssScore: number | null
+  notes: string | null
 }
 
-interface TechnologyDetail {
+interface ComponentRef {
   name: string
-  description: string
-  type: string
-  timeCategory: string
-  versionRange: string
-  stewardTeam: string | null
-  riskLevel: string
-  versionCount: number
-  componentCount: number
-  systemCount: number
-  versions: Version[]
-  policies: string[]
-  approvedByTeams: string[]
+  version: string
+  packageManager: string | null
+}
+
+interface PolicyRef {
+  name: string
+  severity: string
+  ruleType: string
+}
+
+interface TechnologyDetailData {
+  name: string
+  category: string
+  vendor: string | null
+  approvedVersionRange: string | null
+  ownerTeam: string | null
+  riskLevel: string | null
+  lastReviewed: string | null
+  ownerTeamName: string | null
+  ownerTeamEmail: string | null
+  versions: VersionDetail[]
+  components: ComponentRef[]
+  systems: string[]
+  policies: PolicyRef[]
+  technologyApprovals: TechnologyApproval[]
+  versionApprovals: TechnologyApproval[]
 }
 
 interface TechnologyResponse {
   success: boolean
-  data: TechnologyDetail
+  data: TechnologyDetailData
 }
 
 function getTimeCategoryColor(category: string): 'success' | 'warning' | 'error' | 'neutral' {
@@ -207,19 +257,35 @@ function getTimeCategoryColor(category: string): 'success' | 'warning' | 'error'
   return colors[category?.toLowerCase()] || 'neutral'
 }
 
-const versionColumns: TableColumn<Version>[] = [
+function getSeverityColor(severity: string): 'error' | 'warning' | 'success' | 'neutral' {
+  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
+    critical: 'error',
+    error: 'error',
+    warning: 'warning',
+    info: 'neutral'
+  }
+  return colors[severity?.toLowerCase()] || 'neutral'
+}
+
+function formatDate(dateString: string): string {
+  if (!dateString) return '—'
+  return new Date(dateString).toLocaleDateString()
+}
+
+const versionColumns: TableColumn<VersionDetail>[] = [
   {
     accessorKey: 'version',
     header: 'Version',
     cell: ({ row }) => h('code', {}, row.getValue('version') as string)
   },
   {
-    accessorKey: 'status',
+    accessorKey: 'approved',
     header: 'Status',
     cell: ({ row }) => {
-      const status = row.getValue('status') as string
-      const color = status === 'active' ? 'success' : status === 'deprecated' ? 'warning' : 'neutral'
-      return h(resolveComponent('UBadge'), { color, variant: 'subtle' }, () => status)
+      const approved = row.getValue('approved') as boolean
+      const color = approved ? 'success' : 'warning'
+      const label = approved ? 'approved' : 'pending'
+      return h(resolveComponent('UBadge'), { color, variant: 'subtle' }, () => label)
     }
   },
   {
@@ -227,22 +293,104 @@ const versionColumns: TableColumn<Version>[] = [
     header: 'Released',
     cell: ({ row }) => {
       const date = row.getValue('releaseDate') as string | null
-      return date ? new Date(date).toLocaleDateString() : '—'
+      return date ? formatDate(date) : '—'
     }
   },
   {
-    accessorKey: 'endOfLife',
+    accessorKey: 'eolDate',
     header: 'End of Life',
     cell: ({ row }) => {
-      const date = row.getValue('endOfLife') as string | null
-      return date ? new Date(date).toLocaleDateString() : '—'
+      const date = row.getValue('eolDate') as string | null
+      return date ? formatDate(date) : '—'
     }
+  },
+  {
+    accessorKey: 'notes',
+    header: 'Notes',
+    cell: ({ row }) => {
+      const notes = row.getValue('notes') as string | null
+      return notes || '—'
+    }
+  }
+]
+
+const approvalColumns: TableColumn<TechnologyApproval>[] = [
+  {
+    accessorKey: 'team',
+    header: 'Team',
+    cell: ({ row }) => {
+      const team = row.getValue('team') as string
+      return h(resolveComponent('NuxtLink'), {
+        to: `/teams/${encodeURIComponent(team)}`,
+        class: 'font-medium hover:underline'
+      }, () => team)
+    }
+  },
+  {
+    accessorKey: 'time',
+    header: 'TIME',
+    cell: ({ row }) => {
+      const time = row.getValue('time') as string | null
+      if (!time) return '—'
+      return h(resolveComponent('UBadge'), { color: getTimeCategoryColor(time), variant: 'subtle' }, () => time)
+    }
+  },
+  {
+    accessorKey: 'versionConstraint',
+    header: 'Version Constraint',
+    cell: ({ row }) => {
+      const vc = row.original.versionConstraint
+      return vc ? h('code', {}, vc) : '—'
+    }
+  },
+  {
+    accessorKey: 'approvedAt',
+    header: 'Approved',
+    cell: ({ row }) => {
+      const date = row.original.approvedAt
+      return date ? formatDate(date) : '—'
+    }
+  },
+  {
+    accessorKey: 'approvedBy',
+    header: 'By',
+    cell: ({ row }) => row.original.approvedBy || '—'
+  },
+  {
+    accessorKey: 'notes',
+    header: 'Notes',
+    cell: ({ row }) => row.original.notes || '—'
+  }
+]
+
+const componentColumns: TableColumn<ComponentRef>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Name',
+    cell: ({ row }) => h('strong', {}, row.getValue('name') as string)
+  },
+  {
+    accessorKey: 'version',
+    header: 'Version',
+    cell: ({ row }) => h('code', {}, row.getValue('version') as string)
+  },
+  {
+    accessorKey: 'packageManager',
+    header: 'Package Manager',
+    cell: ({ row }) => row.getValue('packageManager') || '—'
   }
 ]
 
 const { data, pending, error } = await useFetch<TechnologyResponse>(() => `/api/technologies/${encodeURIComponent(route.params.name as string)}`)
 
+const tech = computed(() => data.value?.data || null)
+
+const timeCategory = computed(() => {
+  const approval = tech.value?.technologyApprovals?.[0]
+  return approval?.time || null
+})
+
 useHead({
-  title: computed(() => data.value?.data ? `${data.value.data.name} - Polaris` : 'Technology - Polaris')
+  title: computed(() => tech.value ? `${tech.value.name} - Polaris` : 'Technology - Polaris')
 })
 </script>

--- a/app/pages/technologies/new.vue
+++ b/app/pages/technologies/new.vue
@@ -1,0 +1,205 @@
+<template>
+  <div class="max-w-3xl mx-auto space-y-6">
+    <UPageHeader
+      title="Create New Technology"
+      description="Add a new technology to the catalog"
+      :links="[{ label: 'Back to Technologies', to: '/technologies', icon: 'i-lucide-arrow-left', variant: 'outline' as const }]"
+    />
+
+    <UCard>
+      <form class="space-y-5" @submit.prevent="handleSubmit">
+        <UFormField label="Technology Name" required>
+          <UInput
+            v-model="formData.name"
+            placeholder="e.g., React"
+            :color="fieldErrors.name ? 'error' : undefined"
+            @blur="validateField('name')"
+          />
+          <template v-if="fieldErrors.name" #help>
+            <span class="text-(--ui-color-error-500)">{{ fieldErrors.name }}</span>
+          </template>
+        </UFormField>
+
+        <UFormField label="Category" required>
+          <USelect
+            v-model="formData.category"
+            :items="categoryItems"
+            placeholder="Select a category"
+          />
+        </UFormField>
+
+        <UFormField label="Vendor">
+          <UInput
+            v-model="formData.vendor"
+            placeholder="e.g., Meta, Google"
+          />
+        </UFormField>
+
+        <UFormField label="Owner Team">
+          <USelect
+            v-model="formData.ownerTeam"
+            :items="teamItems"
+            placeholder="Select a team (optional)"
+          />
+          <template v-if="teamsError" #help>
+            <span class="text-(--ui-color-error-500)">Failed to load teams</span>
+          </template>
+        </UFormField>
+
+        <UAlert
+          v-if="fromComponent"
+          color="info"
+          variant="subtle"
+          icon="i-lucide-link"
+          title="Linked Component"
+          :description="`This technology will be linked to component: ${fromComponent}`"
+        />
+
+        <UAlert
+          v-if="errorMessage"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-alert-circle"
+          :description="errorMessage"
+        />
+
+        <UAlert
+          v-if="successMessage"
+          color="success"
+          variant="subtle"
+          icon="i-lucide-check-circle"
+          :description="successMessage"
+        />
+
+        <div class="flex items-center gap-4 pt-4 border-t border-(--ui-border)">
+          <UButton
+            type="submit"
+            :loading="isSubmitting"
+            :label="isSubmitting ? 'Saving...' : 'Save Technology'"
+            color="primary"
+          />
+          <UButton
+            label="Cancel"
+            to="/technologies"
+            variant="outline"
+          />
+        </div>
+      </form>
+    </UCard>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface TeamsResponse {
+  success: boolean
+  data: { name: string }[]
+  count: number
+}
+
+const route = useRoute()
+
+const componentTypeToCategoryMap: Record<string, string> = {
+  framework: 'framework',
+  library: 'library',
+  platform: 'platform',
+  application: 'tool',
+  container: 'platform',
+  'operating-system': 'platform'
+}
+
+function mapComponentTypeToCategory(type: string | undefined): string {
+  if (!type) return ''
+  return componentTypeToCategoryMap[type] || 'other'
+}
+
+const formData = ref({
+  name: (route.query.name as string) || '',
+  category: mapComponentTypeToCategory(route.query.componentType as string | undefined),
+  vendor: '',
+  ownerTeam: '',
+  componentName: (route.query.componentName as string) || '',
+  componentPackageManager: (route.query.componentPackageManager as string) || ''
+})
+
+const fromComponent = computed(() => {
+  if (!formData.value.componentName) return null
+  const group = route.query.componentGroup as string | undefined
+  const name = formData.value.componentName
+  return group ? `${group}/${name}` : name
+})
+
+const isSubmitting = ref(false)
+const errorMessage = ref('')
+const successMessage = ref('')
+const fieldErrors = ref<Record<string, string>>({})
+
+const { data: teamsData, error: teamsError } = await useFetch<TeamsResponse>('/api/teams')
+const teamItems = computed(() =>
+  (teamsData.value?.data || []).map(t => ({ label: t.name, value: t.name }))
+)
+
+const categoryItems = [
+  { label: 'Language', value: 'language' },
+  { label: 'Framework', value: 'framework' },
+  { label: 'Library', value: 'library' },
+  { label: 'Database', value: 'database' },
+  { label: 'Platform', value: 'platform' },
+  { label: 'Tool', value: 'tool' },
+  { label: 'Runtime', value: 'runtime' },
+  { label: 'Other', value: 'other' }
+]
+
+function validateField(field: string) {
+  switch (field) {
+    case 'name':
+      if (!formData.value.name) {
+        fieldErrors.value.name = 'Technology name is required'
+      } else {
+        delete fieldErrors.value.name
+      }
+      break
+  }
+}
+
+async function handleSubmit() {
+  isSubmitting.value = true
+  errorMessage.value = ''
+  successMessage.value = ''
+
+  try {
+    const response = await $fetch<{ success: boolean; error?: string }>('/api/technologies', {
+      method: 'POST',
+      body: {
+        name: formData.value.name,
+        category: formData.value.category,
+        vendor: formData.value.vendor || undefined,
+        ownerTeam: formData.value.ownerTeam || undefined,
+        componentName: formData.value.componentName || undefined,
+        componentPackageManager: formData.value.componentPackageManager || undefined
+      }
+    })
+
+    if (response.success) {
+      successMessage.value = 'Technology created successfully!'
+      setTimeout(() => navigateTo(`/technologies/${encodeURIComponent(formData.value.name)}`), 1500)
+    } else {
+      errorMessage.value = response.error || 'Failed to create technology'
+    }
+  } catch (error: unknown) {
+    const err = error as { statusCode?: number; data?: { message?: string; error?: string }; message?: string }
+    if (err.statusCode === 409) {
+      errorMessage.value = err.data?.message || 'A technology with this name already exists'
+    } else if (err.statusCode === 422) {
+      errorMessage.value = err.data?.message || 'Invalid input data. Please check your entries.'
+    } else if (err.statusCode === 400) {
+      errorMessage.value = err.data?.message || 'Missing required fields'
+    } else {
+      errorMessage.value = err.data?.message || err.message || 'An unexpected error occurred'
+    }
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+useHead({ title: 'Create Technology - Polaris' })
+</script>

--- a/server/api/technologies.post.ts
+++ b/server/api/technologies.post.ts
@@ -1,0 +1,85 @@
+import type { ApiResponse } from '~~/types/api'
+import { TechnologyService } from '../services/technology.service'
+
+/**
+ * @openapi
+ * /technologies:
+ *   post:
+ *     tags:
+ *       - Technologies
+ *     summary: Create a new technology
+ *     description: Creates a new technology entry, optionally linking it to a source component
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - name
+ *               - category
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 description: Unique technology name
+ *               category:
+ *                 type: string
+ *                 enum: [language, framework, library, database, platform, tool, runtime, other]
+ *               vendor:
+ *                 type: string
+ *               ownerTeam:
+ *                 type: string
+ *               componentName:
+ *                 type: string
+ *                 description: Component name — all versions with this name and packageManager will be linked
+ *               componentPackageManager:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Technology created
+ *       400:
+ *         description: Missing required fields
+ *       409:
+ *         description: Technology already exists
+ *       422:
+ *         description: Invalid field values
+ */
+
+interface CreateTechnologyRequest {
+  name: string
+  category: string
+  vendor?: string
+  ownerTeam?: string
+  componentName?: string
+  componentPackageManager?: string
+}
+
+interface CreateTechnologyResponse {
+  name: string
+}
+
+export default defineEventHandler(async (event): Promise<ApiResponse<CreateTechnologyResponse>> => {
+  await requireAuth(event)
+  const body = await readBody<CreateTechnologyRequest>(event)
+
+  try {
+    const service = new TechnologyService()
+    const name = await service.create(body)
+
+    setResponseStatus(event, 201)
+    return {
+      success: true,
+      data: [{ name }],
+      count: 1
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    throw createError({
+      statusCode: 500,
+      message: error instanceof Error ? error.message : 'Failed to create technology'
+    })
+  }
+})

--- a/server/api/technologies/[name].delete.ts
+++ b/server/api/technologies/[name].delete.ts
@@ -1,0 +1,71 @@
+import { TechnologyService } from '../../services/technology.service'
+
+/**
+ * @openapi
+ * /technologies/{name}:
+ *   delete:
+ *     tags:
+ *       - Technologies
+ *     summary: Delete a technology
+ *     description: Deletes a technology and all its relationships. Requires superuser role or membership in the technology's owner team.
+ *     parameters:
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Technology name
+ *     security:
+ *       - sessionAuth: []
+ *     responses:
+ *       204:
+ *         description: Technology deleted
+ *       400:
+ *         description: Technology name is required
+ *       401:
+ *         description: Unauthorized
+ *       403:
+ *         description: Forbidden - user is not a superuser and does not belong to the owner team
+ *       404:
+ *         description: Technology not found
+ */
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+
+  const rawName = getRouterParam(event, 'name')
+
+  if (!rawName) {
+    throw createError({
+      statusCode: 400,
+      message: 'Technology name is required'
+    })
+  }
+
+  const name = decodeURIComponent(rawName)
+  const service = new TechnologyService()
+
+  const tech = await service.findOwnerTeam(name)
+  if (!tech) {
+    throw createError({
+      statusCode: 404,
+      message: `Technology '${name}' not found`
+    })
+  }
+
+  // Superusers can delete any technology
+  if (user.role !== 'superuser') {
+    // Regular users must belong to the owner team
+    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+    if (!tech.ownerTeam || !userTeamNames.includes(tech.ownerTeam)) {
+      throw createError({
+        statusCode: 403,
+        message: 'Access denied. You must be a superuser or a member of the technology\'s owner team to delete it.'
+      })
+    }
+  }
+
+  await service.delete(name)
+
+  setResponseStatus(event, 204)
+  return null
+})

--- a/server/database/queries/technologies/check-exists.cypher
+++ b/server/database/queries/technologies/check-exists.cypher
@@ -1,0 +1,2 @@
+MATCH (t:Technology {name: $name})
+RETURN t

--- a/server/database/queries/technologies/create.cypher
+++ b/server/database/queries/technologies/create.cypher
@@ -1,0 +1,21 @@
+CREATE (t:Technology {
+  name: $name,
+  category: $category,
+  vendor: $vendor
+})
+WITH t
+OPTIONAL MATCH (team:Team {name: $ownerTeam})
+FOREACH (_ IN CASE WHEN team IS NOT NULL THEN [1] ELSE [] END |
+  CREATE (team)-[:OWNS]->(t)
+)
+WITH t
+CALL (t) {
+  WITH t
+  WHERE $componentName IS NOT NULL
+  MATCH (c:Component)
+  WHERE c.name = $componentName
+    AND ($componentPackageManager IS NULL AND c.packageManager IS NULL
+         OR c.packageManager = $componentPackageManager)
+  MERGE (c)-[:IS_VERSION_OF]->(t)
+}
+RETURN t.name as name

--- a/server/database/queries/technologies/delete.cypher
+++ b/server/database/queries/technologies/delete.cypher
@@ -1,0 +1,2 @@
+MATCH (t:Technology {name: $name})
+DETACH DELETE t

--- a/server/database/queries/technologies/find-owner-team.cypher
+++ b/server/database/queries/technologies/find-owner-team.cypher
@@ -1,0 +1,3 @@
+MATCH (t:Technology {name: $name})
+OPTIONAL MATCH (team:Team)-[:OWNS]->(t)
+RETURN t.name as name, team.name as ownerTeam

--- a/server/repositories/technology.repository.ts
+++ b/server/repositories/technology.repository.ts
@@ -2,6 +2,15 @@ import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
 import type { Technology } from '~~/types/api'
 
+export interface CreateTechnologyParams {
+  name: string
+  category: string
+  vendor: string | null
+  ownerTeam: string | null
+  componentName: string | null
+  componentPackageManager: string | null
+}
+
 export interface TechnologyDetail extends Technology {
   ownerTeamEmail?: string | null
   components?: Array<{
@@ -75,6 +84,61 @@ export class TechnologyRepository extends BaseRepository {
   }
 
   /**
+   * Check if a technology exists by name
+   */
+  async exists(name: string): Promise<boolean> {
+    const query = await loadQuery('technologies/check-exists.cypher')
+    const { records } = await this.executeQuery(query, { name })
+    return records.length > 0
+  }
+
+  /**
+   * Create a new technology, optionally linking a source component
+   */
+  async create(params: CreateTechnologyParams): Promise<string> {
+    const query = await loadQuery('technologies/create.cypher')
+    const { records } = await this.executeQuery(query, {
+      name: params.name,
+      category: params.category,
+      vendor: params.vendor || null,
+      ownerTeam: params.ownerTeam || null,
+      componentName: params.componentName || null,
+      componentPackageManager: params.componentPackageManager || null
+    })
+
+    if (records.length === 0) {
+      throw new Error('Failed to create technology')
+    }
+
+    return records[0]!.get('name')
+  }
+
+  /**
+   * Find the owner team of a technology
+   */
+  async findOwnerTeam(name: string): Promise<{ name: string; ownerTeam: string | null } | null> {
+    const query = await loadQuery('technologies/find-owner-team.cypher')
+    const { records } = await this.executeQuery(query, { name })
+
+    if (records.length === 0) {
+      return null
+    }
+
+    return {
+      name: records[0]!.get('name'),
+      ownerTeam: records[0]!.get('ownerTeam')
+    }
+  }
+
+  /**
+   * Delete a technology and all its relationships
+   */
+  async delete(name: string): Promise<void> {
+    const query = await loadQuery('technologies/delete.cypher')
+    await this.executeQuery(query, { name })
+  }
+
+  /**
    * Map Neo4j record to Technology domain object
    */
   private mapToTechnology(record: Neo4jRecord): Technology {
@@ -93,9 +157,53 @@ export class TechnologyRepository extends BaseRepository {
   }
 
   /**
+   * Convert a Neo4j temporal value to an ISO date string.
+   * Handles Neo4j Date, DateTime, and raw {year,month,day} objects.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private toDateString(val: any): string | null {
+    if (!val) return null
+    if (typeof val === 'string') return val
+    if (typeof val.toString === 'function' && typeof val.year !== 'undefined' && !('low' in val.year)) {
+      return val.toString()
+    }
+    // Raw Neo4j integer objects: {year: {low, high}, month: {low, high}, day: {low, high}, ...}
+    const y = val.year?.low ?? val.year
+    const m = val.month?.low ?? val.month
+    const d = val.day?.low ?? val.day
+    if (y != null && m != null && d != null) {
+      return `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`
+    }
+    return null
+  }
+
+  /**
    * Map Neo4j record to TechnologyDetail domain object
    */
   private mapToTechnologyDetail(record: Neo4jRecord): TechnologyDetail {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const versions = record.get('versions').filter((v: { version?: string }) => v.version).map((v: any) => ({
+      ...v,
+      releaseDate: this.toDateString(v.releaseDate),
+      eolDate: this.toDateString(v.eolDate)
+    }))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const technologyApprovals = record.get('technologyApprovals').filter((a: { team?: string }) => a.team).map((a: any) => ({
+      ...a,
+      approvedAt: this.toDateString(a.approvedAt),
+      deprecatedAt: this.toDateString(a.deprecatedAt),
+      eolDate: this.toDateString(a.eolDate)
+    }))
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const versionApprovals = record.get('versionApprovals').filter((a: { team?: string }) => a.team).map((a: any) => ({
+      ...a,
+      approvedAt: this.toDateString(a.approvedAt),
+      deprecatedAt: this.toDateString(a.deprecatedAt),
+      eolDate: this.toDateString(a.eolDate)
+    }))
+
     return {
       name: record.get('name'),
       category: record.get('category'),
@@ -106,13 +214,13 @@ export class TechnologyRepository extends BaseRepository {
       lastReviewed: record.get('lastReviewed')?.toString(),
       ownerTeamName: record.get('ownerTeamName'),
       ownerTeamEmail: record.get('ownerTeamEmail'),
-      versions: record.get('versions').filter((v: { version?: string }) => v.version),
-      approvals: [], // Not used in detail view
+      versions,
+      approvals: [],
       components: record.get('components').filter((c: { name?: string }) => c.name),
       systems: record.get('systems').filter((s: string) => s),
       policies: record.get('policies').filter((p: { name?: string }) => p.name),
-      technologyApprovals: record.get('technologyApprovals').filter((a: { team?: string }) => a.team),
-      versionApprovals: record.get('versionApprovals').filter((a: { team?: string }) => a.team)
+      technologyApprovals,
+      versionApprovals
     }
   }
 }

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -1,5 +1,14 @@
-import { TechnologyRepository, type TechnologyDetail } from '../repositories/technology.repository'
+import { TechnologyRepository, type TechnologyDetail, type CreateTechnologyParams } from '../repositories/technology.repository'
 import type { Technology } from '~~/types/api'
+
+export interface CreateTechnologyInput {
+  name: string
+  category: string
+  vendor?: string
+  ownerTeam?: string
+  componentName?: string
+  componentPackageManager?: string
+}
 
 /**
  * Service for technology-related business logic
@@ -35,5 +44,76 @@ export class TechnologyService {
    */
   async findByName(name: string): Promise<TechnologyDetail | null> {
     return await this.techRepo.findByName(name)
+  }
+
+  /**
+   * Create a new technology, optionally linking a source component
+   * 
+   * @param input - Technology creation input
+   * @returns Created technology name
+   */
+  async create(input: CreateTechnologyInput): Promise<string> {
+    if (!input.name || !input.category) {
+      throw createError({
+        statusCode: 400,
+        message: 'Name and category are required'
+      })
+    }
+
+    const validCategories = ['language', 'framework', 'library', 'database', 'platform', 'tool', 'runtime', 'other']
+    if (!validCategories.includes(input.category)) {
+      throw createError({
+        statusCode: 422,
+        message: `Invalid category. Must be one of: ${validCategories.join(', ')}`
+      })
+    }
+
+    const exists = await this.techRepo.exists(input.name)
+    if (exists) {
+      throw createError({
+        statusCode: 409,
+        message: `A technology with the name '${input.name}' already exists`
+      })
+    }
+
+    const params: CreateTechnologyParams = {
+      name: input.name,
+      category: input.category,
+      vendor: input.vendor || null,
+      ownerTeam: input.ownerTeam || null,
+      componentName: input.componentName || null,
+      componentPackageManager: input.componentPackageManager || null
+    }
+
+    return await this.techRepo.create(params)
+  }
+
+  /**
+   * Find the owner team of a technology
+   *
+   * @param name - Technology name
+   * @returns Technology name and owner team, or null if not found
+   */
+  async findOwnerTeam(name: string): Promise<{ name: string; ownerTeam: string | null } | null> {
+    return await this.techRepo.findOwnerTeam(name)
+  }
+
+  /**
+   * Delete a technology
+   *
+   * @param name - Technology name
+   * @throws 404 if technology not found
+   */
+  async delete(name: string): Promise<void> {
+    const exists = await this.techRepo.exists(name)
+
+    if (!exists) {
+      throw createError({
+        statusCode: 404,
+        message: `Technology '${name}' not found`
+      })
+    }
+
+    await this.techRepo.delete(name)
   }
 }


### PR DESCRIPTION
## Motivation

Components had no actions available. Technologies could not be created or deleted through the UI. The technology detail page displayed incorrect field values due to mismatched field names and unserialised Neo4j dates.

## Changes

### Components table (`/components`)
- Added actions dropdown column with contextual options:
  - **Copy PURL** — when component has a package URL
  - **Visit Homepage** — when component has a homepage
  - **View Technology** — when component is linked to a technology
  - **Create Technology** — auth-gated, only shown when no technology exists for the component. Pre-fills the creation form with component name, package manager, and maps component type to technology category.

### Technology creation
- **`POST /api/technologies`** — Auth-protected endpoint. Creates a technology node and optionally links all matching components (by name + packageManager) via `IS_VERSION_OF`. Validates name uniqueness and category enum.
- **`/technologies/new`** — Creation form with name, category, vendor, and owner team fields. Category is pre-selected based on component type mapping (e.g. `framework` → Framework, `application` → Tool).

### Technology deletion
- **`DELETE /api/technologies/[name]`** — Restricted to superusers or members of the technology's owner team.
- Delete option added to the technologies list page dropdown with a confirmation modal.

### Technology detail page (`/technologies/[name]`)
- Rewrote to use actual API field names (`category` not `type`, `ownerTeamName` not `stewardTeam`, `approvedVersionRange` not `versionRange`, etc.)
- Stat cards now compute counts from array lengths instead of expecting non-existent fields
- Added tables for approvals, components, and systems sections
- Policies now display severity badges

### Neo4j date serialization
- Added `toDateString()` helper in the technology repository to convert Neo4j temporal objects (`{year: {low: N, high: 0}, ...}`) to ISO date strings. Applied to version and approval date fields.

## New files
- `app/pages/technologies/new.vue`
- `server/api/technologies.post.ts`
- `server/api/technologies/[name].delete.ts`
- `server/database/queries/technologies/check-exists.cypher`
- `server/database/queries/technologies/create.cypher`
- `server/database/queries/technologies/delete.cypher`
- `server/database/queries/technologies/find-owner-team.cypher`

## Testing
- All 743 existing tests pass
- Lint passes with no new warnings
