### PR TITLE
fix: open PR for version bump instead of pushing directly to main

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           RESOLVED_VERSION: ${{ steps.release.outputs.resolved_version }}
           RELEASE_BODY: ${{ steps.release.outputs.body }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -e
 
@@ -103,8 +104,16 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          BRANCH="chore/release-v${RESOLVED_VERSION}"
+          git checkout -b "$BRANCH"
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore: release v${RESOLVED_VERSION} [skip ci]"
+          git push origin "$BRANCH"
 
-          # Push the bump commit only — release-drafter already created the tag
-          git push origin main
+          # Open a PR — branch protection prevents direct pushes to main
+          gh pr create \
+            --title "chore: release v${RESOLVED_VERSION} [skip ci]" \
+            --body "Automated version bump and CHANGELOG update for v${RESOLVED_VERSION}." \
+            --base main \
+            --head "$BRANCH" \
+            --label "chore"


### PR DESCRIPTION
## Description

After the previous fix (removing the duplicate tag), the workflow now fails with:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

`GITHUB_TOKEN` cannot bypass branch protection. The bump commit (`package.json` + `CHANGELOG.md`) cannot be pushed directly to `main`.

Instead, the workflow now:
1. Creates a `chore/release-vX.Y.Z` branch
2. Commits the version bump there
3. Opens a PR via `gh pr create`

The existing skip guard (`grep -qE '^chore: release v'`) prevents an infinite loop when that PR is merged back to `main`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Changes Made

- `.github/workflows/release-drafter.yml` — replaced direct `git push origin main` with branch + `gh pr create`
- Added `GH_TOKEN` env var to the bump step so `gh` CLI can authenticate

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors