### PR TITLE
feat: split deploy into publish + deploy workflows with parallel builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,10 +22,11 @@ jobs:
     name: Deploy to production
     runs-on: ubuntu-latest
 
-    # For workflow_run triggers, only proceed when publish succeeded
+    # For manual deploys, only allow runs from main.
+    # For workflow_run triggers, only proceed when publish succeeded.
     if: >
-      github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
 
     permissions:
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,22 +1,31 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - main
+  # Automatically deploy when the Publish workflow completes successfully
+  workflow_run:
+    workflows: ["Publish"]
+    types: [completed]
 
-# Prevent concurrent deploys; cancel any in-progress run for the same branch
+  # Allow manual deploys from the GitHub Actions UI (always deploys latest)
+  workflow_dispatch:
+
+# Prevent concurrent deploys; do not cancel in-progress — let them finish
 concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  group: deploy
+  cancel-in-progress: false
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   deploy:
-    name: Build, push, and deploy
+    name: Deploy to production
     runs-on: ubuntu-latest
+
+    # For workflow_run triggers, only proceed when publish succeeded
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
 
     permissions:
       contents: read
@@ -24,57 +33,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Read version from package.json
-        id: version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
-          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push app image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: runner
-          push: true
-          build-args: |
-            APP_VERSION=${{ steps.version.outputs.version }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.version }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.minor }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.major }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Build and push migrator image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: migrator
-          push: true
-          build-args: |
-            APP_VERSION=${{ steps.version.outputs.version }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.version }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.minor }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.major }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
 
       - name: Copy compose file
         uses: appleboy/scp-action@v1.0.0
@@ -85,6 +43,7 @@ jobs:
           source: infra/docker-compose.yml
           target: /opt/polaris/infra/
           overwrite: true
+          debug: true
 
       - name: Write .env and deploy
         uses: appleboy/ssh-action@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
+
       - name: Read version from package.json
         id: version
         run: |
@@ -85,6 +90,11 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 'lts/*'
 
       - name: Read version from package.json
         id: version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,121 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+# Cancel any in-progress publish run for the same branch
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build-app:
+    name: Build and push app image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push app image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: runner
+          push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.minor }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.major }}
+          cache-from: type=gha,scope=app
+          cache-to: type=gha,mode=max,scope=app
+
+  build-migrator:
+    name: Build and push migrator image
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push migrator image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          target: migrator
+          push: true
+          build-args: |
+            APP_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.minor }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.major }}
+          cache-from: type=gha,scope=migrator
+          cache-to: type=gha,mode=max,scope=migrator
+
+  publish-complete:
+    name: Publish complete
+    runs-on: ubuntu-latest
+    needs: [build-app, build-migrator]
+    steps:
+      - name: Done
+        run: echo "Both images published successfully."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,12 +14,23 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
-  build-app:
-    name: Build and push app image
+  build:
+    name: Build and push ${{ matrix.image }} image
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: polaris
+            target: runner
+            cache: app
+          - image: polaris-migrator
+            target: migrator
+            cache: migrator
 
     steps:
       - name: Checkout
@@ -52,80 +63,26 @@ jobs:
           echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
           echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
 
-      - name: Build and push app image
+      - name: Build and push ${{ matrix.image }} image
         uses: docker/build-push-action@v7
         with:
           context: .
-          target: runner
+          target: ${{ matrix.target }}
           push: true
           build-args: |
             APP_VERSION=${{ steps.version.outputs.version }}
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.version }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.minor }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris:${{ steps.version.outputs.major }}
-          cache-from: type=gha,scope=app
-          cache-to: type=gha,mode=max,scope=app
-
-  build-migrator:
-    name: Build and push migrator image
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 'lts/*'
-
-      - name: Read version from package.json
-        id: version
-        run: |
-          VERSION=$(node -p "require('./package.json').version")
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f1-2)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
-          echo "minor=$MINOR" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push migrator image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          target: migrator
-          push: true
-          build-args: |
-            APP_VERSION=${{ steps.version.outputs.version }}
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.version }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.minor }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/polaris-migrator:${{ steps.version.outputs.major }}
-          cache-from: type=gha,scope=migrator
-          cache-to: type=gha,mode=max,scope=migrator
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:${{ steps.version.outputs.minor }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.image }}:${{ steps.version.outputs.major }}
+          cache-from: type=gha,scope=${{ matrix.cache }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.cache }}
 
   publish-complete:
     name: Publish complete
     runs-on: ubuntu-latest
-    needs: [build-app, build-migrator]
+    needs: [build]
     steps:
       - name: Done
         run: echo "Both images published successfully."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.18...v0.1.19
 
-
 ## [0.1.13] - 2026-04-16
 
 ## What's Changed


### PR DESCRIPTION
## Description

Replaces the monolithic `deploy.yml` with two focused workflows to speed up debugging and enable parallel image builds.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Configuration or build changes

## Changes Made

**`.github/workflows/publish.yml` (new)**
- Triggers on push to `main`
- Builds `polaris` (app) and `polaris-migrator` images in two independent parallel jobs — a failure in one does not cancel the other
- Each job uses a scoped GHA cache key (`scope=app` / `scope=migrator`) to avoid cache collisions between parallel builds
- A `publish-complete` job (`needs: [build-app, build-migrator]`) provides a single clean completion event for `workflow_run` to listen on

**`.github/workflows/deploy.yml` (replaced)**
- Removed all build/push steps
- Triggers via `workflow_run` on `Publish` completion (only when conclusion is `success`) and via `workflow_dispatch` for manual deploys from the GitHub UI
- Concurrent deploys are queued (`cancel-in-progress: false`) rather than cancelled, so an in-progress deploy is never interrupted
- Added `debug: true` to the `scp-action` step to expose the exact remote tar command in logs for ongoing diagnosis of the `Process exited with status 1` failure

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and `npm run mdlint` — no errors

## Additional Notes

The scp-action failure is still present. With `debug: true` the next failed run will print the exact `tar` command executed on the remote, which will confirm whether the issue is BusyBox tar, a missing directory, or a permissions problem.