### PR TITLE
fix: move dozzle data dir to /opt/polaris/dozzle to avoid permission error

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -114,7 +114,7 @@ jobs:
                 restart: unless-stopped
                 volumes:
                   - /var/run/docker.sock:/var/run/docker.sock:ro
-                  - /opt/polaris/data/dozzle:/data
+                  - /opt/polaris/dozzle:/data
                 environment:
                   DOZZLE_NO_ANALYTICS: "true"
                   DOZZLE_AUTH_PROVIDER: simple
@@ -169,12 +169,12 @@ jobs:
             chmod 600 /opt/polaris/.env
 
             # Generate Dozzle users.yml using the official generate command
-            mkdir -p /opt/polaris/data/dozzle
+            mkdir -p /opt/polaris/dozzle
             docker run --rm amir20/dozzle generate ${{ secrets.DOZZLE_USER }} \
               --password '${{ secrets.DOZZLE_PASSWORD }}' \
               --name '${{ secrets.DOZZLE_USER }}' \
-              > /opt/polaris/data/dozzle/users.yml
-            chmod 600 /opt/polaris/data/dozzle/users.yml
+              > /opt/polaris/dozzle/users.yml
+            chmod 600 /opt/polaris/dozzle/users.yml
 
             cd /opt/polaris
 

--- a/infra/ansible/playbook.yml
+++ b/infra/ansible/playbook.yml
@@ -98,6 +98,14 @@
         group: "{{ polaris_user }}"
         mode: "0750"
 
+    - name: Create data directory owned by polaris
+      file:
+        path: "{{ polaris_dir }}/data"
+        state: directory
+        owner: "{{ polaris_user }}"
+        group: "{{ polaris_user }}"
+        mode: "0750"
+
     - name: Create Neo4j data directories
       file:
         path: "{{ item }}"
@@ -110,6 +118,14 @@
         - "{{ polaris_dir }}/data/neo4j/logs"
         - "{{ polaris_dir }}/data/neo4j/import"
         - "{{ polaris_dir }}/data/neo4j/plugins"
+
+    - name: Create Dozzle data directory
+      file:
+        path: "{{ polaris_dir }}/dozzle"
+        state: directory
+        owner: "{{ polaris_user }}"
+        group: "{{ polaris_user }}"
+        mode: "0750"
 
     - name: Create polaris SSH directory
       file:

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -45,8 +45,10 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
-      - app
-      - dozzle
+      app:
+        condition: service_started
+      dozzle:
+        condition: service_healthy
     networks:
       - polaris-net
 
@@ -55,8 +57,16 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - /opt/polaris/dozzle:/data
     environment:
       DOZZLE_NO_ANALYTICS: "true"
+      DOZZLE_AUTH_PROVIDER: simple
+    healthcheck:
+      test: ["CMD", "/dozzle", "healthcheck"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     networks:
       - polaris-net
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -68,7 +68,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /opt/polaris/data/dozzle:/data
+      - /opt/polaris/dozzle:/data
     environment:
       DOZZLE_NO_ANALYTICS: "true"
       DOZZLE_AUTH_PROVIDER: simple


### PR DESCRIPTION
## Description

The deploy was failing with `mkdir: cannot create directory '/opt/polaris/data': Permission denied`.

`/opt/polaris/data` is owned by uid `7474` (Neo4j) because the Ansible playbook creates the Neo4j subdirectories with that owner. The `polaris` SSH user cannot create new directories inside it, so `mkdir -p /opt/polaris/data/dozzle` fails.

The fix moves the dozzle data volume to `/opt/polaris/dozzle` — directly under `/opt/polaris`, which is owned by the `polaris` user. The Ansible playbook is also updated to create this directory on fresh server provisioning, and the Ansible compose template is synced with the current dozzle service definition (healthcheck, auth provider, volume mount).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- `deploy.yml`: `mkdir /opt/polaris/dozzle` instead of `/opt/polaris/data/dozzle`; update volume mount in inlined compose
- `infra/docker-compose.yml`: update dozzle volume mount to `/opt/polaris/dozzle:/data`
- `infra/ansible/playbook.yml`: add task to create `/opt/polaris/data` owned by `polaris`; add task to create `/opt/polaris/dozzle` owned by `polaris`
- `infra/ansible/templates/docker-compose.yml.j2`: sync dozzle service with current state (healthcheck, auth provider, volume, caddy depends_on)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors

## Additional Notes

**To unblock the current server without re-running Ansible**, run once as root:

```bash
mkdir -p /opt/polaris/dozzle && chown polaris:polaris /opt/polaris/dozzle
```

Then re-trigger the deploy from the GitHub Actions UI.