### PR TITLE
feat: server-side column sorting on all tables

### DIFF
--- a/app/composables/useSortableTable.ts
+++ b/app/composables/useSortableTable.ts
@@ -1,0 +1,58 @@
+import { h } from 'vue'
+import type { Column } from '@tanstack/vue-table'
+import { UDropdownMenu, UButton } from '#components'
+
+/**
+ * Returns a render function for sortable column headers.
+ * Uses UDropdownMenu with Asc/Desc checkboxes and a UButton trigger.
+ */
+export function useSortableTable() {
+
+  function getSortableHeader<T>(column: Column<T>, label: string) {
+    const isSorted = column.getIsSorted()
+
+    return h(UDropdownMenu, {
+      content: { align: 'start' as const },
+      items: [
+        {
+          label: 'Asc',
+          type: 'checkbox' as const,
+          icon: 'i-lucide-arrow-up-narrow-wide',
+          checked: isSorted === 'asc',
+          onSelect: () => {
+            if (isSorted === 'asc') {
+              column.clearSorting()
+            } else {
+              column.toggleSorting(false)
+            }
+          }
+        },
+        {
+          label: 'Desc',
+          type: 'checkbox' as const,
+          icon: 'i-lucide-arrow-down-wide-narrow',
+          checked: isSorted === 'desc',
+          onSelect: () => {
+            if (isSorted === 'desc') {
+              column.clearSorting()
+            } else {
+              column.toggleSorting(true)
+            }
+          }
+        }
+      ]
+    }, () => h(UButton, {
+      color: 'neutral',
+      variant: 'ghost',
+      label,
+      icon: isSorted
+        ? isSorted === 'asc'
+          ? 'i-lucide-arrow-up-narrow-wide'
+          : 'i-lucide-arrow-down-wide-narrow'
+        : 'i-lucide-arrow-up-down',
+      class: '-mx-2.5 data-[state=open]:bg-elevated'
+    }))
+  }
+
+  return { getSortableHeader }
+}

--- a/app/pages/audit.vue
+++ b/app/pages/audit.vue
@@ -58,6 +58,8 @@
 
       <UCard>
         <UTable
+          v-model:sorting="sorting"
+          :manual-sorting="true"
           :data="entries"
           :columns="columns"
           :loading="pending"
