### PR TITLE
fix: copy Cypher queries and schemas into Docker runner image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ FROM node:lts-alpine AS runner
 WORKDIR /app
 
 COPY --from=builder /app/.output ./output
+# Cypher queries and JSON schemas are read at runtime via fs using process.cwd().
+# process.cwd() is /app (WORKDIR), so copy files to match the expected paths.
+COPY --from=builder /app/server/database/queries ./server/database/queries
+COPY --from=builder /app/server/schemas ./server/schemas
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -48,21 +48,6 @@ export default defineNuxtConfig({
     }
   },
 
-  nitro: {
-    // Bundle server-side file assets into .output so they are available at runtime
-    // without relying on process.cwd() pointing to the source tree.
-    serverAssets: [
-      {
-        baseName: 'queries',
-        dir: './server/database/queries'
-      },
-      {
-        baseName: 'schemas',
-        dir: './server/schemas'
-      }
-    ]
-  },
-
   devServer: {
     host: '0.0.0.0'  // Listen on all available network interfaces
   },

--- a/server/utils/query-loader.ts
+++ b/server/utils/query-loader.ts
@@ -6,13 +6,12 @@ const queryCache = new Map<string, string>()
 /**
  * Load a Cypher query from a .cypher file.
  *
- * In production (Nitro runtime) queries are read from the bundled server
- * assets configured in nuxt.config.ts (nitro.serverAssets). This avoids
- * relying on process.cwd() pointing to the source tree, which is not the
- * case inside the Docker runner image.
+ * Resolves relative to process.cwd()/server/database/queries/. In the
+ * Docker runner image WORKDIR is /app and the query files are copied to
+ * /app/server/database/queries/ by the Dockerfile, so this path is correct
+ * in both development and production.
  *
- * In development and test environments the file is read directly from disk
- * via fs/promises, which keeps the test helper working without a Nitro context.
+ * Queries are cached in production for performance.
  *
  * @param path - Relative path from server/database/queries/ (e.g., 'technologies/find-all.cypher')
  * @returns The query string
@@ -22,23 +21,9 @@ export async function loadQuery(path: string): Promise<string> {
     return queryCache.get(path)!
   }
 
-  let query: string
+  const fullPath = resolve('./server/database/queries', path)
+  const query = await readFile(fullPath, 'utf-8')
 
-  // useStorage is only available inside the Nitro server runtime
-  if (process.env.NODE_ENV === 'production' && typeof useStorage === 'function') {
-    const storage = useStorage('assets:queries')
-    // Nitro asset keys use colons as path separators and strip the extension
-    const key = path.replace(/\//g, ':').replace(/\.cypher$/, '')
-    query = await storage.getItem<string>(key) ?? ''
-    if (!query) {
-      throw new Error(`Query not found in server assets: ${path}`)
-    }
-  } else {
-    const fullPath = resolve('./server/database/queries', path)
-    query = await readFile(fullPath, 'utf-8')
-  }
-
-  // Cache in production for performance
   if (process.env.NODE_ENV === 'production') {
     queryCache.set(path, query)
   }
@@ -56,7 +41,7 @@ export function clearQueryCache(): void {
 /**
  * Inject WHERE conditions into a query template
  * Replaces {{WHERE_CONDITIONS}} placeholder with actual conditions
- * 
+ *
  * @param query - Query template with {{WHERE_CONDITIONS}} placeholder
  * @param conditions - Array of WHERE conditions
  * @returns Query with conditions injected
@@ -65,7 +50,7 @@ export function injectWhereConditions(query: string, conditions: string[]): stri
   if (conditions.length === 0) {
     return query.replace('{{WHERE_CONDITIONS}}', '').replace('{{AND_CONDITIONS}}', '')
   }
-  
+
   const whereClause = `WHERE ${conditions.join(' AND ')}`
   const andClause = `AND ${conditions.join(' AND ')}`
   return query

--- a/server/utils/sbom-validator.ts
+++ b/server/utils/sbom-validator.ts
@@ -61,22 +61,16 @@ export class SbomValidator {
     }
 
     try {
-      // Load schema files — use Nitro server assets in production, fs in dev/test
-      let cyclonedxSchema, spdxSchema, spdxRefSchema, jsfSchema
+      // Resolve schema directory relative to this file so the path is correct
+      // in both development (source tree) and production (.output/server/).
+      // Resolves to process.cwd()/server/schemas/. In the Docker runner image
+      // WORKDIR is /app and schemas are copied to /app/server/schemas/.
+      const schemaDir = join(process.cwd(), 'server', 'schemas')
 
-      if (process.env.NODE_ENV === 'production' && typeof useStorage === 'function') {
-        const storage = useStorage('assets:schemas')
-        cyclonedxSchema = await storage.getItem('cyclonedx-1.6.schema')
-        spdxSchema = await storage.getItem('spdx-2.3.schema')
-        spdxRefSchema = await storage.getItem('spdx.schema')
-        jsfSchema = await storage.getItem('jsf-0.82.schema')
-      } else {
-        const schemaDir = join(process.cwd(), 'server', 'schemas')
-        cyclonedxSchema = JSON.parse(readFileSync(join(schemaDir, 'cyclonedx-1.6.schema.json'), 'utf-8'))
-        spdxSchema = JSON.parse(readFileSync(join(schemaDir, 'spdx-2.3.schema.json'), 'utf-8'))
-        spdxRefSchema = JSON.parse(readFileSync(join(schemaDir, 'spdx.schema.json'), 'utf-8'))
-        jsfSchema = JSON.parse(readFileSync(join(schemaDir, 'jsf-0.82.schema.json'), 'utf-8'))
-      }
+      const cyclonedxSchema = JSON.parse(readFileSync(join(schemaDir, 'cyclonedx-1.6.schema.json'), 'utf-8'))
+      const spdxSchema = JSON.parse(readFileSync(join(schemaDir, 'spdx-2.3.schema.json'), 'utf-8'))
+      const spdxRefSchema = JSON.parse(readFileSync(join(schemaDir, 'spdx.schema.json'), 'utf-8'))
+      const jsfSchema = JSON.parse(readFileSync(join(schemaDir, 'jsf-0.82.schema.json'), 'utf-8'))
       
       // Add referenced schemas to Ajv
       this.ajv.addSchema(spdxRefSchema, 'http://cyclonedx.org/schema/spdx.schema.json')


### PR DESCRIPTION
## Description

Follow-up to #282. The `serverAssets` approach failed because Nitro does not recognise `.cypher` as an inlineable file type — `_assets` remained empty at runtime. The `import.meta.url` fallback also failed because Nitro replaces `import.meta.url` with the fixed placeholder `file:///_entry.js` in the bundle, making path resolution point to `/database/queries` (root of the filesystem).

The correct fix is to copy the files into the Docker image at the path `process.cwd()` resolves to. The runner image sets `WORKDIR /app`, so `process.cwd()` is `/app`. Copying the files to `/app/server/database/queries/` and `/app/server/schemas/` makes the existing `resolve('./server/database/queries', path)` calls work correctly without any code changes to the loaders.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- **`Dockerfile`** — Copy `server/database/queries` and `server/schemas` into the runner image at `./server/database/queries` and `./server/schemas` (relative to `WORKDIR /app`)
- **`server/utils/query-loader.ts`** — Reverted to the original `process.cwd()` approach (clean, no dead code)
- **`server/utils/sbom-validator.ts`** — Reverted to the original `process.cwd()` approach
- **`nuxt.config.ts`** — Removed the `nitro.serverAssets` config that had no effect

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

After this deploys, sign out and back in to trigger the `signIn` callback with the now-working Neo4j writes.