### PR TITLE
fix: remove duplicate git tag in release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -106,6 +106,5 @@ jobs:
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore: release v${RESOLVED_VERSION} [skip ci]"
 
-          # Tag and push
-          git tag "v${RESOLVED_VERSION}"
-          git push origin main --follow-tags
+          # Push the bump commit only — release-drafter already created the tag
+          git push origin main


### PR DESCRIPTION
## Description

The release-drafter workflow fails on every push to `main` with:

```
fatal: tag 'v0.1.5' already exists
Process completed with exit code 128.
```

`release-drafter` runs with `publish: true`, which creates and pushes the version tag to GitHub as part of publishing the release. The bump script then tries to create the same tag locally with `git tag "v${RESOLVED_VERSION}"` and push it with `--follow-tags` — but the tag already exists on the remote, so git exits 128.

The tag is owned by release-drafter. The bump script only needs to push the `package.json`/`CHANGELOG.md` commit.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Changes Made

- `.github/workflows/release-drafter.yml` — removed the redundant `git tag` line and replaced `git push origin main --follow-tags` with `git push origin main`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors