### PR TITLE
feat: collapsible sidebar with icon-only mode

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,34 +1,39 @@
 <template>
   <div class="flex min-h-screen">
     <!-- Sidebar -->
-    <aside class="w-64 border-r border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900 flex flex-col">
-      <!-- Logo -->
-      <div class="p-4 border-b border-gray-200 dark:border-gray-800">
-        <div class="flex items-center justify-between">
-          <NuxtLink to="/" class="flex items-center gap-2">
-            <UIcon name="i-lucide-zap" class="w-6 h-6 text-(--ui-primary)" />
-            <span class="text-xl font-bold">Polaris</span>
-          </NuxtLink>
-          <ClientOnly>
-            <UColorModeButton color="neutral" variant="ghost" />
-            <template #fallback>
-              <div class="w-8 h-8" />
-            </template>
-          </ClientOnly>
-        </div>
-      </div>
+    <USidebar
+      v-model:open="sidebarOpen"
+      collapsible="icon"
+      :rail="true"
+      class="border-r border-default bg-(--ui-bg-elevated)"
+    >
+      <template #header="{ state }">
+        <!-- Logo -->
+        <NuxtLink to="/" class="flex items-center gap-2 min-w-0">
+          <UIcon name="i-lucide-zap" class="w-6 h-6 shrink-0 text-(--ui-primary)" />
+          <span v-show="state === 'expanded'" class="text-xl font-bold truncate">Polaris</span>
+        </NuxtLink>
+        <ClientOnly>
+          <UColorModeButton v-if="state === 'expanded'" color="neutral" variant="ghost" class="shrink-0" />
+          <template #fallback>
+            <div v-if="state === 'expanded'" class="w-8 h-8" />
+          </template>
+        </ClientOnly>
+      </template>
 
-      <!-- Navigation -->
-      <nav class="flex-1 py-4 px-6 overflow-y-auto">
+      <!-- Default slot: navigation body -->
+      <template #default="{ state }">
         <!-- Main Menu -->
         <UNavigationMenu
           orientation="vertical"
           :items="mainMenuItems"
+          :collapsed="state === 'collapsed'"
+          :tooltip="state === 'collapsed'"
           class="w-full"
         />
 
         <!-- User Section -->
-        <div class="my-4 py-4 border-t border-b border-gray-200 dark:border-gray-800">
+        <div class="py-4 border-t border-b border-default">
           <template v-if="status === 'authenticated' && session">
             <div class="flex items-center gap-3 mb-3">
               <UAvatar
@@ -36,18 +41,21 @@
                 :src="session.user.image"
                 :alt="session.user.name || 'User'"
                 size="sm"
+                class="shrink-0"
               />
               <UAvatar
                 v-else
                 :text="((session.user?.name || session.user?.email || 'U')[0] || 'U').toUpperCase()"
                 size="sm"
+                class="shrink-0"
               />
-              <div class="flex-1 min-w-0">
+              <div v-show="state === 'expanded'" class="flex-1 min-w-0">
                 <div class="text-sm font-medium truncate">{{ session.user?.name || 'User' }}</div>
                 <div class="text-xs text-gray-500 truncate">{{ session.user?.email }}</div>
               </div>
             </div>
             <UBadge
+              v-show="state === 'expanded'"
               :color="session.user?.role === 'superuser' ? 'error' : 'primary'"
               size="xs"
               class="mb-3"
@@ -57,13 +65,29 @@
             <UNavigationMenu
               orientation="vertical"
               :items="userMenuItems"
+              :collapsed="state === 'collapsed'"
+              :tooltip="state === 'collapsed'"
               class="w-full"
             />
           </template>
           <template v-else>
-            <UButton to="/auth/signin" color="primary" block>
+            <UButton
+              v-if="state === 'expanded'"
+              to="/auth/signin"
+              color="primary"
+              block
+            >
               Sign In
             </UButton>
+            <UTooltip v-else text="Sign In" :content="{ side: 'right' }">
+              <UButton
+                to="/auth/signin"
+                color="primary"
+                icon="i-lucide-log-in"
+                variant="ghost"
+                square
+              />
+            </UTooltip>
           </template>
         </div>
 
