### PR TITLE
feat: restyle access-model and graph-model pages; sync API version

### DIFF
--- a/app/pages/docs/access-model.vue
+++ b/app/pages/docs/access-model.vue
@@ -5,273 +5,135 @@
       description="Who can view, create, edit, and delete each element in Polaris"
     />
 
+    <!-- Roles -->
     <UCard>
-      <div class="prose dark:prose-invert max-w-none">
-        <h2>Roles</h2>
-        <p>Polaris has three access levels:</p>
-        <ul>
-          <li><strong>Unauthenticated</strong> — Can browse read-only data: systems, components, technologies, teams, licenses, version constraints, violations, and approvals.</li>
-          <li><strong>Authenticated (User)</strong> — Can create and manage systems, technologies, version constraints, and submit SBOMs. Can view audit logs and their own profile.</li>
-          <li><strong>Superuser</strong> — Full administrative access. Can manage teams, users, API tokens, license allow/deny lists, impersonation, and GitHub imports.</li>
-        </ul>
-
-        <h2>Access by Element</h2>
-        <p>The table below shows which operations are available at each access level. A dash (—) means the operation does not apply to that element.</p>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-shield" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">Roles</h2>
+        </div>
+      </template>
+      <div class="space-y-4">
+        <p class="text-(--ui-text-muted)">Polaris has three access levels:</p>
+        <div class="space-y-3">
+          <UPageFeature
+            v-for="role in roles"
+            :key="role.title"
+            :icon="role.icon"
+            :title="role.title"
+            :description="role.description"
+            orientation="horizontal"
+          />
+        </div>
       </div>
     </UCard>
 
+    <!-- Access by Element -->
     <UCard>
-      <div class="overflow-x-auto">
-        <table class="min-w-full text-sm">
-          <thead>
-            <tr class="border-b border-(--ui-border)">
-              <th class="text-left py-2 px-3 font-semibold">Element</th>
-              <th class="text-left py-2 px-3 font-semibold">View</th>
-              <th class="text-left py-2 px-3 font-semibold">Create</th>
-              <th class="text-left py-2 px-3 font-semibold">Edit</th>
-              <th class="text-left py-2 px-3 font-semibold">Delete</th>
-              <th class="text-left py-2 px-3 font-semibold">Notes</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="row in accessRows" :key="row.element" class="border-b border-(--ui-border-muted)">
-              <td class="py-2 px-3 font-medium">{{ row.element }}</td>
-              <td class="py-2 px-3">
-                <UBadge :color="badgeColor(row.view)" variant="subtle" size="xs">{{ row.view }}</UBadge>
-              </td>
-              <td class="py-2 px-3">
-                <UBadge v-if="row.create !== '—'" :color="badgeColor(row.create)" variant="subtle" size="xs">{{ row.create }}</UBadge>
-                <span v-else class="text-(--ui-text-muted)">—</span>
-              </td>
-              <td class="py-2 px-3">
-                <UBadge v-if="row.edit !== '—'" :color="badgeColor(row.edit)" variant="subtle" size="xs">{{ row.edit }}</UBadge>
-                <span v-else class="text-(--ui-text-muted)">—</span>
-              </td>
-              <td class="py-2 px-3">
-                <UBadge v-if="row.delete !== '—'" :color="badgeColor(row.delete)" variant="subtle" size="xs">{{ row.delete }}</UBadge>
-                <span v-else class="text-(--ui-text-muted)">—</span>
-              </td>
-              <td class="py-2 px-3 text-(--ui-text-muted) text-xs">{{ row.notes }}</td>
-            </tr>
-          </tbody>
-        </table>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-table" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">Access by Element</h2>
+        </div>
+      </template>
+      <div class="space-y-4">
+        <p class="text-(--ui-text-muted)">Operations available at each access level. A dash (—) means the operation does not apply.</p>
+        <UTable :data="accessRows" :columns="accessColumns" />
       </div>
     </UCard>
 
+    <!-- How Elements Are Created -->
     <UCard>
