### PR TITLE
feat: add Dozzle log viewer at logs.mindfield.dk

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,6 +93,7 @@ jobs:
               caddy:
                 image: caddy:2-alpine
                 restart: unless-stopped
+                env_file: .env
                 ports:
                   - "80:80"
                   - "443:443"
@@ -102,6 +103,17 @@ jobs:
                   - caddy_config:/config
                 depends_on:
                   - app
+                  - dozzle
+                networks:
+                  - polaris-net
+
+              dozzle:
+                image: amir20/dozzle:latest
+                restart: unless-stopped
+                volumes:
+                  - /var/run/docker.sock:/var/run/docker.sock:ro
+                environment:
+                  DOZZLE_NO_ANALYTICS: "true"
                 networks:
                   - polaris-net
 
@@ -131,6 +143,8 @@ jobs:
             GITHUB_CLIENT_SECRET=${{ secrets.OAUTH_CLIENT_SECRET }}
             SUPERUSER_EMAILS=${{ secrets.SUPERUSER_EMAILS }}
             DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+            DOZZLE_USER=${{ secrets.DOZZLE_USER }}
+            DOZZLE_PASSWORD_HASH=${{ secrets.DOZZLE_PASSWORD_HASH }}
             ENV
 
             chmod 600 /opt/polaris/.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,8 +47,9 @@ FROM node:lts-alpine AS migrator
 
 WORKDIR /app
 
-COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json /app/package-lock.json ./
+RUN npm ci --omit=dev
+
 COPY --from=builder /app/schema ./schema
-COPY --from=builder /app/package.json ./package.json
 
 ENV NODE_ENV=production

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -1,5 +1,10 @@
-# Replace with your domain name to enable automatic TLS via Let's Encrypt.
-# Example: polaris.example.com
-:80 {
+polaris.mindfield.dk {
     reverse_proxy app:3000
+}
+
+logs.mindfield.dk {
+    basicauth {
+        {$DOZZLE_USER} {$DOZZLE_PASSWORD_HASH}
+    }
+    reverse_proxy dozzle:8080
 }

--- a/infra/README.md
+++ b/infra/README.md
@@ -70,6 +70,8 @@ In your repository go to **Settings → Secrets and variables → Actions** and 
 | `GITHUB_CLIENT_ID` | From your GitHub OAuth app |
 | `GITHUB_CLIENT_SECRET` | From your GitHub OAuth app |
 | `SUPERUSER_EMAILS` | Comma-separated admin email addresses |
+| `DOZZLE_USER` | Username for the Dozzle log viewer |
+| `DOZZLE_PASSWORD_HASH` | Caddy bcrypt hash (`caddy hash-password`) |
 
 ### 4. Trigger the first deploy
 
@@ -82,6 +84,35 @@ Push any commit to `main`. The `Deploy` workflow will:
 5. Run `npm run migrate:up` inside the app container
 
 After the workflow completes, `curl http://[2a01:4f9:c014:472c::1]` should return the Polaris app.
+
+## Log viewer (Dozzle)
+
+Live Docker container logs are accessible at `https://logs.mindfield.dk`, protected by HTTP basic auth via Caddy.
+
+### Setup
+
+1. **Generate a bcrypt password hash** using the Caddy image (no local install needed):
+
+   ```bash
+   docker run --rm caddy:2-alpine caddy hash-password --plaintext 'your-password-here'
+   ```
+
+   The output (e.g. `$2a$14$...`) is the value for `DOZZLE_PASSWORD_HASH`.
+
+2. **Add two GitHub Actions secrets** (Settings → Secrets and variables → Actions):
+
+   | Secret | Value |
+   |---|---|
+   | `DOZZLE_USER` | Username for the log viewer |
+   | `DOZZLE_PASSWORD_HASH` | Bcrypt hash from step 1 |
+
+   The deploy workflow writes these to `/opt/polaris/.env`, where Caddy reads them via `{$DOZZLE_USER}` / `{$DOZZLE_PASSWORD_HASH}` env var substitution in the Caddyfile.
+
+3. **Trigger a deploy** — the next deploy will start the Dozzle container and configure Caddy.
+
+### Security note
+
+Dozzle mounts the Docker socket read-only (`/var/run/docker.sock:ro`). This grants log-stream access to all containers on the host. The socket is not exposed outside the internal `polaris-net` network; all access goes through Caddy with basic auth over TLS.
 
 ## Enabling TLS (when you have a domain)
 

--- a/infra/ansible/templates/Caddyfile.j2
+++ b/infra/ansible/templates/Caddyfile.j2
@@ -1,3 +1,10 @@
 {{ domain }} {
     reverse_proxy app:3000
 }
+
+logs.{{ domain }} {
+    basicauth {
+        {$DOZZLE_USER} {$DOZZLE_PASSWORD_HASH}
+    }
+    reverse_proxy dozzle:8080
+}

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -36,6 +36,7 @@ services:
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
+    env_file: /opt/polaris/.env
     ports:
       - "80:80"
       - "443:443"
@@ -45,6 +46,17 @@ services:
       - caddy_config:/config
     depends_on:
       - app
+      - dozzle
+    networks:
+      - polaris-net
+
+  dozzle:
+    image: amir20/dozzle:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      DOZZLE_NO_ANALYTICS: "true"
     networks:
       - polaris-net
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -47,6 +47,7 @@ services:
   caddy:
     image: caddy:2-alpine
     restart: unless-stopped
+    env_file: .env
     ports:
       - "80:80"
       - "443:443"
@@ -56,6 +57,17 @@ services:
       - caddy_config:/config
     depends_on:
       - app
+      - dozzle
+    networks:
+      - polaris-net
+
+  dozzle:
+    image: amir20/dozzle:latest
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    environment:
+      DOZZLE_NO_ANALYTICS: "true"
     networks:
       - polaris-net
 


### PR DESCRIPTION
## Description

Adds a browser-accessible Docker log viewer (Dozzle) at `https://logs.mindfield.dk`, protected by Caddy HTTP basic auth with automatic TLS via Let's Encrypt.

Also updates the Caddyfile from the `:80` placeholder to real domain names, and reduces the migrator image size by installing only production dependencies.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Configuration or build changes

## Changes Made

- Add `dozzle` service to `docker-compose.yml` (read-only Docker socket, no host port, internal network only)
- Add `env_file` to `caddy` service so `DOZZLE_USER`/`DOZZLE_PASSWORD_HASH` are available for Caddyfile env var substitution
- Replace `:80` placeholder in `Caddyfile` with `polaris.mindfield.dk` and `logs.mindfield.dk` site blocks (both get automatic TLS)
- Mirror all compose and Caddyfile changes into Ansible templates
- Write `DOZZLE_USER` and `DOZZLE_PASSWORD_HASH` to `.env` in the deploy workflow
- Reduce migrator image from ~1.7GB to ~200MB by running `npm ci --omit=dev` instead of copying full `node_modules` from builder
- Document log viewer setup and new GitHub secrets in `infra/README.md`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have updated documentation if needed

## Additional Notes

Two GitHub Actions secrets must be added before deploying:

| Secret | How to get the value |
|---|---|
| `DOZZLE_USER` | Choose a username |
| `DOZZLE_PASSWORD_HASH` | Run `docker run --rm caddy:2-alpine caddy hash-password --plaintext 'your-password'` |

The DNS A record for `logs.mindfield.dk` is already in place.