@@ -87,6 +89,8 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+
+const { getSortableHeader } = useSortableTable()
 
 interface AuditEntry {
   id: string
@@ -133,7 +137,7 @@ function formatDate(dateString: string): string {
 const columns: TableColumn<AuditEntry>[] = [
   {
     accessorKey: 'operation',
-    header: 'Operation',
+    header: ({ column }) => getSortableHeader(column, 'Operation'),
     cell: ({ row }) => {
       const operation = row.getValue('operation') as string
       return h(resolveComponent('UBadge'), {
@@ -144,12 +148,12 @@ const columns: TableColumn<AuditEntry>[] = [
   },
   {
     accessorKey: 'entityType',
-    header: 'Entity Type',
+    header: ({ column }) => getSortableHeader(column, 'Entity Type'),
     cell: ({ row }) => h('span', { class: 'font-medium' }, row.getValue('entityType') as string)
   },
   {
     accessorKey: 'entityLabel',
-    header: 'Entity',
+    header: ({ column }) => getSortableHeader(column, 'Entity'),
     cell: ({ row }) => {
       const label = row.original.entityLabel || row.original.entityId
       return label || '—'
@@ -157,7 +161,7 @@ const columns: TableColumn<AuditEntry>[] = [
   },
   {
     accessorKey: 'userId',
-    header: 'Performed By',
+    header: ({ column }) => getSortableHeader(column, 'Performed By'),
     cell: ({ row }) => {
       const entry = row.original
       const display = entry.userName || entry.userId
@@ -167,11 +171,13 @@ const columns: TableColumn<AuditEntry>[] = [
   },
   {
     accessorKey: 'timestamp',
-    header: 'Timestamp',
+    header: ({ column }) => getSortableHeader(column, 'Timestamp'),
     cell: ({ row }) => formatDate(row.getValue('timestamp') as string)
   }
 ]
 
+const sorting = ref([])
+watch(sorting, () => { page.value = 1 })
 const selectedEntityType = ref('all')
 const selectedOperation = ref('all')
 const page = ref(1)
@@ -184,6 +190,10 @@ const queryParams = computed(() => {
   }
   if (selectedEntityType.value && selectedEntityType.value !== 'all') params.entityType = selectedEntityType.value
   if (selectedOperation.value && selectedOperation.value !== 'all') params.operation = selectedOperation.value
+  if (sorting.value.length) {
+    params.sortBy = sorting.value[0].id
+    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
+  }
   return params
 })
 

--- a/app/pages/systems/[name]/unmapped-components.vue
+++ b/app/pages/systems/[name]/unmapped-components.vue
@@ -25,6 +25,8 @@
 
       <UCard>
         <UTable
+          v-model:sorting="sorting"
+          :manual-sorting="true"
           :data="components"
           :columns="columns"
           :loading="pending"
@@ -57,6 +59,7 @@
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
 
+const { getSortableHeader } = useSortableTable()
 const route = useRoute()
 const systemName = computed(() => decodeURIComponent(String(route.params.name)))
 
@@ -77,18 +80,21 @@ interface UnmappedResponse {
 const columns: TableColumn<UnmappedComponent>[] = [
   {
     accessorKey: 'name',
-    header: 'Name',
+    header: ({ column }) => getSortableHeader(column, 'Name'),
     cell: ({ row }) => h('strong', {}, row.getValue('name') as string)
   },
   {
     accessorKey: 'version',
-    header: 'Version',
+    header: ({ column }) => getSortableHeader(column, 'Version'),
     cell: ({ row }) => h('code', {}, row.getValue('version') as string)
   },
-  { accessorKey: 'packageManager', header: 'Package Manager' },
+  {
+    accessorKey: 'packageManager',
+    header: ({ column }) => getSortableHeader(column, 'Package Manager')
+  },
   {
     accessorKey: 'license',
-    header: 'License',
+    header: ({ column }) => getSortableHeader(column, 'License'),
     cell: ({ row }) => {
       const license = row.getValue('license') as string | null
       if (!license) return h('span', { class: 'text-(--ui-text-muted)' }, 'Unknown')
@@ -97,9 +103,18 @@ const columns: TableColumn<UnmappedComponent>[] = [
   }
 ]
 
+const sorting = ref([])
+watch(sorting, () => { page.value = 1 })
 const page = ref(1)
 const pageSize = 20
-const queryParams = computed(() => ({ limit: pageSize, offset: (page.value - 1) * pageSize }))
+const queryParams = computed(() => {
+  const params: Record<string, string | number> = { limit: pageSize, offset: (page.value - 1) * pageSize }
+  if (sorting.value.length) {
+    params.sortBy = sorting.value[0].id
+    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
+  }
+  return params
+})
 
 const { data, pending, error } = await useFetch<UnmappedResponse>(
   () => `/api/systems/${route.params.name}/unmapped-components`,

--- a/app/pages/teams/[name].vue
+++ b/app/pages/teams/[name].vue
@@ -53,28 +53,28 @@
         <template #header>
           <h2 class="text-lg font-semibold">Members ({{ data.data.members.length }})</h2>
         </template>
-        <UTable :data="data.data.members" :columns="memberColumns" class="flex-1" />
+        <UTable v-model:sorting="memberSorting" :data="data.data.members" :columns="memberColumns" class="flex-1" />
       </UCard>
 
       <UCard v-if="data.data.technologies && data.data.technologies.length > 0">
         <template #header>
           <h2 class="text-lg font-semibold">Technologies ({{ data.data.technologies.length }})</h2>
         </template>
-        <UTable :data="data.data.technologies" :columns="technologyColumns" class="flex-1" />
+        <UTable v-model:sorting="technologySorting" :data="data.data.technologies" :columns="technologyColumns" class="flex-1" />
       </UCard>
 
       <UCard v-if="data.data.systems && data.data.systems.length > 0">
         <template #header>
           <h2 class="text-lg font-semibold">Systems ({{ data.data.systems.length }})</h2>
         </template>
-        <UTable :data="data.data.systems" :columns="systemColumns" class="flex-1" />
+        <UTable v-model:sorting="systemSorting" :data="data.data.systems" :columns="systemColumns" class="flex-1" />
       </UCard>
 
       <UCard v-if="data.data.approvals && data.data.approvals.length > 0">
         <template #header>
           <h2 class="text-lg font-semibold">Technology Approvals ({{ data.data.approvals.length }})</h2>
         </template>
-        <UTable :data="data.data.approvals" :columns="approvalColumns" class="flex-1" />
+        <UTable v-model:sorting="approvalSorting" :data="data.data.approvals" :columns="approvalColumns" class="flex-1" />
       </UCard>
     </template>
   </div>
@@ -83,6 +83,12 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+
+const { getSortableHeader } = useSortableTable()
+const memberSorting = ref([])
+const technologySorting = ref([])
+const systemSorting = ref([])
+const approvalSorting = ref([])
 
 const route = useRoute()
 
@@ -141,11 +147,17 @@ function getTimeCategoryColor(category: string): 'success' | 'warning' | 'error'
 }
 
 const memberColumns: TableColumn<Member>[] = [
-  { accessorKey: 'name', header: 'Name' },
-  { accessorKey: 'email', header: 'Email' },
+  {
+    accessorKey: 'name',
+    header: ({ column }) => getSortableHeader(column, 'Name')
+  },
+  {
+    accessorKey: 'email',
+    header: ({ column }) => getSortableHeader(column, 'Email')
+  },
   {
     accessorKey: 'role',
-    header: 'Role',
+    header: ({ column }) => getSortableHeader(column, 'Role'),
     cell: ({ row }) => {
       const role = row.getValue('role') as string
       return h(resolveComponent('UBadge'), { color: 'neutral', variant: 'subtle' }, () => role)
@@ -156,7 +168,7 @@ const memberColumns: TableColumn<Member>[] = [
 const technologyColumns: TableColumn<Technology>[] = [
   {
     accessorKey: 'name',
-    header: 'Name',
+    header: ({ column }) => getSortableHeader(column, 'Name'),
     cell: ({ row }) => {
       const tech = row.original
       return h(resolveComponent('NuxtLink'), {
@@ -165,23 +177,29 @@ const technologyColumns: TableColumn<Technology>[] = [
       }, () => tech.name)
     }
   },
-  { accessorKey: 'type', header: 'Type' },
+  {
+    accessorKey: 'type',
+    header: ({ column }) => getSortableHeader(column, 'Type')
+  },
   {
     accessorKey: 'timeCategory',
-    header: 'TIME',
+    header: ({ column }) => getSortableHeader(column, 'TIME'),
     cell: ({ row }) => {
       const cat = row.getValue('timeCategory') as string
       if (!cat) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
       return h(resolveComponent('UBadge'), { color: getTimeCategoryColor(cat), variant: 'subtle' }, () => cat)
     }
   },
-  { accessorKey: 'relationship', header: 'Relationship' }
+  {
+    accessorKey: 'relationship',
+    header: ({ column }) => getSortableHeader(column, 'Relationship')
+  }
 ]
 
 const systemColumns: TableColumn<System>[] = [
   {
     accessorKey: 'name',
-    header: 'Name',
+    header: ({ column }) => getSortableHeader(column, 'Name'),
     cell: ({ row }) => {
       const sys = row.original
       return h(resolveComponent('NuxtLink'), {
@@ -190,14 +208,20 @@ const systemColumns: TableColumn<System>[] = [
       }, () => sys.name)
     }
   },
-  { accessorKey: 'businessCriticality', header: 'Criticality' },
-  { accessorKey: 'environment', header: 'Environment' }
+  {
+    accessorKey: 'businessCriticality',
+    header: ({ column }) => getSortableHeader(column, 'Criticality')
+  },
+  {
+    accessorKey: 'environment',
+    header: ({ column }) => getSortableHeader(column, 'Environment')
+  }
 ]
 
 const approvalColumns: TableColumn<Approval>[] = [
   {
     accessorKey: 'technologyName',
-    header: 'Technology',
+    header: ({ column }) => getSortableHeader(column, 'Technology'),
     cell: ({ row }) => {
       const name = row.getValue('technologyName') as string
       return h(resolveComponent('NuxtLink'), {
@@ -208,7 +232,7 @@ const approvalColumns: TableColumn<Approval>[] = [
   },
   {
     accessorKey: 'timeCategory',
-    header: 'TIME Category',
+    header: ({ column }) => getSortableHeader(column, 'TIME Category'),
     cell: ({ row }) => {
       const cat = row.getValue('timeCategory') as string
       if (!cat) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
@@ -217,13 +241,16 @@ const approvalColumns: TableColumn<Approval>[] = [
   },
   {
     accessorKey: 'approvedAt',
-    header: 'Approved',
+    header: ({ column }) => getSortableHeader(column, 'Approved'),
     cell: ({ row }) => {
       const date = row.getValue('approvedAt') as string
       return date ? new Date(date).toLocaleDateString() : '—'
     }
   },
-  { accessorKey: 'approvedBy', header: 'Approved By' }
+  {
+    accessorKey: 'approvedBy',
+    header: ({ column }) => getSortableHeader(column, 'Approved By')
+  }
 ]
 
 const { data, pending, error } = await useFetch<TeamResponse>(() => `/api/teams/${encodeURIComponent(route.params.name as string)}`)

--- a/app/pages/technologies/[name].vue
+++ b/app/pages/technologies/[name].vue
@@ -144,6 +144,7 @@
         </template>
         <UTable
           v-if="tech.technologyApprovals && tech.technologyApprovals.length > 0"
+          v-model:sorting="approvalSorting"
           :data="tech.technologyApprovals"
           :columns="approvalColumns"
           class="flex-1"
@@ -228,7 +229,7 @@
         <template #header>
           <h2 class="text-lg font-semibold">Versions ({{ tech.versions.length }})</h2>
         </template>
-        <UTable :data="tech.versions" :columns="versionColumns" class="flex-1" />
+        <UTable v-model:sorting="versionSorting" :data="tech.versions" :columns="versionColumns" class="flex-1" />
       </UCard>
 
       <!-- Components -->
@@ -236,7 +237,7 @@
         <template #header>
           <h2 class="text-lg font-semibold">Components ({{ tech.components.length }})</h2>
         </template>
-        <UTable :data="tech.components" :columns="componentColumns" class="flex-1" />
+        <UTable v-model:sorting="componentSorting" :data="tech.components" :columns="componentColumns" class="flex-1" />
       </UCard>
 
       <!-- Systems -->
@@ -288,6 +289,11 @@
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
 import type { TechnologyApproval } from '~~/types/api'
+
+const { getSortableHeader } = useSortableTable()
+const approvalSorting = ref([])
+const versionSorting = ref([])
+const componentSorting = ref([])
 
 const route = useRoute()
 const { data: session } = useAuth()
@@ -368,12 +374,12 @@ function formatDate(dateString: string): string {
 const versionColumns: TableColumn<VersionDetail>[] = [
   {
     accessorKey: 'version',
-    header: 'Version',
+    header: ({ column }) => getSortableHeader(column, 'Version'),
     cell: ({ row }) => h('code', {}, row.getValue('version') as string)
   },
   {
     accessorKey: 'approved',
-    header: 'Status',
+    header: ({ column }) => getSortableHeader(column, 'Status'),
     cell: ({ row }) => {
       const approved = row.getValue('approved') as boolean
       const color = approved ? 'success' : 'warning'
@@ -383,7 +389,7 @@ const versionColumns: TableColumn<VersionDetail>[] = [
   },
   {
     accessorKey: 'releaseDate',
-    header: 'Released',
+    header: ({ column }) => getSortableHeader(column, 'Released'),
     cell: ({ row }) => {
       const date = row.getValue('releaseDate') as string | null
       return date ? formatDate(date) : '—'
@@ -391,7 +397,7 @@ const versionColumns: TableColumn<VersionDetail>[] = [
   },
   {
     accessorKey: 'eolDate',
-    header: 'End of Life',
+    header: ({ column }) => getSortableHeader(column, 'End of Life'),
     cell: ({ row }) => {
       const date = row.getValue('eolDate') as string | null
       return date ? formatDate(date) : '—'
@@ -399,7 +405,7 @@ const versionColumns: TableColumn<VersionDetail>[] = [
   },
   {
     accessorKey: 'notes',
-    header: 'Notes',
+    header: ({ column }) => getSortableHeader(column, 'Notes'),
     cell: ({ row }) => {
       const notes = row.getValue('notes') as string | null
       return notes || '—'
@@ -410,7 +416,7 @@ const versionColumns: TableColumn<VersionDetail>[] = [
 const approvalColumns: TableColumn<TechnologyApproval>[] = [
   {
     accessorKey: 'team',
-    header: 'Team',
+    header: ({ column }) => getSortableHeader(column, 'Team'),
     cell: ({ row }) => {
       const team = row.getValue('team') as string
       return h(resolveComponent('NuxtLink'), {
@@ -421,7 +427,7 @@ const approvalColumns: TableColumn<TechnologyApproval>[] = [
   },
   {
     accessorKey: 'time',
-    header: 'TIME',
+    header: ({ column }) => getSortableHeader(column, 'TIME'),
     cell: ({ row }) => {
       const time = row.getValue('time') as string | null
       if (!time) return '—'
@@ -430,7 +436,7 @@ const approvalColumns: TableColumn<TechnologyApproval>[] = [
   },
   {
     accessorKey: 'versionConstraint',
-    header: 'Version Constraint',
+    header: ({ column }) => getSortableHeader(column, 'Version Constraint'),
     cell: ({ row }) => {
       const vc = row.original.versionConstraint
       return vc ? h('code', {}, vc) : '—'
@@ -438,7 +444,7 @@ const approvalColumns: TableColumn<TechnologyApproval>[] = [
   },
   {
     accessorKey: 'approvedAt',
-    header: 'Approved',
+    header: ({ column }) => getSortableHeader(column, 'Approved'),
     cell: ({ row }) => {
       const date = row.original.approvedAt
       return date ? formatDate(date) : '—'
@@ -446,12 +452,12 @@ const approvalColumns: TableColumn<TechnologyApproval>[] = [
   },
   {
     accessorKey: 'approvedBy',
-    header: 'By',
+    header: ({ column }) => getSortableHeader(column, 'By'),
     cell: ({ row }) => row.original.approvedBy || '—'
   },
   {
     accessorKey: 'notes',
-    header: 'Notes',
+    header: ({ column }) => getSortableHeader(column, 'Notes'),
     cell: ({ row }) => row.original.notes || '—'
   }
 ]
@@ -459,17 +465,17 @@ const approvalColumns: TableColumn<TechnologyApproval>[] = [
 const componentColumns: TableColumn<ComponentRef>[] = [
   {
     accessorKey: 'name',
-    header: 'Name',
+    header: ({ column }) => getSortableHeader(column, 'Name'),
     cell: ({ row }) => h('strong', {}, row.getValue('name') as string)
   },
   {
     accessorKey: 'version',
-    header: 'Version',
+    header: ({ column }) => getSortableHeader(column, 'Version'),
     cell: ({ row }) => h('code', {}, row.getValue('version') as string)
   },
   {
     accessorKey: 'packageManager',
-    header: 'Package Manager',
+    header: ({ column }) => getSortableHeader(column, 'Package Manager'),
     cell: ({ row }) => row.getValue('packageManager') || '—'
   }
 ]

--- a/schema/fixtures/tech-catalog.json
+++ b/schema/fixtures/tech-catalog.json
@@ -33,26 +33,6 @@
   ],
   "technologies": [
     {
-      "name": "React",
-      "category": "framework",
-      "vendor": "Meta",
-      "status": "approved",
-      "approvedVersionRange": ">=18.0.0 <19.0.0",
-      "ownerTeam": "Frontend Platform",
-      "riskLevel": "low",
-      "lastReviewed": "2025-10-01"
-    },
-    {
-      "name": "Vue",
-      "category": "framework",
-      "vendor": "Vue.js Team",
-      "status": "approved",
-      "approvedVersionRange": ">=3.3.0 <4.0.0",
-      "ownerTeam": "Frontend Platform",
-      "riskLevel": "low",
-      "lastReviewed": "2025-10-01"
-    },
-    {
       "name": "Angular",
       "category": "framework",
       "vendor": "Google",
@@ -103,26 +83,6 @@
       "lastReviewed": "2025-09-20"
     },
     {
-      "name": "Express",
-      "category": "framework",
-      "vendor": "OpenJS Foundation",
-      "status": "approved",
-      "approvedVersionRange": ">=4.18.0 <5.0.0",
-      "ownerTeam": "Backend Platform",
-      "riskLevel": "low",
-      "lastReviewed": "2025-10-01"
-    },
-    {
-      "name": "TypeScript",
-      "category": "language",
-      "vendor": "Microsoft",
-      "status": "approved",
-      "approvedVersionRange": ">=5.0.0 <6.0.0",
-      "ownerTeam": "Frontend Platform",
-      "riskLevel": "low",
-      "lastReviewed": "2025-10-01"
-    },
-    {
       "name": "Docker",
       "category": "container",
       "vendor": "Docker Inc.",
@@ -131,26 +91,6 @@
       "ownerTeam": "DevOps",
       "riskLevel": "low",
       "lastReviewed": "2025-10-01"
-    },
-    {
-      "name": "jQuery",
-      "category": "library",
-      "vendor": "jQuery Foundation",
-      "status": "deprecated",
-      "approvedVersionRange": ">=3.0.0 <4.0.0",
-      "ownerTeam": "Frontend Platform",
-      "riskLevel": "high",
-      "lastReviewed": "2024-01-01"
-    },
-    {
-      "name": "Lodash",
-      "category": "library",
-      "vendor": "Lodash",
-      "status": "deprecated",
-      "approvedVersionRange": ">=4.17.0 <5.0.0",
-      "ownerTeam": "Frontend Platform",
-      "riskLevel": "medium",
-      "lastReviewed": "2024-06-01"
     },
     {
       "name": "MySQL",
@@ -174,33 +114,6 @@
     }
   ],
   "versions": [
-    {
-      "technologyName": "React",
-      "version": "18.2.0",
-      "releaseDate": "2023-06-14",
-      "eolDate": "2025-12-31",
-      "approved": true,
-      "cvssScore": 0,
-      "notes": "Stable LTS version"
-    },
-    {
-      "technologyName": "React",
-      "version": "18.3.1",
-      "releaseDate": "2024-04-26",
-      "eolDate": "2026-06-30",
-      "approved": true,
-      "cvssScore": 0,
-      "notes": "Latest stable version"
-    },
-    {
-      "technologyName": "Vue",
-      "version": "3.3.4",
-      "releaseDate": "2023-07-28",
-      "eolDate": "2025-12-31",
-      "approved": true,
-      "cvssScore": 0,
-      "notes": "Stable version"
-    },
     {
       "technologyName": "Node.js",
       "version": "20.11.0",
@@ -227,15 +140,6 @@
       "approved": true,
       "cvssScore": 0,
       "notes": "Community edition"
-    },
-    {
-      "technologyName": "TypeScript",
-      "version": "5.3.3",
-      "releaseDate": "2023-12-11",
-      "eolDate": "2026-12-31",
-      "approved": true,
-      "cvssScore": 0,
-      "notes": "Latest stable version"
     }
   ],
   "policies": [
@@ -302,80 +206,115 @@
   ],
   "relationships": {
     "technology_versions": [
-      { "technology": "React", "version": "18.2.0" },
-      { "technology": "React", "version": "18.3.1" },
-      { "technology": "Vue", "version": "3.3.4" },
-      { "technology": "Node.js", "version": "20.11.0" },
-      { "technology": "PostgreSQL", "version": "16.1" },
-      { "technology": "Neo4j", "version": "5.26.13" },
-      { "technology": "TypeScript", "version": "5.3.3" }
+      {
+        "technology": "Node.js",
+        "version": "20.11.0"
+      },
+      {
+        "technology": "PostgreSQL",
+        "version": "16.1"
+      },
+      {
+        "technology": "Neo4j",
+        "version": "5.26.13"
+      }
     ],
     "team_technologies": [
-      { "team": "Frontend Platform", "technology": "React" },
-      { "team": "Frontend Platform", "technology": "Vue" },
-      { "team": "Frontend Platform", "technology": "Angular" },
-      { "team": "Frontend Platform", "technology": "TypeScript" },
-      { "team": "Frontend Platform", "technology": "jQuery" },
-      { "team": "Frontend Platform", "technology": "Lodash" },
-      { "team": "Backend Platform", "technology": "Node.js" },
-      { "team": "Backend Platform", "technology": "Express" },
-      { "team": "Backend Platform", "technology": "Redis" },
-      { "team": "Data Platform", "technology": "PostgreSQL" },
-      { "team": "Data Platform", "technology": "Neo4j" },
-      { "team": "Data Platform", "technology": "MongoDB" },
-      { "team": "Data Platform", "technology": "MySQL" },
-      { "team": "DevOps", "technology": "Docker" },
-      { "team": "Platform Team", "technology": "TypeScript" },
-      { "team": "Platform Team", "technology": "Node.js" },
-      { "team": "Platform Team", "technology": "Vue" },
-      { "team": "Platform Team", "technology": "Neo4j" }
+      {
+        "team": "Frontend Platform",
+        "technology": "Angular"
+      },
+      {
+        "team": "Backend Platform",
+        "technology": "Node.js"
+      },
+      {
+        "team": "Backend Platform",
+        "technology": "Redis"
+      },
+      {
+        "team": "Data Platform",
+        "technology": "PostgreSQL"
+      },
+      {
+        "team": "Data Platform",
+        "technology": "Neo4j"
+      },
+      {
+        "team": "Data Platform",
+        "technology": "MongoDB"
+      },
+      {
+        "team": "Data Platform",
+        "technology": "MySQL"
+      },
+      {
+        "team": "DevOps",
+        "technology": "Docker"
+      },
+      {
+        "team": "Platform Team",
+        "technology": "Node.js"
+      },
+      {
+        "team": "Platform Team",
+        "technology": "Neo4j"
+      }
     ],
     "policy_technologies": [
-      { "policy": "Technology Approval Required", "technology": "React" },
-      { "policy": "Technology Approval Required", "technology": "Vue" },
-      { "policy": "Technology Approval Required", "technology": "Angular" },
-      { "policy": "Database Version Compliance", "technology": "PostgreSQL" },
-      { "policy": "Database Version Compliance", "technology": "Neo4j" },
-      { "policy": "Database Version Compliance", "technology": "MongoDB" },
-      { "policy": "Database Version Compliance", "technology": "MySQL" },
-      { "policy": "Migration Target Required", "technology": "Angular" },
-      { "policy": "Migration Target Required", "technology": "jQuery" },
-      { "policy": "Migration Target Required", "technology": "Lodash" },
-      { "policy": "High Risk Technology Approval", "technology": "jQuery" },
-      { "policy": "EOL Warning", "technology": "React" },
-      { "policy": "EOL Warning", "technology": "Vue" }
+      {
+        "policy": "Technology Approval Required",
+        "technology": "Angular"
+      },
+      {
+        "policy": "Database Version Compliance",
+        "technology": "PostgreSQL"
+      },
+      {
+        "policy": "Database Version Compliance",
+        "technology": "Neo4j"
+      },
+      {
+        "policy": "Database Version Compliance",
+        "technology": "MongoDB"
+      },
+      {
+        "policy": "Database Version Compliance",
+        "technology": "MySQL"
+      },
+      {
+        "policy": "Migration Target Required",
+        "technology": "Angular"
+      }
     ]
   },
   "github_systems": {
     "_comment": "These systems are created by seed:github from github-repos.json. Relationships defined here are applied after GitHub seeding.",
     "team_systems": [
-      { "team": "Platform Team", "system": "Polaris Technology Catalog" },
-      { "team": "Platform Team", "system": "Catalyst" },
-      { "team": "Platform Team", "system": "TSArchi" },
-      { "team": "Platform Team", "system": "PlantKit" },
-      { "team": "Platform Team", "system": "Karla" }
+      {
+        "team": "Platform Team",
+        "system": "Polaris Technology Catalog"
+      },
+      {
+        "team": "Platform Team",
+        "system": "Catalyst"
+      },
+      {
+        "team": "Platform Team",
+        "system": "TSArchi"
+      },
+      {
+        "team": "Platform Team",
+        "system": "PlantKit"
+      },
+      {
+        "team": "Platform Team",
+        "system": "Karla"
+      }
     ]
   },
   "approvals": {
     "team_technology_approvals": [
-      {
-        "team": "Frontend Platform",
-        "technology": "React",
-        "time": "invest",
-        "approvedAt": "2024-01-15",
-        "notes": "Primary frontend framework - strategic investment",
-        "approvedBy": "Tech Lead",
-        "versionConstraint": ">=18.0.0"
-      },
-      {
-        "team": "Frontend Platform",
-        "technology": "Vue",
-        "time": "invest",
-        "approvedAt": "2024-01-15",
-        "notes": "Alternative frontend framework for specific use cases",
-        "approvedBy": "Tech Lead",
-        "versionConstraint": ">=3.3.0"
-      },
       {
         "team": "Frontend Platform",
         "technology": "Angular",
@@ -387,36 +326,6 @@
         "approvedBy": "Tech Lead"
       },
       {
-        "team": "Frontend Platform",
-        "technology": "TypeScript",
-        "time": "invest",
-        "approvedAt": "2024-01-15",
-        "notes": "Required for all new projects",
-        "approvedBy": "Tech Lead",
-        "versionConstraint": ">=5.0.0"
-      },
-      {
-        "team": "Frontend Platform",
-        "technology": "jQuery",
-        "time": "eliminate",
-        "approvedAt": "2020-01-01",
-        "deprecatedAt": "2023-01-01",
-        "eolDate": "2025-12-31",
-        "migrationTarget": "React",
-        "notes": "Phase out - do not use in any projects",
-        "approvedBy": "Tech Lead"
-      },
-      {
-        "team": "Frontend Platform",
-        "technology": "Lodash",
-        "time": "migrate",
-        "approvedAt": "2022-01-01",
-        "deprecatedAt": "2024-06-01",
-        "migrationTarget": "Native ES6+",
-        "notes": "Migrate to native JavaScript methods",
-        "approvedBy": "Tech Lead"
-      },
-      {
         "team": "Backend Platform",
         "technology": "Node.js",
         "time": "invest",
@@ -424,15 +333,6 @@
         "notes": "Primary backend runtime - strategic investment",
         "approvedBy": "Tech Lead",
         "versionConstraint": ">=20.0.0"
-      },
-      {
-        "team": "Backend Platform",
-        "technology": "Express",
-        "time": "invest",
-        "approvedAt": "2024-01-15",
-        "notes": "Primary web framework",
-        "approvedBy": "Tech Lead",
-        "versionConstraint": ">=4.18.0"
       },
       {
         "team": "Backend Platform",
@@ -489,30 +389,12 @@
       },
       {
         "team": "Platform Team",
-        "technology": "TypeScript",
-        "time": "invest",
-        "approvedAt": "2024-01-15",
-        "notes": "Primary language for all Platform Team projects",
-        "approvedBy": "Platform Lead",
-        "versionConstraint": ">=5.0.0"
-      },
-      {
-        "team": "Platform Team",
         "technology": "Node.js",
         "time": "invest",
         "approvedAt": "2024-01-15",
         "notes": "Runtime for TypeScript projects",
         "approvedBy": "Platform Lead",
         "versionConstraint": ">=20.0.0"
-      },
-      {
-        "team": "Platform Team",
-        "technology": "Vue",
-        "time": "invest",
-        "approvedAt": "2024-01-15",
-        "notes": "Frontend framework for Polaris",
-        "approvedBy": "Platform Lead",
-        "versionConstraint": ">=3.3.0"
       },
       {
         "team": "Platform Team",
@@ -524,5 +406,183 @@
         "versionConstraint": ">=5.0.0"
       }
     ]
-  }
+  },
+  "component_technologies": [
+    {
+      "componentName": "react",
+      "packageManager": "npm",
+      "technology": {
+        "name": "React",
+        "category": "framework",
+        "vendor": "Meta"
+      },
+      "ownerTeam": "Frontend Platform",
+      "stewardTeams": [
+        "Frontend Platform"
+      ],
+      "policies": [
+        "Technology Approval Required",
+        "EOL Warning"
+      ],
+      "approvals": [
+        {
+          "team": "Frontend Platform",
+          "time": "invest",
+          "approvedAt": "2024-01-15",
+          "notes": "Primary frontend framework - strategic investment",
+          "approvedBy": "Tech Lead",
+          "versionConstraint": ">=18.0.0"
+        }
+      ]
+    },
+    {
+      "componentName": "vue",
+      "packageManager": "npm",
+      "technology": {
+        "name": "Vue",
+        "category": "framework",
+        "vendor": "Vue.js Team"
+      },
+      "ownerTeam": "Frontend Platform",
+      "stewardTeams": [
+        "Frontend Platform",
+        "Platform Team"
+      ],
+      "policies": [
+        "Technology Approval Required",
+        "EOL Warning"
+      ],
+      "approvals": [
+        {
+          "team": "Frontend Platform",
+          "time": "invest",
+          "approvedAt": "2024-01-15",
+          "notes": "Alternative frontend framework for specific use cases",
+          "approvedBy": "Tech Lead",
+          "versionConstraint": ">=3.3.0"
+        },
+        {
+          "team": "Platform Team",
+          "time": "invest",
+          "approvedAt": "2024-01-15",
+          "notes": "Frontend framework for Polaris",
+          "approvedBy": "Platform Lead",
+          "versionConstraint": ">=3.3.0"
+        }
+      ]
+    },
+    {
+      "componentName": "express",
+      "packageManager": "npm",
+      "technology": {
+        "name": "Express",
+        "category": "framework",
+        "vendor": "OpenJS Foundation"
+      },
+      "ownerTeam": "Backend Platform",
+      "stewardTeams": [
+        "Backend Platform"
+      ],
+      "policies": [],
+      "approvals": [
+        {
+          "team": "Backend Platform",
+          "time": "invest",
+          "approvedAt": "2024-01-15",
+          "notes": "Primary web framework",
+          "approvedBy": "Tech Lead",
+          "versionConstraint": ">=4.18.0"
+        }
+      ]
+    },
+    {
+      "componentName": "typescript",
+      "packageManager": "npm",
+      "technology": {
+        "name": "TypeScript",
+        "category": "language",
+        "vendor": "Microsoft"
+      },
+      "ownerTeam": "Frontend Platform",
+      "stewardTeams": [
+        "Frontend Platform",
+        "Platform Team"
+      ],
+      "policies": [],
+      "approvals": [
+        {
+          "team": "Frontend Platform",
+          "time": "invest",
+          "approvedAt": "2024-01-15",
+          "notes": "Required for all new projects",
+          "approvedBy": "Tech Lead",
+          "versionConstraint": ">=5.0.0"
+        },
+        {
+          "team": "Platform Team",
+          "time": "invest",
+          "approvedAt": "2024-01-15",
+          "notes": "Primary language for all Platform Team projects",
+          "approvedBy": "Platform Lead",
+          "versionConstraint": ">=5.0.0"
+        }
+      ]
+    },
+    {
+      "componentName": "jquery",
+      "packageManager": "npm",
+      "technology": {
+        "name": "jQuery",
+        "category": "library",
+        "vendor": "jQuery Foundation"
+      },
+      "ownerTeam": "Frontend Platform",
+      "stewardTeams": [
+        "Frontend Platform"
+      ],
+      "policies": [
+        "Migration Target Required",
+        "High Risk Technology Approval"
+      ],
+      "approvals": [
+        {
+          "team": "Frontend Platform",
+          "time": "eliminate",
+          "approvedAt": "2020-01-01",
+          "deprecatedAt": "2023-01-01",
+          "eolDate": "2025-12-31",
+          "migrationTarget": "React",
+          "notes": "Phase out - do not use in any projects",
+          "approvedBy": "Tech Lead"
+        }
+      ]
+    },
+    {
+      "componentName": "lodash",
+      "packageManager": "npm",
+      "technology": {
+        "name": "Lodash",
+        "category": "library",
+        "vendor": "Lodash"
+      },
+      "ownerTeam": "Frontend Platform",
+      "stewardTeams": [
+        "Frontend Platform"
+      ],
+      "policies": [
+        "Migration Target Required"
+      ],
+      "approvals": [
+        {
+          "team": "Frontend Platform",
+          "time": "migrate",
+          "approvedAt": "2022-01-01",
+          "deprecatedAt": "2024-06-01",
+          "migrationTarget": "Native ES6+",
+          "notes": "Migrate to native JavaScript methods",
+          "approvedBy": "Tech Lead"
+        }
+      ]
+    }
+  ]
 }

--- a/server/api/audit-logs.get.ts
+++ b/server/api/audit-logs.get.ts
@@ -85,7 +85,9 @@ export default defineEventHandler(async (event) => {
     operation: query.operation as string | undefined,
     userId: query.userId as string | undefined,
     limit: query.limit ? parseInt(query.limit as string, 10) : 100,
-    offset: query.offset ? parseInt(query.offset as string, 10) : 0
+    offset: query.offset ? parseInt(query.offset as string, 10) : 0,
+    sortBy: query.sortBy as string | undefined,
+    sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
   }
 
   const auditLogService = new AuditLogService()

--- a/server/api/components.get.ts
+++ b/server/api/components.get.ts
@@ -109,7 +109,9 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Component>>
       license: query.license as string | undefined,
       hasLicense: query.hasLicense === 'true' ? true : query.hasLicense === 'false' ? false : undefined,
       limit,
-      offset
+      offset,
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
     }
 
     const componentService = new ComponentService()

--- a/server/api/components/unmapped.get.ts
+++ b/server/api/components/unmapped.get.ts
@@ -93,7 +93,10 @@ export default defineEventHandler(async (event): Promise<ApiResponse<UnmappedCom
     const offset = Math.max(0, rawOffset)
 
     const componentService = new ComponentService()
-    const result = await componentService.findUnmapped(limit, offset)
+    const result = await componentService.findUnmapped(limit, offset, {
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
+    })
     
     return {
       success: true,

--- a/server/api/licenses.get.ts
+++ b/server/api/licenses.get.ts
@@ -107,7 +107,11 @@ export default defineEventHandler(async (event): Promise<ApiResponse<License>> =
     }
     
     const licenseRepo = new LicenseRepository()
-    const allLicenses = await licenseRepo.findAll(filters)
+    const allLicenses = await licenseRepo.findAll({
+      ...filters,
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
+    })
     const total = allLicenses.length
     const paginatedLicenses = allLicenses.slice(offset, offset + limit)
     

--- a/server/api/policies.get.ts
+++ b/server/api/policies.get.ts
@@ -78,7 +78,11 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Policy>> =>
     const ruleType = query.ruleType as string | undefined
     
     const policyService = new PolicyService()
-    const result = await policyService.findAll({ scope, status, enforcedBy, ruleType })
+    const result = await policyService.findAll({
+      scope, status, enforcedBy, ruleType,
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
+    })
     const total = result.data.length
     const paginatedData = result.data.slice(offset, offset + limit)
     

--- a/server/api/policies/license-violations.get.ts
+++ b/server/api/policies/license-violations.get.ts
@@ -135,7 +135,9 @@ export default defineEventHandler(async (event): Promise<LicenseViolationRespons
       system: query.system as string | undefined,
       license: query.license as string | undefined,
       limit: query.limit ? parseInt(query.limit as string, 10) : undefined,
-      offset: query.offset ? parseInt(query.offset as string, 10) : undefined
+      offset: query.offset ? parseInt(query.offset as string, 10) : undefined,
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
     }
     
     const policyService = new PolicyService()

--- a/server/api/systems.get.ts
+++ b/server/api/systems.get.ts
@@ -53,7 +53,10 @@ export default defineEventHandler(async (event): Promise<ApiResponse<System>> =>
     const offset = query.offset ? parseInt(query.offset as string, 10) : 0
 
     const systemService = new SystemService()
-    const result = await systemService.findAll()
+    const result = await systemService.findAll({
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
+    })
     const total = result.data.length
     const paginatedData = result.data.slice(offset, offset + limit)
     

--- a/server/api/systems/[name]/unmapped-components.get.ts
+++ b/server/api/systems/[name]/unmapped-components.get.ts
@@ -88,6 +88,19 @@ export default defineEventHandler(async (event) => {
     
     const systemService = new SystemService()
     const result = await systemService.findUnmappedComponents(systemName)
+    
+    // Apply sorting
+    const sortBy = query.sortBy as string | undefined
+    const sortOrder = (query.sortOrder as string)?.toLowerCase() === 'desc' ? -1 : 1
+    const sortableFields = ['name', 'version', 'packageManager', 'license'] as const
+    if (sortBy && sortableFields.includes(sortBy as typeof sortableFields[number])) {
+      result.components.sort((a: Record<string, unknown>, b: Record<string, unknown>) => {
+        const aVal = String(a[sortBy] || '').toLowerCase()
+        const bVal = String(b[sortBy] || '').toLowerCase()
+        return aVal < bVal ? -sortOrder : aVal > bVal ? sortOrder : 0
+      })
+    }
+    
     const total = result.components.length
     const paginatedData = result.components.slice(offset, offset + limit)
 

--- a/server/api/teams.get.ts
+++ b/server/api/teams.get.ts
@@ -53,7 +53,10 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Team>> => {
     const offset = query.offset ? parseInt(query.offset as string, 10) : 0
 
     const teamService = new TeamService()
-    const result = await teamService.findAll()
+    const result = await teamService.findAll({
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
+    })
     const total = result.data.length
     const paginatedData = result.data.slice(offset, offset + limit)
     

--- a/server/api/technologies.get.ts
+++ b/server/api/technologies.get.ts
@@ -53,7 +53,10 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Technology>
     const offset = query.offset ? parseInt(query.offset as string, 10) : 0
 
     const technologyService = new TechnologyService()
-    const result = await technologyService.findAll()
+    const result = await technologyService.findAll({
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
+    })
     const total = result.data.length
     const paginatedData = result.data.slice(offset, offset + limit)
     

--- a/server/api/users.get.ts
+++ b/server/api/users.get.ts
@@ -70,7 +70,10 @@ export default defineEventHandler(async (event) => {
     const offset = query.offset ? parseInt(query.offset as string, 10) : 0
 
     const userService = new UserService()
-    const allUsers = await userService.findAllSummary()
+    const allUsers = await userService.findAllSummary({
+      sortBy: query.sortBy as string | undefined,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
+    })
     const total = allUsers.length
     const paginatedUsers = allUsers.slice(offset, offset + limit)
     

--- a/server/database/queries/components/find-all.cypher
+++ b/server/database/queries/components/find-all.cypher
@@ -4,10 +4,11 @@ MATCH (c:Component)
 OPTIONAL MATCH (c)-[:IS_VERSION_OF]->(tech:Technology)
 {{LICENSE_MATCH}}
 {{JOIN_WHERE}}
-WITH collect({c: c, tech: tech}) as allRows, count(c) as total
+{{PRE_AGGREGATION}}
+WITH collect({c: c, tech: tech{{PRE_AGG_COLLECT}}}) as allRows, count(c) as total
 UNWIND allRows as row
-WITH row.c as c, row.tech as tech, total
-ORDER BY c.packageManager, c.name, c.version
+WITH row.c as c, row.tech as tech, total{{PRE_AGG_UNWIND}}
+ORDER BY {{PRE_ORDER_BY}}
 {{PAGINATION}}
 // Phase 2: fetch related data only for the paginated subset
 OPTIONAL MATCH (sys:System)-[:USES]->(c)
@@ -43,4 +44,4 @@ RETURN c.name as name,
        tech.name as technologyName,
        systemCount,
        total
-ORDER BY c.packageManager, c.name, c.version
+ORDER BY {{ORDER_BY}}

--- a/server/repositories/license.repository.ts
+++ b/server/repositories/license.repository.ts
@@ -1,5 +1,6 @@
 import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
+import { buildOrderByClause, type SortConfig } from '../utils/sorting'
 
 export interface License {
   id: string
@@ -24,6 +25,20 @@ export interface LicenseFilters {
   search?: string
   limit?: number
   offset?: number
+  sortBy?: string
+  sortOrder?: 'asc' | 'desc'
+}
+
+const licenseSortConfig: SortConfig = {
+  allowedFields: {
+    spdxId: 'l.id',
+    name: 'l.name',
+    category: 'l.category',
+    osiApproved: 'l.osiApproved',
+    status: 'l.whitelisted',
+    componentCount: 'componentCount'
+  },
+  defaultOrderBy: 'componentCount DESC, l.id ASC'
 }
 
 /**
@@ -134,7 +149,7 @@ export class LicenseRepository extends BaseRepository {
         l.createdAt as createdAt,
         l.updatedAt as updatedAt,
         componentCount
-      ORDER BY componentCount DESC, l.id
+      ORDER BY ${buildOrderByClause({ sortBy: filters.sortBy, sortOrder: filters.sortOrder }, licenseSortConfig)}
     `
     
     if (filters.limit !== undefined) {

--- a/server/services/component.service.ts
+++ b/server/services/component.service.ts
@@ -48,12 +48,12 @@ export class ComponentService {
    * Retrieves components not mapped to a known technology, ordered by
    * system count to help prioritize mapping efforts.
    */
-  async findUnmapped(limit: number = 50, offset: number = 0): Promise<{
+  async findUnmapped(limit: number = 50, offset: number = 0, sort?: { sortBy?: string; sortOrder?: 'asc' | 'desc' }): Promise<{
     data: UnmappedComponent[]
     count: number
     total: number
   }> {
-    const components = await this.componentRepo.findUnmapped(limit, offset)
+    const components = await this.componentRepo.findUnmapped(limit, offset, sort)
     const total = await this.componentRepo.countUnmapped()
     
     return {

--- a/server/services/policy.service.ts
+++ b/server/services/policy.service.ts
@@ -240,6 +240,17 @@ export class PolicyService {
     // Business logic: calculate summary from all violations
     const summary = this.calculateLicenseSummary(allViolations)
     
+    // Apply sorting if specified
+    const { sortBy, sortOrder } = filters
+    if (sortBy && (sortBy === 'system' || sortBy === 'team')) {
+      const dir = sortOrder === 'desc' ? -1 : 1
+      allViolations.sort((a, b) => {
+        const aVal = (a[sortBy] || '').toLowerCase()
+        const bVal = (b[sortBy] || '').toLowerCase()
+        return aVal < bVal ? -dir : aVal > bVal ? dir : 0
+      })
+    }
+
     // Apply pagination if specified
     let paginatedViolations = allViolations
     if (limit !== undefined && offset !== undefined) {

--- a/server/services/system.service.ts
+++ b/server/services/system.service.ts
@@ -3,6 +3,7 @@ import { SourceRepositoryRepository } from '../repositories/source-repository.re
 import type { System, CreateSystemParams, RepositoryInput, UnmappedComponentsResult } from '../repositories/system.repository'
 import type { Repository } from '~~/types/api'
 import { normalizeRepoUrl } from '../utils/repository'
+import type { SortParams } from '../utils/sorting'
 
 export interface CreateSystemInput {
   name: string
@@ -33,8 +34,8 @@ export class SystemService {
    * 
    * @returns Array of systems with count
    */
-  async findAll(): Promise<{ data: System[]; count: number }> {
-    const systems = await this.systemRepo.findAll()
+  async findAll(sort?: SortParams): Promise<{ data: System[]; count: number }> {
+    const systems = await this.systemRepo.findAll(sort)
     
     return {
       data: systems,

--- a/server/services/team.service.ts
+++ b/server/services/team.service.ts
@@ -1,5 +1,6 @@
 import { TeamRepository } from '../repositories/team.repository'
 import type { Team, TeamApprovalsResult, TeamPoliciesResult, TeamUsageResult, ApprovalStatus } from '../repositories/team.repository'
+import type { SortParams } from '../utils/sorting'
 
 /**
  * Service for team-related business logic
@@ -16,8 +17,8 @@ export class TeamService {
    * 
    * @returns Array of teams with count
    */
-  async findAll(): Promise<{ data: Team[]; count: number }> {
-    const teams = await this.teamRepo.findAll()
+  async findAll(sort?: SortParams): Promise<{ data: Team[]; count: number }> {
+    const teams = await this.teamRepo.findAll(sort)
     
     return {
       data: teams,

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -1,5 +1,6 @@
 import { TechnologyRepository, type TechnologyDetail, type CreateTechnologyParams, type UpsertApprovalParams } from '../repositories/technology.repository'
 import type { Technology } from '~~/types/api'
+import type { SortParams } from '../utils/sorting'
 
 export interface SetApprovalInput {
   technologyName: string
@@ -35,8 +36,8 @@ export class TechnologyService {
    * 
    * @returns Array of technologies with count
    */
-  async findAll(): Promise<{ data: Technology[]; count: number }> {
-    const technologies = await this.techRepo.findAll()
+  async findAll(sort?: SortParams): Promise<{ data: Technology[]; count: number }> {
+    const technologies = await this.techRepo.findAll(sort)
     
     return {
       data: technologies,

--- a/server/services/user.service.ts
+++ b/server/services/user.service.ts
@@ -1,4 +1,5 @@
 import { UserRepository, type User, type UserSummary, type AssignTeamsParams, type CreateOrUpdateUserParams, type UserAuthData } from '../repositories/user.repository'
+import type { SortParams } from '../utils/sorting'
 
 /**
  * Service for user-related business logic
@@ -72,8 +73,8 @@ export class UserService {
    * 
    * @returns Array of user summaries
    */
-  async findAllSummary(): Promise<UserSummary[]> {
-    return await this.userRepo.findAllSummary()
+  async findAllSummary(sort?: SortParams): Promise<UserSummary[]> {
+    return await this.userRepo.findAllSummary(sort)
   }
 
   /**

--- a/server/utils/sorting.ts
+++ b/server/utils/sorting.ts
@@ -1,0 +1,45 @@
+/**
+ * Shared sorting utilities for building dynamic ORDER BY clauses.
+ *
+ * Each repository defines a map of allowed sort fields to their Cypher
+ * expressions. The utility validates the requested field and direction,
+ * falling back to a default when the input is invalid.
+ */
+
+export interface SortConfig {
+  /** Map of client-facing field names to Cypher ORDER BY expressions */
+  allowedFields: Record<string, string>
+  /** Default ORDER BY clause when no sort is requested */
+  defaultOrderBy: string
+}
+
+export interface SortParams {
+  sortBy?: string
+  sortOrder?: 'asc' | 'desc'
+}
+
+/**
+ * Build a validated ORDER BY clause from client sort params.
+ *
+ * Returns the default if sortBy is missing or not in the allowlist.
+ */
+export function buildOrderByClause(params: SortParams, config: SortConfig): string {
+  if (!params.sortBy || !config.allowedFields[params.sortBy]) {
+    return config.defaultOrderBy
+  }
+
+  const expression = config.allowedFields[params.sortBy]
+  const direction = params.sortOrder === 'desc' ? 'DESC' : 'ASC'
+  return `${expression} ${direction}`
+}
+
+/**
+ * Parse sort query params from an API request.
+ */
+export function parseSortParams(query: Record<string, unknown>): SortParams {
+  const sortBy = query.sortBy as string | undefined
+  const rawOrder = (query.sortOrder as string || '').toLowerCase()
+  const sortOrder = rawOrder === 'desc' ? 'desc' as const : 'asc' as const
+
+  return { sortBy, sortOrder }
+}

--- a/test/server/services/component.service.spec.ts
+++ b/test/server/services/component.service.spec.ts
@@ -155,7 +155,7 @@ describe('ComponentService', () => {
 
       const result = await service.findUnmapped(50, 0)
 
-      expect(ComponentRepository.prototype.findUnmapped).toHaveBeenCalledWith(50, 0)
+      expect(ComponentRepository.prototype.findUnmapped).toHaveBeenCalledWith(50, 0, undefined)
       expect(ComponentRepository.prototype.countUnmapped).toHaveBeenCalledOnce()
       expect(result).toEqual({
         data: mockUnmappedComponents,


### PR DESCRIPTION
## Description

Replace client-side column sorting with server-side sorting across all paginated tables. Sort operations now query the database with the correct ORDER BY clause, ensuring pagination returns correctly sorted results across the entire dataset.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Relates to #193

## Changes Made

- Add `server/utils/sorting.ts` with `buildOrderByClause()` and `parseSortParams()` — validates sort fields against per-entity allowlists to prevent injection
- Add `app/composables/useSortableTable.ts` — shared composable for sortable column headers using TanStack Table + Nuxt UI dropdown menus
- Update all 11 paginated API endpoints to accept `sortBy`/`sortOrder` query params
- Update all 8 repositories with entity-specific `SortConfig` allowlists and dynamic ORDER BY in Cypher queries
- Update all 6 services to pass sort params through to repositories
- Update all 14 frontend table pages with sortable column headers, `manual-sorting` mode, and sort state passed to API
- Handle post-aggregation sort fields (e.g. `systemCount`) by pre-computing the aggregation before pagination in the Cypher query
- Fix `injectPlaceholders()` to use `replaceAll()` for templates with repeated placeholders

## Screenshots

N/A — sorting UI was already present, this changes the backend behavior.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

All 743 tests pass. The `systemCount` sort required special handling — the component query now conditionally pre-computes system counts before the pagination step when sorting by that field.