-      <div class="prose dark:prose-invert max-w-none">
-        <h2>How Elements Are Created</h2>
-        <p>Not all elements are created directly through the UI. The table below clarifies the creation path for each element.</p>
-      </div>
-
-      <div class="overflow-x-auto mt-4">
-        <table class="min-w-full text-sm">
-          <thead>
-            <tr class="border-b border-(--ui-border)">
-              <th class="text-left py-2 px-3 font-semibold">Element</th>
-              <th class="text-left py-2 px-3 font-semibold">Creation Method</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="row in creationRows" :key="row.element" class="border-b border-(--ui-border-muted)">
-              <td class="py-2 px-3 font-medium">{{ row.element }}</td>
-              <td class="py-2 px-3">{{ row.method }}</td>
-            </tr>
-          </tbody>
-        </table>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-plus-circle" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">How Elements Are Created</h2>
+        </div>
+      </template>
+      <div class="space-y-4">
+        <p class="text-(--ui-text-muted)">Not all elements are created directly through the UI.</p>
+        <UTable :data="creationRows" :columns="creationColumns" />
       </div>
     </UCard>
 
+    <!-- Superuser-Only Pages -->
     <UCard>
-      <div class="prose dark:prose-invert max-w-none">
-        <h2>Superuser-Only Pages</h2>
-        <p>The following pages and actions are only visible in the navigation and UI when the current user (or impersonated user) has the superuser role:</p>
-        <ul>
-          <li><strong>Users</strong> — User list and user detail pages, including technical user creation and API token management.</li>
-          <li><strong>Impersonate User</strong> — View the application as another user to verify access controls.</li>
-          <li><strong>License Allow/Deny</strong> — Manage the organization license whitelist and deny list.</li>
-          <li><strong>Import from GitHub</strong> — Import a system from a GitHub repository on the Systems page.</li>
-          <li><strong>Team management</strong> — Create, edit, and delete teams on the Teams page.</li>
-        </ul>
-
-        <h2>Impersonation</h2>
-        <p>
-          Superusers can impersonate other users to verify what they see. While impersonating,
-          the UI respects the impersonated user's role — superuser-only actions and navigation
-          items are hidden if the impersonated user is not a superuser.
-        </p>
-
-        <h2>Audit Trail</h2>
-        <p>
-          All create, update, and delete operations are recorded in the audit log with the
-          user ID, operation type, affected entity, changed fields, and timestamp. The audit
-          log is viewable by authenticated users at <code>/audit</code>.
-        </p>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-lock" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">Superuser-Only Pages</h2>
+        </div>
+      </template>
+      <div class="space-y-4">
+        <p class="text-(--ui-text-muted)">The following pages and actions are only visible when the current user has the superuser role:</p>
+        <div class="space-y-3">
+          <UPageFeature
+            v-for="page in superuserPages"
+            :key="page.title"
+            :icon="page.icon"
+            :title="page.title"
+            :description="page.description"
+            orientation="horizontal"
+          />
+        </div>
       </div>
     </UCard>