@@ -71,18 +95,19 @@
         <UNavigationMenu
           orientation="vertical"
           :items="docsMenuItems"
+          :collapsed="state === 'collapsed'"
+          :tooltip="state === 'collapsed'"
           class="w-full"
         />
-      </nav>
+      </template>
 
-      <!-- Version footer -->
-      <div class="p-4 border-t border-gray-200 dark:border-gray-800">
-        <span class="text-xs text-gray-400 dark:text-gray-600">v{{ appVersion }}</span>
-      </div>
-    </aside>
+      <template #footer="{ state }">
+        <span v-show="state === 'expanded'" class="text-xs text-gray-400 dark:text-gray-600">v{{ appVersion }}</span>
+      </template>
+    </USidebar>
 
     <!-- Main Content -->
-    <main class="flex-1 overflow-auto">
+    <main class="flex-1 overflow-auto min-w-0">
       <!-- Impersonation Banner -->
       <div
         v-if="impersonation.active && impersonation.user"
@@ -169,12 +194,16 @@
 </template>
 
 <script setup lang="ts">
+import { useLocalStorage } from '@vueuse/core'
 import type { NavigationMenuItem } from '@nuxt/ui'
 
 const { public: { appVersion } } = useRuntimeConfig()
 const { data: session, status, signOut } = useAuth()
 const { impersonation, impersonationLoading, fetchImpersonationStatus, startImpersonating, stopImpersonating } = useImpersonation()
 const { isSuperuser } = useEffectiveRole()
