### PR TITLE
fix: bundle Cypher queries and schemas as Nitro server assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ FROM node:lts-alpine AS runner
 WORKDIR /app
 
 COPY --from=builder /app/.output ./output
-# sbom-validator reads schemas from process.cwd()/server/schemas at runtime
-COPY --from=builder /app/server/schemas ./server/schemas
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -48,6 +48,21 @@ export default defineNuxtConfig({
     }
   },
 
+  nitro: {
+    // Bundle server-side file assets into .output so they are available at runtime
+    // without relying on process.cwd() pointing to the source tree.
+    serverAssets: [
+      {
+        baseName: 'queries',
+        dir: './server/database/queries'
+      },
+      {
+        baseName: 'schemas',
+        dir: './server/schemas'
+      }
+    ]
+  },
+
   devServer: {
     host: '0.0.0.0'  // Listen on all available network interfaces
   },

--- a/server/utils/query-loader.ts
+++ b/server/utils/query-loader.ts
@@ -4,9 +4,16 @@ import { resolve } from 'path'
 const queryCache = new Map<string, string>()
 
 /**
- * Load a Cypher query from a .cypher file
- * Queries are cached in production for performance
- * 
+ * Load a Cypher query from a .cypher file.
+ *
+ * In production (Nitro runtime) queries are read from the bundled server
+ * assets configured in nuxt.config.ts (nitro.serverAssets). This avoids
+ * relying on process.cwd() pointing to the source tree, which is not the
+ * case inside the Docker runner image.
+ *
+ * In development and test environments the file is read directly from disk
+ * via fs/promises, which keeps the test helper working without a Nitro context.
+ *
  * @param path - Relative path from server/database/queries/ (e.g., 'technologies/find-all.cypher')
  * @returns The query string
  */
@@ -15,14 +22,27 @@ export async function loadQuery(path: string): Promise<string> {
     return queryCache.get(path)!
   }
 
-  const fullPath = resolve('./server/database/queries', path)
-  const query = await readFile(fullPath, 'utf-8')
-  
+  let query: string
+
+  // useStorage is only available inside the Nitro server runtime
+  if (process.env.NODE_ENV === 'production' && typeof useStorage === 'function') {
+    const storage = useStorage('assets:queries')
+    // Nitro asset keys use colons as path separators and strip the extension
+    const key = path.replace(/\//g, ':').replace(/\.cypher$/, '')
+    query = await storage.getItem<string>(key) ?? ''
+    if (!query) {
+      throw new Error(`Query not found in server assets: ${path}`)
+    }
+  } else {
+    const fullPath = resolve('./server/database/queries', path)
+    query = await readFile(fullPath, 'utf-8')
+  }
+
   // Cache in production for performance
   if (process.env.NODE_ENV === 'production') {
     queryCache.set(path, query)
   }
-  
+
   return query
 }
 

--- a/server/utils/sbom-validator.ts
+++ b/server/utils/sbom-validator.ts
@@ -61,18 +61,22 @@ export class SbomValidator {
     }
 
     try {
-      // Load schema files
-      const schemaDir = join(process.cwd(), 'server', 'schemas')
-      
-      const cyclonedxSchemaPath = join(schemaDir, 'cyclonedx-1.6.schema.json')
-      const spdxSchemaPath = join(schemaDir, 'spdx-2.3.schema.json')
-      const spdxRefSchemaPath = join(schemaDir, 'spdx.schema.json') // Referenced by CycloneDX
-      const jsfSchemaPath = join(schemaDir, 'jsf-0.82.schema.json') // Referenced by CycloneDX
-      
-      const cyclonedxSchema = JSON.parse(readFileSync(cyclonedxSchemaPath, 'utf-8'))
-      const spdxSchema = JSON.parse(readFileSync(spdxSchemaPath, 'utf-8'))
-      const spdxRefSchema = JSON.parse(readFileSync(spdxRefSchemaPath, 'utf-8'))
-      const jsfSchema = JSON.parse(readFileSync(jsfSchemaPath, 'utf-8'))
+      // Load schema files — use Nitro server assets in production, fs in dev/test
+      let cyclonedxSchema, spdxSchema, spdxRefSchema, jsfSchema
+
+      if (process.env.NODE_ENV === 'production' && typeof useStorage === 'function') {
+        const storage = useStorage('assets:schemas')
+        cyclonedxSchema = await storage.getItem('cyclonedx-1.6.schema')
+        spdxSchema = await storage.getItem('spdx-2.3.schema')
+        spdxRefSchema = await storage.getItem('spdx.schema')
+        jsfSchema = await storage.getItem('jsf-0.82.schema')
+      } else {
+        const schemaDir = join(process.cwd(), 'server', 'schemas')
+        cyclonedxSchema = JSON.parse(readFileSync(join(schemaDir, 'cyclonedx-1.6.schema.json'), 'utf-8'))
+        spdxSchema = JSON.parse(readFileSync(join(schemaDir, 'spdx-2.3.schema.json'), 'utf-8'))
+        spdxRefSchema = JSON.parse(readFileSync(join(schemaDir, 'spdx.schema.json'), 'utf-8'))
+        jsfSchema = JSON.parse(readFileSync(join(schemaDir, 'jsf-0.82.schema.json'), 'utf-8'))
+      }
       
       // Add referenced schemas to Ajv
       this.ajv.addSchema(spdxRefSchema, 'http://cyclonedx.org/schema/spdx.schema.json')


### PR DESCRIPTION
## Description

The Docker runner image only contained `.output` — `server/database/queries` and `server/schemas` were never copied into it. Every database query failed silently at runtime because the `try/catch` in the `signIn` callback swallowed the error. This meant users were never written to Neo4j, so superuser role assignment was lost on every sign-in.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #
Relates to #

## Changes Made

- **`nuxt.config.ts`** — Register `server/database/queries` and `server/schemas` as `nitro.serverAssets` so they are included in `.output` at build time
- **`server/utils/query-loader.ts`** — Read queries from `useStorage('assets:queries')` in production; fall back to `fs` in dev/test where Nitro storage is not available
- **`server/utils/sbom-validator.ts`** — Read schemas from `useStorage('assets:schemas')` in production; fall back to `fs` in dev/test
- **`Dockerfile`** — Remove the manual `COPY server/schemas` workaround (now redundant)

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

After this deploys, sign out and back in to trigger the `signIn` callback — it will now successfully write your user to Neo4j with the `superuser` role.