### PR TITLE
fix: restore dozzle service at logs.mindfield.dk

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,8 +114,10 @@ jobs:
                 restart: unless-stopped
                 volumes:
                   - /var/run/docker.sock:/var/run/docker.sock:ro
+                  - /opt/polaris/data/dozzle:/data
                 environment:
                   DOZZLE_NO_ANALYTICS: "true"
+                  DOZZLE_AUTH_PROVIDER: simple
                 healthcheck:
                   test: ["CMD", "/dozzle", "healthcheck"]
                   interval: 10s
@@ -135,6 +137,17 @@ jobs:
               caddy_config:
             COMPOSE
 
+            # Write Caddyfile (no basicauth — auth is handled by Dozzle natively)
+            cat > /opt/polaris/Caddyfile << 'CADDYFILE'
+            polaris.mindfield.dk {
+                reverse_proxy app:3000
+            }
+
+            logs.mindfield.dk {
+                reverse_proxy dozzle:8080
+            }
+            CADDYFILE
+
             # Write production .env from GitHub secrets
             cat > /opt/polaris/.env << ENV
             # Neo4j connection (plain vars for migrator, NUXT_ vars for app runtimeConfig)
@@ -151,11 +164,17 @@ jobs:
             GITHUB_CLIENT_SECRET=${{ secrets.OAUTH_CLIENT_SECRET }}
             SUPERUSER_EMAILS=${{ secrets.SUPERUSER_EMAILS }}
             DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
-            DOZZLE_USER=${{ secrets.DOZZLE_USER }}
-            DOZZLE_PASSWORD_HASH=${{ secrets.DOZZLE_PASSWORD_HASH }}
             ENV
 
             chmod 600 /opt/polaris/.env
+
+            # Generate Dozzle users.yml using the official generate command
+            mkdir -p /opt/polaris/data/dozzle
+            docker run --rm amir20/dozzle generate ${{ secrets.DOZZLE_USER }} \
+              --password '${{ secrets.DOZZLE_PASSWORD }}' \
+              --name '${{ secrets.DOZZLE_USER }}' \
+              > /opt/polaris/data/dozzle/users.yml
+            chmod 600 /opt/polaris/data/dozzle/users.yml
 
             cd /opt/polaris
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,8 +102,10 @@ jobs:
                   - caddy_data:/data
                   - caddy_config:/config
                 depends_on:
-                  - app
-                  - dozzle
+                  app:
+                    condition: service_started
+                  dozzle:
+                    condition: service_healthy
                 networks:
                   - polaris-net
 
@@ -114,6 +116,12 @@ jobs:
                   - /var/run/docker.sock:/var/run/docker.sock:ro
                 environment:
                   DOZZLE_NO_ANALYTICS: "true"
+                healthcheck:
+                  test: ["CMD", "/dozzle", "healthcheck"]
+                  interval: 10s
+                  timeout: 5s
+                  retries: 5
+                  start_period: 10s
                 networks:
                   - polaris-net
 

--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -3,8 +3,5 @@ polaris.mindfield.dk {
 }
 
 logs.mindfield.dk {
-    basicauth {
-        {$DOZZLE_USER} {$DOZZLE_PASSWORD_HASH}
-    }
     reverse_proxy dozzle:8080
 }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -68,8 +68,10 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /opt/polaris/data/dozzle:/data
     environment:
       DOZZLE_NO_ANALYTICS: "true"
+      DOZZLE_AUTH_PROVIDER: simple
     healthcheck:
       test: ["CMD", "/dozzle", "healthcheck"]
       interval: 10s

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -56,8 +56,10 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
-      - app
-      - dozzle
+      app:
+        condition: service_started
+      dozzle:
+        condition: service_healthy
     networks:
       - polaris-net
 
@@ -68,6 +70,12 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       DOZZLE_NO_ANALYTICS: "true"
+    healthcheck:
+      test: ["CMD", "/dozzle", "healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     networks:
       - polaris-net
 


### PR DESCRIPTION
## Description

Dozzle was unreachable at https://logs.mindfield.dk/ due to two compounding issues:

1. `DOZZLE_USER` and `DOZZLE_PASSWORD_HASH` were absent from the server's `.env`, so Caddy's `basicauth` block failed to expand its env vars.
2. Even with the vars present, the bcrypt hash contains `/` and `+` characters that break Caddy's Caddyfile parser during env var substitution, silently dropping the entire `logs.mindfield.dk` block — which also prevented Caddy from provisioning a TLS certificate for that domain (causing the 525 SSL handshake error).

The fix moves auth entirely to Dozzle's built-in `simple` auth provider, which handles bcrypt correctly and removes the dependency on Caddy for authentication.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- Removed `basicauth` from `infra/Caddyfile`; the deploy workflow now writes the Caddyfile to disk directly
- Added `DOZZLE_AUTH_PROVIDER: simple` and `/opt/polaris/data/dozzle:/data` volume mount to the dozzle service
- Added a `healthcheck` to dozzle; updated caddy `depends_on` to `condition: service_healthy`
- Deploy workflow now generates `users.yml` on the server using `docker run amir20/dozzle generate` with a plaintext `DOZZLE_PASSWORD` secret
- Removed `DOZZLE_USER` and `DOZZLE_PASSWORD_HASH` from the `.env` write step (no longer needed)

## Screenshots

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues

## Additional Notes

**Required action before deploying:** Add a `DOZZLE_PASSWORD` GitHub secret (plaintext password). The old `DOZZLE_PASSWORD_HASH` secret can be removed after the first successful deploy.

To restore the service immediately, trigger a manual deploy from the GitHub Actions UI once the secret is in place.