### PR TITLE
fix: copy migrator package files from source not builder stage

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -71,7 +71,7 @@ jobs:
           with open('CHANGELOG.md', 'r') as f:
               content = f.read()
 
-          new_section = f"## [{version}] - {today}\n\n{body}\n"
+          new_section = f"## [{version}] - {today}\n\n{body.strip()}\n"
           unreleased_block = (
               "## [Unreleased]\n\n"
               "### Added\n\n"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.27...v0.1.28
 
-
 ## [0.1.23] - 2026-04-23
 
 ## What's Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,8 @@ FROM node:lts-alpine AS migrator
 
 WORKDIR /app
 
-COPY --from=builder /app/package.json /app/package-lock.json ./
+# Copy package files from source (not builder) to avoid lockfile drift caused by the Nuxt build
+COPY package.json package-lock.json .npmrc ./
 RUN npm ci --omit=dev
 
 COPY --from=builder /app/schema ./schema


### PR DESCRIPTION
## Description

Two CI failures fixed:

**1. Migrator Docker build — `npm ci` lockfile mismatch**
The migrator Dockerfile stage was copying `package.json` and `package-lock.json` from the builder stage after `npm run build` had run. Nuxt's build modifies `package.json` in place, causing the lockfile to be out of sync. `npm ci` then fails with `Missing: X from lock file` errors. Fixed by copying both files directly from the build context instead.

**2. mdlint — MD012 double blank lines in CHANGELOG**
The release script was inserting the release-drafter body verbatim, which ends with a trailing newline. Combined with the existing newline before the next versioned section, this produced two consecutive blank lines that fail MD012. Fixed by calling `.strip()` on the body before inserting, and corrected the existing double blank line in `CHANGELOG.md`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- `Dockerfile`: copy `package.json`/`package-lock.json` from build context in migrator stage, not from builder
- `.github/workflows/release-drafter.yml`: strip trailing whitespace from release body before inserting into CHANGELOG
- `CHANGELOG.md`: remove existing double blank line at line 30

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues