### PR TITLE
fix: improve GitHub import error handling and add token support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ AUTH_SECRET=replace-me-in-production-use-openssl-rand-base64-32
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret
 
+# GitHub API token for the "Import from GitHub" feature (optional but strongly recommended)
+# Without this, the GitHub API is called unauthenticated (60 req/hour limit per IP).
+# With a token the limit rises to 5,000 req/hour, preventing 403 errors in production.
+# Create a fine-grained token with read-only access to public repositories:
+# https://github.com/settings/tokens
+# GITHUB_TOKEN=github_pat_...
+
 # Auth Origin (optional - auto-detected for Gitpod)
 # For local development: http://localhost:3000/api/auth (default)
 # For Gitpod: Set to the environment's preview URL + /api/auth

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.12...v0.1.13
 
-
 ## [0.1.10] - 2026-04-11
 
 ## What's Changed
@@ -42,12 +41,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.9...v0.1.10
 
-
 ## [0.1.9] - 2026-04-11
 
 ## What's Changed
 
-* No changes
+- No changes
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.8...v0.1.9
-

--- a/server/api/admin/import/github.post.ts
+++ b/server/api/admin/import/github.post.ts
@@ -92,15 +92,25 @@ export default defineEventHandler(async (event) => {
       data: result
     }
   } catch (error: unknown) {
-    // Re-throw HTTP errors
+    // Re-throw HTTP errors (4xx/5xx already created via createError)
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }
 
     const message = error instanceof Error ? error.message : 'Import failed'
+    const stack = error instanceof Error ? error.stack : undefined
 
-    // GitHub API errors (not found, rate limit, etc.)
-    if (message.includes('not found') || message.includes('Cannot parse')) {
+    // Log the full error so it appears in production server logs
+    console.error('[github-import] Import failed:', message, stack)
+
+    // GitHub API errors — surface as 422 so the client gets a useful message
+    if (
+      message.includes('not found') ||
+      message.includes('Cannot parse') ||
+      message.includes('rate limit') ||
+      message.includes('authentication failed') ||
+      message.includes('access denied')
+    ) {
       throw createError({ statusCode: 422, message })
     }
 

--- a/server/services/github-import.service.ts
+++ b/server/services/github-import.service.ts
@@ -157,6 +157,8 @@ export class GitHubImportService {
         writeFileSync(filePath, file.content, 'utf-8')
       }
 
+      console.log(`[github-import] Running cdxgen in ${tempDir} for project "${projectName}" with ${manifests.length} manifest(s)`)
+
       // Run cdxgen
       const bom = await createBom(tempDir, {
         installDeps: false,
@@ -165,7 +167,10 @@ export class GitHubImportService {
         multiProject: true
       })
 
-      if (!bom) return null
+      if (!bom) {
+        console.warn(`[github-import] cdxgen returned no BOM for "${projectName}"`)
+        return null
+      }
 
       if (typeof bom === 'string') {
         return JSON.parse(bom)
@@ -174,6 +179,9 @@ export class GitHubImportService {
       }
 
       return bom as object
+    } catch (err) {
+      console.error(`[github-import] cdxgen threw for "${projectName}":`, err instanceof Error ? err.message : err)
+      throw err
     } finally {
       // Always clean up
       if (existsSync(tempDir)) {

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -94,22 +94,52 @@ export function parseGitHubRepo(input: string): { owner: string; repo: string } 
 }
 
 /**
+ * Build GitHub API request headers.
+ * Includes a Bearer token when GITHUB_TOKEN is set in the environment,
+ * raising the rate limit from 60 to 5,000 requests/hour.
+ */
+function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github.v3+json',
+    'User-Agent': 'Polaris'
+  }
+  const token = process.env.GITHUB_TOKEN
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`
+  }
+  return headers
+}
+
+/**
+ * Throw a structured error for non-OK GitHub API responses.
+ * Maps 401/403 (auth/rate-limit) and 404 to specific messages so callers
+ * can surface them as 422 rather than 500.
+ */
+function throwGitHubError(status: number, statusText: string, context: string): never {
+  if (status === 404) {
+    throw new Error(`${context} not found`)
+  }
+  if (status === 401) {
+    throw new Error(`GitHub API authentication failed for ${context} — check GITHUB_TOKEN`)
+  }
+  if (status === 403) {
+    throw new Error(`GitHub API rate limit exceeded or access denied for ${context}`)
+  }
+  if (status === 429) {
+    throw new Error(`GitHub API rate limit exceeded for ${context}`)
+  }
+  throw new Error(`GitHub API error ${status} ${statusText} for ${context}`)
+}
+
+/**
  * Fetch repository metadata from the GitHub API.
  */
 export async function fetchRepoMetadata(owner: string, repo: string): Promise<GitHubRepoMetadata> {
   const url = `https://api.github.com/repos/${owner}/${repo}`
-  const response = await fetch(url, {
-    headers: {
-      'Accept': 'application/vnd.github.v3+json',
-      'User-Agent': 'Polaris'
-    }
-  })
+  const response = await fetch(url, { headers: githubHeaders() })
 
   if (!response.ok) {
-    if (response.status === 404) {
-      throw new Error(`Repository not found: ${owner}/${repo}`)
-    }
-    throw new Error(`GitHub API error: ${response.status} ${response.statusText}`)
+    throwGitHubError(response.status, response.statusText, `repository ${owner}/${repo}`)
   }
 
   return await response.json() as GitHubRepoMetadata
@@ -120,18 +150,20 @@ export async function fetchRepoMetadata(owner: string, repo: string): Promise<Gi
  */
 export async function fetchFileTree(owner: string, repo: string, branch: string): Promise<GitHubTreeEntry[]> {
   const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`
-  const response = await fetch(url, {
-    headers: {
-      'Accept': 'application/vnd.github.v3+json',
-      'User-Agent': 'Polaris'
-    }
-  })
+  const response = await fetch(url, { headers: githubHeaders() })
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch file tree: ${response.status} ${response.statusText}`)
+    throwGitHubError(response.status, response.statusText, `file tree for ${owner}/${repo}@${branch}`)
   }
 
   const data = await response.json() as { tree: GitHubTreeEntry[]; truncated: boolean }
+
+  if (data.truncated) {
+    // Repository has more than 100,000 tree entries; the tree is partial.
+    // Log a warning but continue — manifests near the root will still be found.
+    console.warn(`[github] Tree response truncated for ${owner}/${repo}@${branch} — large repo, some manifests may be missed`)
+  }
+
   return data.tree
 }
 