+
+// Sidebar open state — persisted across reloads
+const sidebarOpen = useLocalStorage('polaris:sidebar:open', true)
 
 // Fetch impersonation status on load for superusers
 watch(() => session.value?.user?.role, async (role) => {

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,94 @@
+# Spec: Collapsible Sidebar
+
+## Problem Statement
+
+The sidebar is a fixed `w-64` `<aside>` with no responsive behaviour. On small screens it consumes a disproportionate share of the viewport, leaving little room for main content.
+
+## Nuxt UI v4 Capability Summary
+
+All requirements are achievable with standard Nuxt UI v4 components — no custom CSS width toggling or manual tooltip wrappers are needed:
+
+| Requirement | Nuxt UI solution |
+|---|---|
+| Collapsible sidebar with icon-only mode | `<USidebar collapsible="icon">` |
+| Rail toggle button on sidebar edge | `<USidebar :rail="true">` |
+| Nav items icon-only + tooltips on hover | `<UNavigationMenu :collapsed="true" :tooltip="true">` |
+| Mobile: full-screen slideover | `<USidebar mode="slideover">` (auto below 1024px) |
+| Persist state across reloads | `useLocalStorage` from `@vueuse/core` (already a dependency) |
+
+## Requirements
+
+### Collapse Trigger
+
+- A rail (thin clickable strip) on the right edge of the sidebar toggles collapse/expand.
+- The user controls this manually on all screen sizes.
+- On screens narrower than 1024px, `USidebar` automatically switches to a slideover (mobile drawer) — this is built-in behaviour.
+
+### Collapsed State (icon-only mode)
+
+- Sidebar narrows to icon-only width (`--sidebar-width-icon: 4rem`, built into `USidebar`).
+- Each navigation item shows only its icon; labels are hidden.
+- Hovering an icon shows the item label as a tooltip (right-side, built into `UNavigationMenu :tooltip="true"`).
+- The main content area expands to fill the freed space (handled by `USidebar`'s gap spacer).
+- Width transition is animated (built into `USidebar` — `transition-[width] duration-200 ease-linear`).
+
+### Logo / Header Area (collapsed)
+
+- Hide "Polaris" text label (`v-show="sidebarOpen"`).
+- Hide `UColorModeButton` (`v-show="sidebarOpen"`).
+- The zap icon remains visible as the only logo element.
+
+### User Section (collapsed)
+
+- Hide user name, email, and role badge (`v-show="sidebarOpen"`).
+- Avatar remains visible.
+- Profile and Sign Out items show icon-only with tooltips (handled by `UNavigationMenu :collapsed` + `:tooltip`).
+- "Sign In" button: hide the full button, show an icon-only button when collapsed.
+
+### Documentation Section (collapsed)
+
+- The "Documentation" label (`type: 'label'`) is hidden automatically by `UNavigationMenu` when `collapsed` is true.
+- All doc nav items show icon-only with tooltips.
+
+### Version Footer (collapsed)
+
+- Version string hidden (`v-show="sidebarOpen"`).
+
+### State Persistence
+
+- `sidebarOpen` is backed by `useLocalStorage('polaris:sidebar:open', true)`.
+- Restores last state on page reload.
+
+## Acceptance Criteria
+
+1. The sidebar renders using `<USidebar collapsible="icon" :rail="true">`.
+2. Clicking the rail toggles between expanded (`w-64`) and collapsed (`w-16`) states.
+3. In collapsed mode, all navigation icons are visible and links work.
+4. In collapsed mode, hovering any nav icon shows a tooltip with the item label.
+5. In collapsed mode, the logo area shows only the zap icon.
+6. In collapsed mode, the user section shows only the avatar.
+7. The collapsed/expanded state persists across page reloads via `localStorage`.
+8. The width transition is smooth (no layout jump).
+9. The main content area fills the remaining width in both states.
+10. On screens < 1024px, the sidebar opens as a slideover (mobile behaviour).
+11. Dark mode continues to work correctly in both states.
+
+## Implementation Approach
+
+1. **Verify `@vueuse/core` import** — confirm `useLocalStorage` is importable (it is, already used by `@nuxt/ui` internally).
+2. **Replace `<aside>` with `<USidebar>`** in `app/layouts/default.vue`:
+   - `collapsible="icon"` for icon-only collapse mode.
+   - `:rail="true"` for the edge toggle strip.
+   - `v-model:open="sidebarOpen"` bound to a `useLocalStorage` ref.
+   - Move all sidebar content into the default slot (header, nav, footer slots as appropriate).
+3. **Add `sidebarOpen` state** using `useLocalStorage('polaris:sidebar:open', true)`.
+4. **Update all three `UNavigationMenu` instances** to pass `:collapsed="!sidebarOpen"` and `:tooltip="!sidebarOpen"`.
+5. **Guard text-only elements** with `v-show="sidebarOpen"`:
+   - "Polaris" `<span>` in the logo.
+   - `UColorModeButton`.
+   - User name `<div>`, email `<div>`, role `UBadge`.
+   - Version `<span>` in the footer.
+6. **Handle Sign In button** — show full `UButton` when expanded (`v-if="sidebarOpen"`), icon-only button when collapsed (`v-else`).
+7. **Adjust nav padding** — `USidebar`'s body slot uses `p-4`; remove the existing `px-6` from the `<nav>` to avoid double padding.
+8. **Verify layout** — confirm `<main>` fills remaining width correctly with `USidebar`'s gap spacer approach (the `flex min-h-screen` wrapper on the outer div should still work).
+9. **Test** — expanded/collapsed toggle, tooltip display, localStorage persistence, mobile slideover, dark mode.


### PR DESCRIPTION
## Description

Replaces the fixed-width sidebar with a collapsible version using Nuxt UI's `USidebar` component. On small screens the sidebar can be collapsed to icon-only width, freeing up significant horizontal space. State is persisted across reloads.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Fixes #
Relates to #

## Changes Made

- Replace `<aside>` with `<USidebar collapsible="icon" :rail="true">` in `app/layouts/default.vue`
- Pass `:collapsed` and `:tooltip` to all three `UNavigationMenu` instances so labels hide and right-side tooltips appear in collapsed mode
- Guard logo text, dark-mode button, user name/email/role badge, and version string with `v-if`/`v-show` tied to sidebar state
- Show icon-only Sign In button when collapsed, full button when expanded
- Persist sidebar open/collapsed state in `localStorage` via `useLocalStorage` from `@vueuse/core`
- On screens < 1024px `USidebar` automatically switches to a slideover (mobile drawer)

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

All functionality is implemented using standard Nuxt UI v4 components — no custom CSS width toggling or manual tooltip wrappers. The `@vueuse/core` dependency is already present (used internally by `@nuxt/ui`).