### PR TITLE
feat: unified version management

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -51,11 +51,6 @@ template: |
 
   $CHANGES
 
-  ## Deployment
-
-  This release has been automatically deployed to GitHub Pages:
-  🚀 **Live Site**: https://localgod.github.io/gitops/
-
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
 autolabeler:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,15 +34,29 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Read version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+
       - name: Build and push app image
         uses: docker/build-push-action@v7
         with:
           context: .
           target: runner
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/polaris:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.minor }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.major }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -52,9 +66,13 @@ jobs:
           context: .
           target: migrator
           push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ github.sha }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.minor }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.major }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -14,11 +14,98 @@ permissions:
 
 jobs:
   update_release_draft:
+    # Only publish and bump version on push to main (not on PR events)
     permissions:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v7
+        id: release
+        with:
+          # Publish immediately on merge to main; remain a draft on PR events
+          publish: ${{ github.event_name == 'push' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # The steps below only run on merge to main (push event)
+      - name: Checkout
+        if: github.event_name == 'push'
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Bump package.json and update CHANGELOG.md
+        if: github.event_name == 'push'
+        env:
+          RESOLVED_VERSION: ${{ steps.release.outputs.resolved_version }}
+          RELEASE_BODY: ${{ steps.release.outputs.body }}
+        run: |
+          set -e
+
+          # Skip if this is already a release commit (prevents infinite loop)
+          LAST_COMMIT_MSG=$(git log -1 --pretty=%s)
+          if echo "$LAST_COMMIT_MSG" | grep -qE '^\[skip ci\]|^chore: release v'; then
+            echo "Release commit detected — skipping version bump."
+            exit 0
+          fi
+
+          # Bump package.json without creating a git tag (we tag manually below)
+          npm version "$RESOLVED_VERSION" --no-git-tag-version
+
+          # Update CHANGELOG.md: replace [Unreleased] section with versioned entry,
+          # then prepend a fresh [Unreleased] section above it.
+          DATE=$(date +%Y-%m-%d)
+
+          python3 - <<'PYEOF'
+          import os, re
+
+          version = os.environ['RESOLVED_VERSION']
+          body = os.environ['RELEASE_BODY']
+
+          from datetime import date
+          today = date.today().isoformat()
+
+          with open('CHANGELOG.md', 'r') as f:
+              content = f.read()
+
+          new_section = f"## [{version}] - {today}\n\n{body}\n"
+          unreleased_block = (
+              "## [Unreleased]\n\n"
+              "### Added\n\n"
+              "### Changed\n\n"
+              "### Deprecated\n\n"
+              "### Removed\n\n"
+              "### Fixed\n\n"
+              "### Security\n"
+          )
+
+          # Replace the [Unreleased] section with the versioned entry
+          content = re.sub(
+              r'## \[Unreleased\].*?(?=\n## \[|\Z)',
+              new_section,
+              content,
+              flags=re.DOTALL
+          )
+
+          # Re-insert a fresh [Unreleased] section before the new versioned entry
+          insert_marker = f'\n## [{version}]'
+          idx = content.find(insert_marker)
+          if idx != -1:
+              content = content[:idx] + '\n' + unreleased_block + content[idx:]
+
+          with open('CHANGELOG.md', 'w') as f:
+              f.write(content)
+          PYEOF
+
+          # Configure git identity for the commit
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore: release v${RESOLVED_VERSION} [skip ci]"
+
+          # Tag and push
+          git tag "v${RESOLVED_VERSION}"
+          git push origin main --follow-tags

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,9 @@ COPY . .
 ARG NEO4J_URI=bolt://neo4j:7687
 ARG NEO4J_USERNAME=neo4j
 ARG NEO4J_PASSWORD=placeholder
+ARG APP_VERSION=dev
+
+ENV APP_VERSION=$APP_VERSION
 
 RUN npm run build
 
@@ -30,6 +33,7 @@ COPY --from=builder /app/server/schemas ./server/schemas
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0
 ENV PORT=3000
+ENV APP_VERSION=dev
 
 EXPOSE 3000
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -75,7 +75,10 @@
         />
       </nav>
 
-
+      <!-- Version footer -->
+      <div class="p-4 border-t border-gray-200 dark:border-gray-800">
+        <span class="text-xs text-gray-400 dark:text-gray-600">v{{ appVersion }}</span>
+      </div>
     </aside>
 
     <!-- Main Content -->
@@ -168,6 +171,7 @@
 <script setup lang="ts">
 import type { NavigationMenuItem } from '@nuxt/ui'
 
+const { public: { appVersion } } = useRuntimeConfig()
 const { data: session, status, signOut } = useAuth()
 const { impersonation, impersonationLoading, fetchImpersonationStatus, startImpersonating, stopImpersonating } = useImpersonation()
 const { isSuperuser } = useEffectiveRole()

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,13 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
 
+  runtimeConfig: {
+    public: {
+      // Baked in at build time from APP_VERSION build arg; falls back to 'dev'
+      appVersion: process.env.APP_VERSION ?? 'dev'
+    }
+  },
+
   // SPA-like behavior with client-side navigation
   ssr: true,
   

--- a/server/api/version.get.ts
+++ b/server/api/version.get.ts
@@ -1,0 +1,24 @@
+/**
+ * @openapi
+ * /version:
+ *   get:
+ *     tags:
+ *       - Health
+ *     summary: Application version
+ *     description: Returns the version of the running application, baked in at build time.
+ *     responses:
+ *       200:
+ *         description: Current application version
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 version:
+ *                   type: string
+ *                   example: '1.2.3'
+ */
+export default defineEventHandler(() => {
+  const config = useRuntimeConfig()
+  return { version: config.public.appVersion }
+})


### PR DESCRIPTION
## Description

Version information was fragmented across four sources with no synchronisation: `package.json` was hardcoded at `0.1.0`, Docker images were tagged with git commit SHAs, GitHub Releases were never published automatically, and the running app had no way to report its version.

This PR ties all four sources together through a single automated flow.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Configuration or build changes

## Changes Made

- **`Dockerfile`** — Added `ARG APP_VERSION=dev` in the builder stage so the version is baked into the Nuxt build
- **`nuxt.config.ts`** — Added `runtimeConfig.public.appVersion` reading from `process.env.APP_VERSION`
- **`server/api/version.get.ts`** — New `GET /api/version` endpoint returning `{ version: "x.y.z" }`
- **`app/layouts/default.vue`** — Sidebar footer now displays the running version (e.g. `v1.2.3`)
- **`.github/workflows/deploy.yml`** — Reads version from `package.json` and tags Docker images as `x.y.z`, `x.y`, `x`, and `latest` (replaces git SHA tags); passes `APP_VERSION` as a build arg
- **`.github/workflows/release-drafter.yml`** — Extended to publish the GitHub Release draft on merge to `main`, then bump `package.json`, update `CHANGELOG.md` with release notes, commit with `[skip ci]`, and push the `vX.Y.Z` git tag
- **`.github/release-drafter.yml`** — Fixed stale `gitops` URL in the release template

## How it works after this PR

1. A PR is merged to `main` with a `patch`, `minor`, or `major` label
2. `release-drafter` resolves the next semver, publishes the GitHub Release, bumps `package.json`, updates `CHANGELOG.md`, and pushes the tag — all in one workflow run
3. The next push to `main` (or the release commit itself if not `[skip ci]`) triggers `deploy.yml`, which reads the bumped version from `package.json` and pushes semver-tagged Docker images
4. The running app reports its version via `GET /api/version` and in the sidebar footer

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues