### PR TITLE
fix: add mobile top bar with sidebar trigger

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -108,6 +108,27 @@
 
     <!-- Main Content -->
     <main class="flex-1 overflow-auto min-w-0">
+      <!-- Mobile top bar -->
+      <div class="sm:hidden flex items-center gap-3 px-4 py-3 border-b border-default bg-(--ui-bg-elevated)">
+        <UButton
+          icon="i-lucide-menu"
+          color="neutral"
+          variant="ghost"
+          square
+          aria-label="Open menu"
+          @click="sidebarOpen = true"
+        />
+        <NuxtLink to="/" class="flex items-center gap-2">
+          <UIcon name="i-lucide-zap" class="w-5 h-5 text-(--ui-primary)" />
+          <span class="text-lg font-bold">Polaris</span>
+        </NuxtLink>
+        <div class="ml-auto">
+          <ClientOnly>
+            <UColorModeButton color="neutral" variant="ghost" />
+          </ClientOnly>
+        </div>
+      </div>
+
       <!-- Impersonation Banner -->
       <div
         v-if="impersonation.active && impersonation.user"


### PR DESCRIPTION
## Description

On mobile the entire sidebar was absent — `USidebar` renders as a slideover on narrow viewports but there was no trigger to open it, making navigation completely inaccessible.

Adds a `sm:hidden` top bar at the top of the main content area containing:
- A hamburger button that sets `sidebarOpen = true`, which `USidebar` maps to `openMobile` on narrow viewports and slides in the navigation drawer
- The Polaris logo/wordmark (links to home)
- The colour mode toggle

On desktop (`sm` and above) the top bar is hidden and the existing collapsible sidebar behaviour is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `app/layouts/default.vue` — added mobile-only top bar with hamburger, logo, and colour mode button

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`