### PR TITLE
fix: inline openapi spec at build time instead of reading from filesystem

### DIFF
--- a/server/api/openapi.json.get.ts
+++ b/server/api/openapi.json.get.ts
@@ -1,11 +1,6 @@
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+// The spec is pre-generated at build time by `npm run docs:api`.
+// Importing it statically lets the bundler inline it — no filesystem
+// reads at runtime, so it works in the production Docker image.
+import spec from '../../public/openapi.json'
 
-// The spec is pre-generated at build time by `npm run docs:api` and committed to
-// public/openapi.json. swagger-jsdoc scans source .ts files which don't exist in
-// the production image, so we serve the static file instead.
-export default defineEventHandler(() => {
-  const specPath = resolve(process.cwd(), 'public/openapi.json')
-  const raw = readFileSync(specPath, 'utf-8')
-  return JSON.parse(raw)
-})
+export default defineEventHandler(() => spec)


### PR DESCRIPTION
## Description

`/api/openapi.json` returns 500 in production.

The previous fix used `readFileSync('public/openapi.json')` at runtime, but `public/` is not copied into the Docker runner image — only `.output/` is deployed. So the file doesn't exist and the read throws.

Replace with a static `import` of the JSON file. The bundler (Rollup/Nitro) inlines the spec as a constant at build time:

```js
const spec = { openapi: "3.1.0", paths: { ... } }
export default defineEventHandler(() => spec)
```

No filesystem access at runtime. Verified in the compiled `.output` — `swaggerJsdoc` is gone and the spec is fully inlined.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/api/openapi.json.get.ts` — replaced `readFileSync` with `import spec from '../../public/openapi.json'`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have tested the build with `npm run build`