### PR TITLE
feat: user impersonation, TIME approvals, and audit logging

### DIFF
--- a/app/composables/useImpersonation.ts
+++ b/app/composables/useImpersonation.ts
@@ -1,0 +1,58 @@
+interface ImpersonatedUser {
+  id: string
+  email: string
+  name: string | null
+  role: string
+}
+
+interface ImpersonationState {
+  active: boolean
+  user: ImpersonatedUser | null
+}
+
+const state = ref<ImpersonationState>({ active: false, user: null })
+const loading = ref(false)
+
+export function useImpersonation() {
+  async function fetchStatus() {
+    try {
+      const data = await $fetch<ImpersonationState>('/api/admin/impersonate')
+      state.value = data
+    } catch {
+      state.value = { active: false, user: null }
+    }
+  }
+
+  async function startImpersonating(userId: string) {
+    loading.value = true
+    try {
+      const data = await $fetch<{ success: boolean; impersonating: ImpersonatedUser }>('/api/admin/impersonate', {
+        method: 'POST',
+        body: { userId }
+      })
+      state.value = { active: true, user: data.impersonating }
+      await refreshNuxtData()
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function stopImpersonating() {
+    loading.value = true
+    try {
+      await $fetch('/api/admin/impersonate', { method: 'DELETE' })
+      state.value = { active: false, user: null }
+      await refreshNuxtData()
+    } finally {
+      loading.value = false
+    }
+  }
+
+  return {
+    impersonation: state,
+    impersonationLoading: loading,
+    fetchImpersonationStatus: fetchStatus,
+    startImpersonating,
+    stopImpersonating
+  }
+}

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -79,9 +79,89 @@
     </aside>
 
     <!-- Main Content -->
-    <main class="flex-1 overflow-auto p-6">
-      <slot />
+    <main class="flex-1 overflow-auto">
+      <!-- Impersonation Banner -->
+      <div
+        v-if="impersonation.active && impersonation.user"
+        class="bg-amber-500 dark:bg-amber-600 text-white px-6 py-2 flex items-center justify-between text-sm"
+      >
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-eye" class="w-4 h-4" />
+          <span>
+            Viewing as <strong>{{ impersonation.user.name || impersonation.user.email }}</strong>
+            ({{ impersonation.user.role }})
+          </span>
+        </div>
+        <UButton
+          label="Stop Impersonating"
+          color="neutral"
+          variant="solid"
+          size="xs"
+          :loading="impersonationLoading"
+          @click="stopImpersonating"
+        />
+      </div>
+      <div class="p-6">
+        <slot />
+      </div>
     </main>
+
+    <!-- Impersonate User Modal -->
+    <UModal v-model:open="impersonateModalOpen">
+      <template #header>
+        <h3 class="text-lg font-semibold">Impersonate User</h3>
+      </template>
+      <template #body>
+        <p class="text-sm text-(--ui-text-muted) mb-4">
+          Select a user to view the application as them. All permission checks will use their role and team memberships.
+        </p>
+
+        <UInput
+          v-model="userSearch"
+          placeholder="Search users..."
+          icon="i-lucide-search"
+          class="mb-4"
+        />
+
+        <div v-if="usersLoading" class="text-center py-4 text-(--ui-text-muted)">
+          Loading users...
+        </div>
+
+        <div v-else class="divide-y divide-(--ui-border) max-h-80 overflow-y-auto">
+          <div
+            v-for="user in filteredUsers"
+            :key="user.id"
+            class="flex items-center justify-between py-3 px-1 hover:bg-(--ui-bg-elevated) rounded cursor-pointer"
+            @click="impersonateUser(user.id)"
+          >
+            <div>
+              <p class="text-sm font-medium">{{ user.name || user.email }}</p>
+              <p class="text-xs text-(--ui-text-muted)">{{ user.email }}</p>
+            </div>
+            <UBadge :color="user.role === 'superuser' ? 'error' : 'neutral'" variant="subtle" size="xs">
+              {{ user.role }}
+            </UBadge>
+          </div>
+          <p v-if="filteredUsers.length === 0" class="text-sm text-(--ui-text-muted) text-center py-4">
+            No users found.
+          </p>
+        </div>
+
+        <UAlert
+          v-if="impersonateError"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-alert-circle"
+          :description="impersonateError"
+          class="mt-4"
+        />
+      </template>
+      <template #footer>
+        <div class="flex justify-end">
+          <UButton label="Cancel" variant="outline" @click="impersonateModalOpen = false" />
+        </div>
+      </template>
+    </UModal>
   </div>
 </template>
 
@@ -89,6 +169,55 @@
 import type { NavigationMenuItem } from '@nuxt/ui'
 
 const { data: session, status, signOut } = useAuth()
+const { impersonation, impersonationLoading, fetchImpersonationStatus, startImpersonating, stopImpersonating } = useImpersonation()
+
+// Fetch impersonation status on load for superusers
+watch(() => session.value?.user?.role, async (role) => {
+  if (role === 'superuser') {
+    await fetchImpersonationStatus()
+  }
+}, { immediate: true })
+
+// Impersonate modal state
+const impersonateModalOpen = ref(false)
+const userSearch = ref('')
+const impersonateError = ref('')
+const usersLoading = ref(false)
+const allUsers = ref<{ id: string; email: string; name: string | null; role: string }[]>([])
+
+const filteredUsers = computed(() => {
+  const q = userSearch.value.toLowerCase()
+  const currentUserId = session.value?.user?.id
+  return allUsers.value
+    .filter(u => u.id !== currentUserId)
+    .filter(u => !q || u.email.toLowerCase().includes(q) || (u.name && u.name.toLowerCase().includes(q)))
+})
+
+async function openImpersonateModal() {
+  impersonateModalOpen.value = true
+  impersonateError.value = ''
+  userSearch.value = ''
+  usersLoading.value = true
+  try {
+    const data = await $fetch<{ success: boolean; data: { id: string; email: string; name: string | null; role: string }[] }>('/api/users?limit=200')
+    allUsers.value = data.data || []
+  } catch {
+    allUsers.value = []
+  } finally {
+    usersLoading.value = false
+  }
+}
+
+async function impersonateUser(userId: string) {
+  impersonateError.value = ''
+  try {
+    await startImpersonating(userId)
+    impersonateModalOpen.value = false
+  } catch (err: unknown) {
+    const error = err as { data?: { message?: string }; message?: string }
+    impersonateError.value = error.data?.message || error.message || 'Failed to impersonate user'
+  }
+}
 
 const mainMenuItems = computed<NavigationMenuItem[][]>(() => {
   const items: NavigationMenuItem[] = [
@@ -139,12 +268,17 @@ const mainMenuItems = computed<NavigationMenuItem[][]>(() => {
     }
   ]
 
-  // Add Users link for superusers
+  // Add admin items for superusers
   if (session.value?.user?.role === 'superuser') {
     items.push({
       label: 'Users',
       icon: 'i-lucide-user-cog',
       to: '/users'
+    })
+    items.push({
+      label: 'Impersonate User',
+      icon: 'i-lucide-eye',
+      onSelect: () => openImpersonateModal()
     })
   }
 

--- a/app/pages/technologies/index.vue
+++ b/app/pages/technologies/index.vue
@@ -127,10 +127,13 @@ const columns: TableColumn<Technology>[] = [
     id: 'time',
     header: 'TIME',
     cell: ({ row }) => {
-      const approval = row.original.approvals?.[0]
-      const cat = approval?.time
-      if (!cat) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
-      return h(resolveComponent('UBadge'), { color: getTimeCategoryColor(cat), variant: 'subtle' }, () => cat)
+      const approvals = (row.original.approvals || []).filter((a: { team?: string; time?: string }) => a.team && a.time)
+      if (approvals.length === 0) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return h('div', { class: 'flex flex-wrap gap-1' }, approvals.map((a: { team: string; time: string }) =>
+        h(resolveComponent('UTooltip'), { text: a.team }, {
+          default: () => h(resolveComponent('UBadge'), { color: getTimeCategoryColor(a.time), variant: 'subtle', size: 'xs' }, () => `${a.team}: ${a.time}`)
+        })
+      ))
     }
   },
   {

--- a/server/api/admin/impersonate.delete.ts
+++ b/server/api/admin/impersonate.delete.ts
@@ -1,0 +1,18 @@
+import { getRealUser } from '../../utils/auth'
+
+/**
+ * Stop impersonating. Clears the impersonation cookie.
+ */
+export default defineEventHandler(async (event) => {
+  const realUser = await getRealUser(event)
+
+  if (!realUser || realUser.role !== 'superuser') {
+    throw createError({ statusCode: 403, message: 'Superuser access required' })
+  }
+
+  deleteCookie(event, 'polaris-impersonate', {
+    path: '/'
+  })
+
+  return { success: true }
+})

--- a/server/api/admin/impersonate.get.ts
+++ b/server/api/admin/impersonate.get.ts
@@ -1,0 +1,39 @@
+import { getRealUser } from '../../utils/auth'
+import { UserService } from '../../services/user.service'
+
+/**
+ * Get current impersonation status.
+ * Returns the impersonated user's info if active, null otherwise.
+ */
+export default defineEventHandler(async (event) => {
+  const realUser = await getRealUser(event)
+
+  if (!realUser || realUser.role !== 'superuser') {
+    return { active: false, user: null }
+  }
+
+  const impersonateUserId = getCookie(event, 'polaris-impersonate')
+
+  if (!impersonateUserId) {
+    return { active: false, user: null }
+  }
+
+  const userService = new UserService()
+  const target = await userService.findById(impersonateUserId)
+
+  if (!target) {
+    // Stale cookie — clear it
+    deleteCookie(event, 'polaris-impersonate', { path: '/' })
+    return { active: false, user: null }
+  }
+
+  return {
+    active: true,
+    user: {
+      id: target.id,
+      email: target.email,
+      name: target.name,
+      role: target.role
+    }
+  }
+})

--- a/server/api/admin/impersonate.post.ts
+++ b/server/api/admin/impersonate.post.ts
@@ -1,0 +1,51 @@
+import { getRealUser } from '../../utils/auth'
+import { UserService } from '../../services/user.service'
+
+/**
+ * Start impersonating a user. Superuser only.
+ * Sets a cookie that causes getCurrentUser to return the target user's data.
+ */
+export default defineEventHandler(async (event) => {
+  const realUser = await getRealUser(event)
+
+  if (!realUser || realUser.role !== 'superuser') {
+    throw createError({ statusCode: 403, message: 'Superuser access required' })
+  }
+
+  const body = await readBody<{ userId: string }>(event)
+
+  if (!body?.userId) {
+    throw createError({ statusCode: 400, message: 'userId is required' })
+  }
+
+  // Prevent impersonating yourself
+  if (body.userId === realUser.id) {
+    throw createError({ statusCode: 422, message: 'Cannot impersonate yourself' })
+  }
+
+  // Verify target user exists
+  const userService = new UserService()
+  const target = await userService.findById(body.userId)
+
+  if (!target) {
+    throw createError({ statusCode: 404, message: 'User not found' })
+  }
+
+  setCookie(event, 'polaris-impersonate', body.userId, {
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    secure: process.env.NODE_ENV === 'production',
+    maxAge: 60 * 60 // 1 hour
+  })
+
+  return {
+    success: true,
+    impersonating: {
+      id: target.id,
+      email: target.email,
+      name: target.name,
+      role: target.role
+    }
+  }
+})

--- a/server/api/technologies.post.ts
+++ b/server/api/technologies.post.ts
@@ -59,12 +59,12 @@ interface CreateTechnologyResponse {
 }
 
 export default defineEventHandler(async (event): Promise<ApiResponse<CreateTechnologyResponse>> => {
-  await requireAuth(event)
+  const user = await requireAuth(event)
   const body = await readBody<CreateTechnologyRequest>(event)
 
   try {
     const service = new TechnologyService()
-    const name = await service.create(body)
+    const name = await service.create({ ...body, userId: user.id })
 
     setResponseStatus(event, 201)
     return {

--- a/server/api/technologies/[name].delete.ts
+++ b/server/api/technologies/[name].delete.ts
@@ -64,7 +64,7 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  await service.delete(name)
+  await service.delete(name, user.id)
 
   setResponseStatus(event, 204)
   return null

--- a/server/api/technologies/[name]/approvals.post.ts
+++ b/server/api/technologies/[name]/approvals.post.ts
@@ -1,0 +1,97 @@
+import { TechnologyService } from '../../../services/technology.service'
+
+/**
+ * @openapi
+ * /technologies/{name}/approvals:
+ *   post:
+ *     tags:
+ *       - Technologies
+ *     summary: Set a team's TIME approval for a technology
+ *     description: Creates or updates a team's APPROVES relationship on a technology. The user must be a member of the specified team or a superuser.
+ *     parameters:
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Technology name
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - teamName
+ *               - time
+ *             properties:
+ *               teamName:
+ *                 type: string
+ *               time:
+ *                 type: string
+ *                 enum: [tolerate, invest, migrate, eliminate]
+ *               versionConstraint:
+ *                 type: string
+ *               notes:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Approval set
+ *       400:
+ *         description: Missing required fields
+ *       403:
+ *         description: User is not a member of the specified team
+ *       404:
+ *         description: Technology not found
+ *       422:
+ *         description: Invalid TIME value
+ */
+
+interface SetApprovalRequest {
+  teamName: string
+  time: string
+  versionConstraint?: string
+  notes?: string
+}
+
+export default defineEventHandler(async (event) => {
+  const user = await requireAuth(event)
+
+  const rawName = getRouterParam(event, 'name')
+  if (!rawName) {
+    throw createError({ statusCode: 400, message: 'Technology name is required' })
+  }
+  const technologyName = decodeURIComponent(rawName)
+
+  const body = await readBody<SetApprovalRequest>(event)
+
+  if (!body?.teamName || !body?.time) {
+    throw createError({ statusCode: 400, message: 'teamName and time are required' })
+  }
+
+  // Verify user is a member of the team or a superuser
+  if (user.role !== 'superuser') {
+    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+    if (!userTeamNames.includes(body.teamName)) {
+      throw createError({
+        statusCode: 403,
+        message: `You must be a member of '${body.teamName}' to set its TIME approval`
+      })
+    }
+  }
+
+  const service = new TechnologyService()
+  const result = await service.setApproval({
+    technologyName,
+    teamName: body.teamName,
+    time: body.time,
+    versionConstraint: body.versionConstraint,
+    notes: body.notes,
+    userId: user.id
+  })
+
+  return {
+    success: true,
+    data: result
+  }
+})

--- a/server/database/queries/technologies/create.cypher
+++ b/server/database/queries/technologies/create.cypher
@@ -18,4 +18,17 @@ CALL (t) {
          OR c.packageManager = $componentPackageManager)
   MERGE (c)-[:IS_VERSION_OF]->(t)
 }
+WITH t
+CREATE (a:AuditLog {
+  id: randomUUID(),
+  timestamp: datetime(),
+  operation: 'CREATE',
+  entityType: 'Technology',
+  entityId: t.name,
+  entityLabel: t.name,
+  changedFields: ['name', 'category', 'vendor'],
+  source: 'API',
+  userId: $userId
+})
+CREATE (a)-[:AUDITS]->(t)
 RETURN t.name as name

--- a/server/database/queries/technologies/delete.cypher
+++ b/server/database/queries/technologies/delete.cypher
@@ -1,2 +1,12 @@
 MATCH (t:Technology {name: $name})
+CREATE (a:AuditLog {
+  id: randomUUID(),
+  timestamp: datetime(),
+  operation: 'DELETE',
+  entityType: 'Technology',
+  entityId: t.name,
+  entityLabel: t.name,
+  source: 'API',
+  userId: $userId
+})
 DETACH DELETE t

--- a/server/database/queries/technologies/upsert-approval.cypher
+++ b/server/database/queries/technologies/upsert-approval.cypher
@@ -1,0 +1,22 @@
+MATCH (team:Team {name: $teamName})
+MATCH (t:Technology {name: $technologyName})
+MERGE (team)-[a:APPROVES]->(t)
+SET a.time = $time,
+    a.approvedAt = CASE WHEN a.approvedAt IS NULL THEN datetime() ELSE a.approvedAt END,
+    a.approvedBy = $approvedBy,
+    a.versionConstraint = $versionConstraint,
+    a.notes = $notes
+WITH t, team, a
+CREATE (al:AuditLog {
+  id: randomUUID(),
+  timestamp: datetime(),
+  operation: CASE WHEN a.approvedAt = datetime() THEN 'CREATE' ELSE 'UPDATE' END,
+  entityType: 'TechnologyApproval',
+  entityId: t.name,
+  entityLabel: team.name + ' -> ' + t.name + ' (' + $time + ')',
+  changedFields: ['time', 'versionConstraint', 'notes'],
+  source: 'API',
+  userId: $userId
+})
+CREATE (al)-[:AUDITS]->(t)
+RETURN a.time as time, team.name as team


### PR DESCRIPTION
## Description

Adds superuser impersonation, per-team TIME category approvals on technologies, audit logging for technology mutations, and fixes the TIME column in the technologies list to show all team stances.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

### Superuser impersonation
- Cookie-based impersonation (`polaris-impersonate`) that overrides `getCurrentUser()` to return the target user's role and teams
- `POST/GET/DELETE /api/admin/impersonate` endpoints with superuser-only access
- `useImpersonation` composable for client-side state management
- Amber banner in the layout when impersonating, with "Stop Impersonating" button
- "Impersonate User" sidebar item with searchable user picker modal
- 1-hour cookie expiry, httpOnly, secure in production

### Per-team TIME approvals
- `POST /api/technologies/[name]/approvals` endpoint — creates or updates a team's `APPROVES` relationship
- Team membership verification (user must belong to the team or be a superuser)
- Validates TIME values: tolerate, invest, migrate, eliminate
- "Set TIME Category" button on `/technologies/[name]` detail page
- Modal with team select, TIME select, version constraint, and notes fields
- Pre-fills form when the selected team already has an existing approval
- Auto-selects team when user belongs to only one

### Audit logging
- Technology create and delete operations now create `AuditLog` nodes
- `userId` passed through the full chain (API → service → repository → Cypher)
- Approval upserts also create audit entries with entity type `TechnologyApproval`

### TIME column fix
- Technologies list now shows all team approvals as individual `team: time` badges instead of just the first one

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run test` — all 743 tests pass
- [x] I have run `npm run mdlint` — no errors
- [x] I have tested my changes locally with `npm run dev`