### PR TITLE
fix: surface github import errors and add GITHUB_TOKEN to production env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,8 @@ GITHUB_CLIENT_SECRET=your-github-client-secret
 # Create a fine-grained token with read-only access to public repositories:
 # https://github.com/settings/tokens
 # GITHUB_TOKEN=github_pat_...
+# In production (deploy.yml), this is sourced from the POLARIS_GITHUB_TOKEN GitHub Actions secret
+# to avoid collision with the Actions-injected GITHUB_TOKEN reserved variable.
 
 # Auth Origin (optional - auto-detected for Gitpod)
 # For local development: http://localhost:3000/api/auth (default)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -164,6 +164,7 @@ jobs:
             GITHUB_CLIENT_SECRET=${{ secrets.OAUTH_CLIENT_SECRET }}
             SUPERUSER_EMAILS=${{ secrets.SUPERUSER_EMAILS }}
             DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}
+            GITHUB_TOKEN=${{ secrets.POLARIS_GITHUB_TOKEN }}
             ENV
 
             chmod 600 /opt/polaris/.env

--- a/server/api/admin/import/github.post.ts
+++ b/server/api/admin/import/github.post.ts
@@ -111,9 +111,10 @@ export default defineEventHandler(async (event) => {
       message.includes('authentication failed') ||
       message.includes('access denied')
     ) {
-      throw createError({ statusCode: 422, message })
+      throw createError({ statusCode: 422, statusMessage: message, message })
     }
 
-    throw createError({ statusCode: 500, message })
+    // Use statusMessage so Nuxt preserves the message in production (500 message is sanitised by default)
+    throw createError({ statusCode: 500, statusMessage: message, message })
   }
 })


### PR DESCRIPTION
## Description

Two issues preventing diagnosis and resolution of the 500 error on the GitHub import endpoint.

**Issue 1 — Error message swallowed in production**
Nuxt sanitises 5xx `statusMessage` to `"Server Error"` in production mode for security. The import handler was using only `message` on `createError`, which Nuxt also overrides for 500s. Setting `statusMessage` explicitly preserves the actual error in the response body, making it possible to diagnose failures from the client side without needing server log access.

**Issue 2 — `GITHUB_TOKEN` not deployed to production**
The deploy workflow was not writing `GITHUB_TOKEN` to the production `.env`. Without it, GitHub API calls are unauthenticated (60 req/hr limit per IP). On a shared IP this limit is easily hit, causing 403 responses from GitHub that would surface as 500s before this fix.

`POLARIS_GITHUB_TOKEN` is used as the GitHub Actions secret name to avoid collision with the Actions-reserved `GITHUB_TOKEN` variable, which cannot be stored as a custom secret.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- `server/api/admin/import/github.post.ts`: set `statusMessage` on all `createError` calls so the actual message is preserved in production responses
- `.github/workflows/deploy.yml`: write `GITHUB_TOKEN=${{ secrets.POLARIS_GITHUB_TOKEN }}` to the production `.env`
- `.env.example`: document the `POLARIS_GITHUB_TOKEN` secret name convention

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues

## Additional Notes

**Required action before deploying:** Add a `POLARIS_GITHUB_TOKEN` GitHub Actions secret — a fine-grained PAT with read-only access to public repositories is sufficient.

After deploying, retry the import. The response will now include the actual error message, which will identify the root cause if the 500 persists.