### PR TITLE
fix: serve pre-generated openapi.json in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "vue"
   ],
   "scripts": {
-    "build": "nuxt build",
+    "build": "npm run docs:api && nuxt build",
     "dev": "nuxt dev --host",
     "generate": "nuxt generate",
     "preview": "nuxt preview",

--- a/server/api/openapi.json.get.ts
+++ b/server/api/openapi.json.get.ts
@@ -1,5 +1,11 @@
-import { openapiSpec } from '../openapi'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
 
+// The spec is pre-generated at build time by `npm run docs:api` and committed to
+// public/openapi.json. swagger-jsdoc scans source .ts files which don't exist in
+// the production image, so we serve the static file instead.
 export default defineEventHandler(() => {
-  return openapiSpec
+  const specPath = resolve(process.cwd(), 'public/openapi.json')
+  const raw = readFileSync(specPath, 'utf-8')
+  return JSON.parse(raw)
 })


### PR DESCRIPTION
## Description

The `/api-reference` page showed all HTTP verbs in development but none in production. The production API returned `"paths": {}`.

`swagger-jsdoc` is configured with `apis: ['./server/api/**/*.ts']` and scans source files at runtime to build the paths object. In production only the compiled `.output/` bundle is deployed — the source `.ts` files are absent, so the glob matches nothing and paths is empty. `swagger-jsdoc` is also a `devDependency`, making this approach inherently fragile in production.

A pre-generated `public/openapi.json` (with all 41 paths / 58 operations) already existed, produced by `npm run docs:api`. The fix is to serve that file directly.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Changes Made

- `server/api/openapi.json.get.ts` — replaced `swagger-jsdoc` runtime call with `readFileSync` of `public/openapi.json`
- `package.json` — prefixed `build` script with `npm run docs:api &&` so the static spec is always regenerated from current JSDoc annotations before each Docker build

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have updated documentation if needed