@@ -141,15 +173,10 @@ export async function fetchFileTree(owner: string, repo: string, branch: string)
  */
 export async function fetchFileContent(owner: string, repo: string, path: string, branch: string): Promise<string> {
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`
-  const response = await fetch(url, {
-    headers: {
-      'Accept': 'application/vnd.github.v3+json',
-      'User-Agent': 'Polaris'
-    }
-  })
+  const response = await fetch(url, { headers: githubHeaders() })
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch ${path}: ${response.status}`)
+    throwGitHubError(response.status, response.statusText, path)
   }
 
   const data = await response.json() as { content: string; encoding: string }


### PR DESCRIPTION
## Description

Two production bugs fixed: the "Import from GitHub" 500 error, and a deploy pipeline failure.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Changes Made

**GitHub import error handling (`server/utils/github.ts`, `server/api/admin/import/github.post.ts`, `server/services/github-import.service.ts`):**
- Centralised GitHub API request headers into `githubHeaders()`, which includes `Authorization: Bearer $GITHUB_TOKEN` when the env var is set (raises rate limit from 60 to 5,000 req/hour). Without a token, production hits the unauthenticated limit and receives 403, which was previously swallowed as a 500.
- Added `throwGitHubError()` that maps HTTP 401, 403, 404, and 429 responses to descriptive error messages.
- Extended the catch block in the API handler to map rate-limit and auth error messages to 422 instead of 500.
- Added `console.error` with full stack trace and structured `console.log` around `createBom` so failures appear in `docker compose logs app` rather than being silently re-thrown as a generic 500.
- Added a warning log when the Git Trees API returns a truncated response for large repos.

**Deploy pipeline (`deploy.yml`):**
- `appleboy/scp-action` uses `tar` on the remote to extract the uploaded archive. `--strip-components` is a GNU tar extension not available on BusyBox `tar` (the production server), causing `Process exited with status 1`. Replaced `strip_components: 1` with a plain copy to `/opt/polaris/infra/` and an explicit `mv` in the SSH step.

**Documentation (`.env.example`, `CHANGELOG.md`):**
- Documented `GITHUB_TOKEN` as optional but strongly recommended.
- Fixed pre-existing markdownlint violations.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have updated documentation if needed

## Additional Notes

**Action required on production after merge:** Add `GITHUB_TOKEN` to the deploy workflow secrets (a fine-grained PAT with read-only access to public repositories is sufficient). Without it the rate-limit fix prevents the 500 but the 60 req/hour limit remains.

If the import 500 persists after deploy, run `docker compose logs app --tail=100 | grep github-import` — the new logging will show the exact error and stack trace.