+
+    <!-- Impersonation -->
+    <UAlert
+      color="info"
+      variant="subtle"
+      icon="i-lucide-eye"
+      title="Impersonation"
+      description="Superusers can impersonate other users to verify what they see. While impersonating, the UI respects the impersonated user's role — superuser-only actions and navigation items are hidden if the impersonated user is not a superuser."
+    />
+
+    <!-- Audit Trail -->
+    <UAlert
+      color="neutral"
+      variant="subtle"
+      icon="i-lucide-clipboard-list"
+      title="Audit Trail"
+      description="All create, update, and delete operations are recorded in the audit log with the user ID, operation type, affected entity, changed fields, and timestamp. The audit log is viewable by authenticated users at /audit."
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-interface AccessRow {
-  element: string
-  view: string
-  create: string
-  edit: string
-  delete: string
-  notes: string
-}
+import { h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
 
-interface CreationRow {
-  element: string
-  method: string
-}
+// --- Roles ---
 
-const accessRows: AccessRow[] = [
+const roles = [
   {
-    element: 'Systems',
-    view: 'Public',
-    create: 'Authenticated',
-    edit: 'Owner team*',
-    delete: 'Owner team*',
-    notes: '* Superusers or members of the system\'s owner team'
+    icon: 'i-lucide-eye',
+    title: 'Unauthenticated',
+    description: 'Can browse read-only data: systems, components, technologies, teams, licenses, version constraints, violations, and approvals.',
   },
   {
-    element: 'Repositories',
-    view: 'Public',
-    create: 'Authenticated',
-    edit: '—',
-    delete: '—',
-    notes: 'Added to systems; viewed as part of system detail'
+    icon: 'i-lucide-user',
+    title: 'Authenticated (User)',
+    description: 'Can create and manage systems, technologies, version constraints, and submit SBOMs. Can view audit logs and their own profile.',
   },
   {
-    element: 'Components',
-    view: 'Public',
-    create: '—',
-    edit: '—',
-    delete: '—',
-    notes: 'Created only via SBOM ingestion, never directly'
+    icon: 'i-lucide-shield-alert',
+    title: 'Superuser',
+    description: 'Full administrative access. Can manage teams, users, API tokens, license allow/deny lists, impersonation, and GitHub imports.',
   },
-  {
-    element: 'Technologies',
-    view: 'Public',
-    create: 'Authenticated',
-    edit: '—',
-    delete: 'Owner team*',
-    notes: '* Superusers or members of the technology\'s steward team'
-  },
-  {
-    element: 'Teams',
-    view: 'Public',
-    create: 'Superuser',
-    edit: 'Superuser',
-    delete: 'Superuser',
-    notes: 'Full team management is superuser-only'
-  },
-  {
-    element: 'Users',
-    view: 'Superuser',
-    create: 'Superuser',
-    edit: '—',
-    delete: 'Superuser',
-    notes: 'Technical users only; OAuth users are created on sign-in'
-  },
-  {
-    element: 'API Tokens',
-    view: 'Superuser',
-    create: 'Superuser',
-    edit: '—',
-    delete: 'Superuser',
-    notes: 'Managed per technical user; token value shown once'
-  },
-  {
-    element: 'Version Constraints',
-    view: 'Public',
-    create: 'Authenticated',
-    edit: 'Creator*',
-    delete: 'Creator*',
-    notes: '* Superusers or the user who created the version constraint'
-  },
-  {
-    element: 'Licenses',
-    view: 'Public',
-    create: '—',
-    edit: '—',
-    delete: '—',
-    notes: 'Discovered via SBOM ingestion; not directly managed'
-  },
-  {
-    element: 'License Allow/Deny',
-    view: 'Authenticated',
-    create: 'Superuser',
-    edit: 'Superuser',
-    delete: 'Superuser',
-    notes: 'Superusers manage the organization license whitelist'
-  },
-  {
-    element: 'Violations',
-    view: 'Authenticated',
-    create: '—',
-    edit: '—',
-    delete: '—',
-    notes: 'Compliance and version constraint violations; read-only for authenticated users'
-  },
-  {
-    element: 'Approvals',
-    view: 'Public',
-    create: 'Authenticated',
-    edit: '—',
-    delete: '—',
-    notes: 'Team members approve technologies for their team'
-  },
-  {
-    element: 'SBOMs',
-    view: '—',
-    create: 'Authenticated',
-    edit: '—',
-    delete: '—',
-    notes: 'Submitted via API; creates/updates components and licenses'
-  },
-  {
-    element: 'Audit Logs',
-    view: 'Authenticated',
-    create: '—',
-    edit: '—',
-    delete: '—',
-    notes: 'Automatically generated; read-only'
-  },
-  {
-    element: 'GitHub Import',
-    view: '—',
-    create: 'Superuser',
-    edit: '—',
-    delete: '—',
-    notes: 'Creates a system from a GitHub repo without cloning'
-  },
-  {
-    element: 'Impersonation',
-    view: 'Superuser',
-    create: 'Superuser',
-    edit: '—',
-    delete: 'Superuser',
-    notes: 'Start/stop impersonation of other users'
-  }
 ]
 
-const creationRows: CreationRow[] = [
-  { element: 'Systems', method: 'Created via the UI form or GitHub import' },
-  { element: 'Repositories', method: 'Added when creating or editing a system, or via GitHub import' },
-  { element: 'Components', method: 'Discovered automatically when an SBOM is submitted — never created directly' },
-  { element: 'Technologies', method: 'Created via the UI form by authenticated users' },
-  { element: 'Teams', method: 'Created via the UI by superusers' },
-  { element: 'Users (OAuth)', method: 'Created automatically on first sign-in via GitHub OAuth' },
-  { element: 'Users (Technical)', method: 'Created via the UI by superusers for API access' },
-  { element: 'API Tokens', method: 'Generated via the UI by superusers for technical users' },
-  { element: 'Version Constraints', method: 'Created via the UI by authenticated users' },
-  { element: 'Licenses', method: 'Discovered automatically from SBOM component metadata' },
-  { element: 'Approvals', method: 'Created when a team member approves a technology for their team' },
-  { element: 'Audit Logs', method: 'Generated automatically on every create, update, and delete operation' }
+// --- Superuser-only pages ---
+
+const superuserPages = [
+  { icon: 'i-lucide-user-cog', title: 'Users', description: 'User list and user detail pages, including technical user creation and API token management.' },
+  { icon: 'i-lucide-eye', title: 'Impersonate User', description: 'View the application as another user to verify access controls.' },
+  { icon: 'i-lucide-scale', title: 'License Allow/Deny', description: 'Manage the organization license whitelist and deny list.' },
+  { icon: 'i-lucide-github', title: 'Import from GitHub', description: 'Import a system from a GitHub repository on the Systems page.' },
+  { icon: 'i-lucide-users', title: 'Team management', description: 'Create, edit, and delete teams on the Teams page.' },
 ]
+
+// --- Access table ---
 
 function badgeColor(level: string): 'success' | 'primary' | 'error' | 'warning' | 'neutral' {
   switch (level) {
@@ -283,6 +145,63 @@ function badgeColor(level: string): 'success' | 'primary' | 'error' | 'warning' 
     default: return 'neutral'
   }
 }
+
+const UBadgeComponent = resolveComponent('UBadge')
+
+function badgeCell(value: string) {
+  if (value === '—') return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+  return h(UBadgeComponent, { color: badgeColor(value), variant: 'subtle', size: 'xs' }, () => value)
+}
+
+const accessColumns: TableColumn<typeof accessRows[0]>[] = [
+  { accessorKey: 'element', header: 'Element', cell: ({ row }) => h('span', { class: 'font-medium' }, row.getValue('element') as string) },
+  { accessorKey: 'view', header: 'View', cell: ({ row }) => badgeCell(row.getValue('view') as string) },
+  { accessorKey: 'create', header: 'Create', cell: ({ row }) => badgeCell(row.getValue('create') as string) },
+  { accessorKey: 'edit', header: 'Edit', cell: ({ row }) => badgeCell(row.getValue('edit') as string) },
+  { accessorKey: 'delete', header: 'Delete', cell: ({ row }) => badgeCell(row.getValue('delete') as string) },
+  { accessorKey: 'notes', header: 'Notes', cell: ({ row }) => h('span', { class: 'text-(--ui-text-muted) text-xs' }, row.getValue('notes') as string) },
+]
+
+const accessRows = [
+  { element: 'Systems', view: 'Public', create: 'Authenticated', edit: 'Owner team*', delete: 'Owner team*', notes: '* Superusers or members of the system\'s owner team' },
+  { element: 'Repositories', view: 'Public', create: 'Authenticated', edit: '—', delete: '—', notes: 'Added to systems; viewed as part of system detail' },
+  { element: 'Components', view: 'Public', create: '—', edit: '—', delete: '—', notes: 'Created only via SBOM ingestion, never directly' },
+  { element: 'Technologies', view: 'Public', create: 'Authenticated', edit: '—', delete: 'Owner team*', notes: '* Superusers or members of the technology\'s steward team' },
+  { element: 'Teams', view: 'Public', create: 'Superuser', edit: 'Superuser', delete: 'Superuser', notes: 'Full team management is superuser-only' },
+  { element: 'Users', view: 'Superuser', create: 'Superuser', edit: '—', delete: 'Superuser', notes: 'Technical users only; OAuth users are created on sign-in' },
+  { element: 'API Tokens', view: 'Superuser', create: 'Superuser', edit: '—', delete: 'Superuser', notes: 'Managed per technical user; token value shown once' },
+  { element: 'Version Constraints', view: 'Public', create: 'Authenticated', edit: 'Creator*', delete: 'Creator*', notes: '* Superusers or the user who created the version constraint' },
+  { element: 'Licenses', view: 'Public', create: '—', edit: '—', delete: '—', notes: 'Discovered via SBOM ingestion; not directly managed' },
+  { element: 'License Allow/Deny', view: 'Authenticated', create: 'Superuser', edit: 'Superuser', delete: 'Superuser', notes: 'Superusers manage the organization license whitelist' },
+  { element: 'Violations', view: 'Authenticated', create: '—', edit: '—', delete: '—', notes: 'Compliance and version constraint violations; read-only for authenticated users' },
+  { element: 'Approvals', view: 'Public', create: 'Authenticated', edit: '—', delete: '—', notes: 'Team members approve technologies for their team' },
+  { element: 'SBOMs', view: '—', create: 'Authenticated', edit: '—', delete: '—', notes: 'Submitted via API; creates/updates components and licenses' },
+  { element: 'Audit Logs', view: 'Authenticated', create: '—', edit: '—', delete: '—', notes: 'Automatically generated; read-only' },
+  { element: 'GitHub Import', view: '—', create: 'Superuser', edit: '—', delete: '—', notes: 'Creates a system from a GitHub repo without cloning' },
+  { element: 'Impersonation', view: 'Superuser', create: 'Superuser', edit: '—', delete: 'Superuser', notes: 'Start/stop impersonation of other users' },
+]
+
+// --- Creation table ---
+
+const creationColumns: TableColumn<typeof creationRows[0]>[] = [
+  { accessorKey: 'element', header: 'Element', cell: ({ row }) => h('span', { class: 'font-medium' }, row.getValue('element') as string) },
+  { accessorKey: 'method', header: 'Creation Method' },
+]
+
+const creationRows = [
+  { element: 'Systems', method: 'Created via the UI form or GitHub import' },
+  { element: 'Repositories', method: 'Added when creating or editing a system, or via GitHub import' },
+  { element: 'Components', method: 'Discovered automatically when an SBOM is submitted — never created directly' },
+  { element: 'Technologies', method: 'Created via the UI form by authenticated users' },
+  { element: 'Teams', method: 'Created via the UI by superusers' },
+  { element: 'Users (OAuth)', method: 'Created automatically on first sign-in via GitHub OAuth' },
+  { element: 'Users (Technical)', method: 'Created via the UI by superusers for API access' },
+  { element: 'API Tokens', method: 'Generated via the UI by superusers for technical users' },
+  { element: 'Version Constraints', method: 'Created via the UI by authenticated users' },
+  { element: 'Licenses', method: 'Discovered automatically from SBOM component metadata' },
+  { element: 'Approvals', method: 'Created when a team member approves a technology for their team' },
+  { element: 'Audit Logs', method: 'Generated automatically on every create, update, and delete operation' },
+]
 
 useHead({ title: 'Access Model - Polaris' })
 </script>

--- a/app/pages/docs/architecture/graph-model.vue
+++ b/app/pages/docs/architecture/graph-model.vue
@@ -5,60 +5,92 @@
       description="Neo4j data model and relationships"
     />
 
-    <UCard>
-      <div>
-        <h2>Overview</h2>
-        <p>Polaris uses Neo4j, a graph database, to model the relationships between technologies, systems, teams, and version constraints. This enables powerful queries about technology usage and compliance.</p>
-      </div>
-    </UCard>
-
+    <!-- Overview -->
     <UCard>
       <template #header>
-        <h2 class="text-lg font-semibold m-0">Graph Visualization</h2>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-git-branch" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">Overview</h2>
+        </div>
+      </template>
+      <p class="text-(--ui-text-muted)">
+        Polaris uses Neo4j, a graph database, to model the relationships between technologies, systems, teams, and version constraints. This enables powerful queries about technology usage and compliance.
+      </p>
+    </UCard>
+
+    <!-- Graph Visualization -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-network" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">Graph Visualization</h2>
+        </div>
       </template>
       <div ref="mermaidEl" class="flex justify-center items-center min-h-50 p-6 overflow-x-auto" />
     </UCard>
 
+    <!-- Core Nodes -->
     <UCard>
-      <div>
-        <h2>Core Nodes</h2>
-        <ul>
-          <li><strong>Technology</strong> — Approved technologies with versions and metadata</li>
-          <li><strong>System</strong> — Deployable applications and services</li>
-          <li><strong>Component</strong> — SBOM entries (libraries, packages)</li>
-          <li><strong>Team</strong> — Organizational teams</li>
-          <li><strong>VersionConstraint</strong> — Version range constraints for technologies</li>
-          <li><strong>License</strong> — Software licenses</li>
-          <li><strong>Version</strong> — Specific versions of technologies</li>
-          <li><strong>Repository</strong> — Source code repositories</li>
-          <li><strong>AuditLog</strong> — Change tracking entries</li>
-        </ul>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-circle-dot" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">Core Nodes</h2>
+        </div>
+      </template>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <UPageFeature
+          v-for="node in coreNodes"
+          :key="node.title"
+          :icon="node.icon"
+          :title="node.title"
+          :description="node.description"
+          orientation="horizontal"
+        />
+      </div>
+    </UCard>
 
-        <h2>Key Relationships</h2>
-        <ul>
-          <li><code>Team -[:STEWARDED_BY]-&gt; Technology</code> — Technical governance responsibility</li>
-          <li><code>Team -[:OWNS]-&gt; System</code> — Operational ownership</li>
-          <li><code>Team -[:USES]-&gt; Technology</code> — Actual technology usage</li>
-          <li><code>Team -[:APPROVES]-&gt; Technology | Version</code> — TIME framework approval</li>
-          <li><code>Team -[:MAINTAINS]-&gt; Repository</code> — Repository maintenance</li>
-          <li><code>Technology -[:HAS_VERSION]-&gt; Version</code> — Version tracking</li>
-          <li><code>Component -[:IS_VERSION_OF]-&gt; Technology</code> — Component to technology mapping</li>
-          <li><code>System -[:USES]-&gt; Component</code> — System dependencies</li>
-          <li><code>System -[:HAS_SOURCE_IN]-&gt; Repository</code> — Source code location</li>
-          <li><code>VersionConstraint -[:GOVERNS]-&gt; Technology</code> — Constraint scope</li>
-          <li><code>AuditLog -[:PERFORMED_BY]-&gt; User</code> — Who made the change</li>
-          <li><code>AuditLog -[:AUDITS]-&gt; Entity</code> — What was changed</li>
-        </ul>
+    <!-- Key Relationships -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-arrow-right" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">Key Relationships</h2>
+        </div>
+      </template>
+      <div class="space-y-3">
+        <div
+          v-for="rel in keyRelationships"
+          :key="rel.label"
+          class="flex items-start gap-3"
+        >
+          <UIcon name="i-lucide-arrow-right" class="w-4 h-4 text-(--ui-primary) shrink-0 mt-1" />
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 flex-wrap">
+              <span class="text-sm font-medium">{{ rel.description }}</span>
+              <UBadge :label="rel.label" variant="subtle" color="neutral" size="xs" />
+            </div>
+            <p class="text-sm text-(--ui-text-muted) mt-0.5">{{ rel.detail }}</p>
+          </div>
+        </div>
+      </div>
+    </UCard>
 
-        <h2>Query Examples</h2>
-        <p>The graph model enables queries like:</p>
-        <ul>
-          <li>Find all systems using a deprecated technology</li>
-          <li>List teams affected by a license rule change</li>
-          <li>Trace component dependencies across systems</li>
-          <li>Identify compliance violations</li>
-          <li>Track all changes made by a specific user</li>
-        </ul>
+    <!-- Query Examples -->
+    <UCard>
+      <template #header>
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-search" class="w-5 h-5 text-(--ui-primary)" />
+          <h2 class="text-lg font-semibold">Query Examples</h2>
+        </div>
+      </template>
+      <div class="space-y-3">
+        <UPageFeature
+          v-for="example in queryExamples"
+          :key="example.title"
+          icon="i-lucide-search"
+          :title="example.title"
+          orientation="horizontal"
+        />
       </div>
     </UCard>
   </div>
@@ -67,9 +99,45 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 
-useHead({
-  title: 'Graph Model - Polaris'
-})
+// --- Core Nodes ---
+const coreNodes = [
+  { icon: 'i-lucide-settings', title: 'Technology', description: 'Approved technologies with versions and metadata' },
+  { icon: 'i-lucide-cpu', title: 'System', description: 'Deployable applications and services' },
+  { icon: 'i-lucide-box', title: 'Component', description: 'SBOM entries (libraries, packages)' },
+  { icon: 'i-lucide-users', title: 'Team', description: 'Organizational teams' },
+  { icon: 'i-lucide-git-branch', title: 'VersionConstraint', description: 'Version range constraints for technologies' },
+  { icon: 'i-lucide-scale', title: 'License', description: 'Software licenses' },
+  { icon: 'i-lucide-tag', title: 'Version', description: 'Specific versions of technologies' },
+  { icon: 'i-lucide-folder-git', title: 'Repository', description: 'Source code repositories' },
+  { icon: 'i-lucide-clipboard-list', title: 'AuditLog', description: 'Change tracking entries' },
+]
+
+// --- Key Relationships ---
+const keyRelationships = [
+  { label: 'STEWARDED_BY', description: 'Team stewards Technology', detail: 'Technical governance responsibility' },
+  { label: 'OWNS', description: 'Team owns System', detail: 'Operational ownership' },
+  { label: 'USES', description: 'Team uses Technology', detail: 'Actual technology usage by a team' },
+  { label: 'APPROVES', description: 'Team approves Technology or Version', detail: 'TIME framework approval' },
+  { label: 'MAINTAINS', description: 'Team maintains Repository', detail: 'Repository maintenance responsibility' },
+  { label: 'HAS_VERSION', description: 'Technology has Version', detail: 'Version tracking per technology' },
+  { label: 'IS_VERSION_OF', description: 'Component is version of Technology', detail: 'Component to technology mapping' },
+  { label: 'USES', description: 'System uses Component', detail: 'System dependency on a component' },
+  { label: 'HAS_SOURCE_IN', description: 'System has source in Repository', detail: 'Source code location' },
+  { label: 'GOVERNS', description: 'VersionConstraint governs Technology', detail: 'Constraint scope' },
+  { label: 'PERFORMED_BY', description: 'AuditLog performed by User', detail: 'Who made the change' },
+  { label: 'AUDITS', description: 'AuditLog audits Entity', detail: 'What was changed' },
+]
+
+// --- Query Examples ---
+const queryExamples = [
+  { title: 'Find all systems using a deprecated technology' },
+  { title: 'List teams affected by a license rule change' },
+  { title: 'Trace component dependencies across systems' },
+  { title: 'Identify compliance violations' },
+  { title: 'Track all changes made by a specific user' },
+]
+
+useHead({ title: 'Graph Model - Polaris' })
 
 const mermaidEl = ref<HTMLElement | null>(null)
 

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -1,11 +1,15 @@
 import swaggerJsdoc from 'swagger-jsdoc'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const { version } = JSON.parse(readFileSync(resolve(process.cwd(), 'package.json'), 'utf-8')) as { version: string }
 
 const options: swaggerJsdoc.Options = {
   definition: {
     openapi: '3.1.0',
     info: {
       title: 'Polaris API',
-      version: '2.0.0',
+      version,
       description: `# Polaris Technology Catalog API
 
 The Polaris API provides programmatic access to the technology catalog, enabling automation, integration, and custom tooling.


### PR DESCRIPTION
## Description

Brings `access-model.vue` and `graph-model.vue` in line with the visual style established by the recently redesigned `concepts.vue`. Also fixes the API reference page showing a hardcoded version number instead of the application version.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [x] Configuration or build changes

## Changes Made

- **`app/pages/docs/access-model.vue`** — Removed all `prose` wrappers and raw HTML. Roles rendered as `UPageFeature` items with icons. Both tables (Access by Element, How Elements Are Created) replaced with `UTable` using existing `badgeColor()` logic. Superuser-only pages as `UPageFeature` items. Impersonation and Audit Trail notes as `UAlert` callouts. All `UCard` sections get icon headers matching the concepts pattern.
- **`app/pages/docs/architecture/graph-model.vue`** — Removed raw `<ul>` and `<h2>` tags. Core Nodes rendered as `UPageFeature` items in a 2-column grid with distinct icons. Key Relationships use an inline layout with `UBadge` for the relationship label. Query Examples as `UPageFeature` items. Mermaid diagram card and all rendering logic are untouched.
- **`server/openapi.ts`** — Replaced hardcoded `version: '2.0.0'` with a runtime read from `package.json`, so the API reference page always shows the same version as the running application.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have run `npm run test` — 1 pre-existing failure unrelated to these changes (present on `main` before this branch)