### PR TITLE
fix: move tsx and @cyclonedx/cdxgen to production dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.27...v0.1.28
 
-
 ## [0.1.23] - 2026-04-23
 
 ## What's Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
+        "@cyclonedx/cdxgen": "^12.2.0",
         "@nuxt/eslint": "^1.13.0",
         "@nuxt/image": "^2.0.0",
         "@nuxt/test-utils": "^4.0.2",
@@ -25,6 +26,7 @@
         "spdx-expression-parse": "^4.0.0",
         "spdx-license-list": "^6.11.0",
         "tailwindcss": "^4.2.4",
+        "tsx": "^4.21.0",
         "typescript": "^6.0.3",
         "vue": "^3.5.33"
       },
@@ -33,7 +35,6 @@
         "@cucumber/cucumber": "^12.8.1",
         "@cucumber/gherkin": "^39.0.0",
         "@cucumber/messages": "^32.3.1",
-        "@cyclonedx/cdxgen": "^12.2.0",
         "@iconify-json/lucide": "^1.2.102",
         "@playwright/test": "^1.59.1",
         "@types/node": "^25.6.0",
@@ -44,7 +45,6 @@
         "markdownlint-cli": "^0.48.0",
         "patch-package": "^8.0.1",
         "swagger-jsdoc": "^6.2.8",
-        "tsx": "^4.21.0",
         "vitest": "^4.1.5"
       }
     },
@@ -144,7 +144,6 @@
     },
     "node_modules/@appthreat/atom": {
       "version": "2.5.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -159,7 +158,6 @@
     },
     "node_modules/@appthreat/atom-common": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -167,7 +165,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/@appthreat/atom-parsetools/-/atom-parsetools-1.1.4.tgz",
       "integrity": "sha512-BpIIdCH1gaWuFNWNzguyHqk/LUepgHIU6q55xtHGLbiIKpbBmgD9w2XcnTea3DqPMOs1ZyqBCSA2R7Gp2UkFKg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -191,7 +188,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -208,7 +204,6 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "dependencies": {
@@ -224,7 +219,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -243,7 +237,6 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -263,7 +256,6 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "license": "ISC",
       "optional": true,
       "engines": {
@@ -274,7 +266,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@appthreat/cdx-proto/-/cdx-proto-1.3.0.tgz",
       "integrity": "sha512-O9vUzzwY/ZgMhlNf7558RTv8nVNoiG39ZHr5vcfA5QE/8oZnkmA/PlIpsw66qisJU5yEK4BJZoFMviydwccg2A==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -680,7 +671,6 @@
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.11.0.tgz",
       "integrity": "sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==",
-      "dev": true,
       "license": "(Apache-2.0 AND BSD-3-Clause)",
       "optional": true
     },
@@ -699,7 +689,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true
     },
@@ -710,7 +699,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -724,7 +712,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -736,7 +723,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -750,7 +736,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -764,7 +749,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -778,7 +762,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -792,7 +775,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -806,7 +788,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -820,7 +801,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -834,7 +814,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1145,7 +1124,6 @@
       "version": "12.2.1",
       "resolved": "https://registry.npmjs.org/@cyclonedx/cdxgen/-/cdxgen-12.2.1.tgz",
       "integrity": "sha512-Omk8tVH29a4S50yDyX45IjmbvwkNk57CezIQi00+vUobNB8A1KWlHoAGKsvDGKW/3lofBBBcuCB7GXvL1zPT3A==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/parser": "7.29.2",
@@ -1891,7 +1869,6 @@
     },
     "node_modules/@gar/promise-retry": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -1939,7 +1916,6 @@
     },
     "node_modules/@iarna/toml": {
       "version": "2.2.5",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@iconify-json/lucide": {
@@ -2557,7 +2533,6 @@
     },
     "node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@jridgewell/gen-mapping": {
@@ -2610,7 +2585,6 @@
     },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@kwsites/file-exists": {
@@ -2699,7 +2673,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-5.0.0.tgz",
       "integrity": "sha512-7OsC1gNORBEawOa5+j2pXN9vsicaIOH5cPXxoR6fJOmH6/EXpJB2CajXOu1fPRFun2m1lktEFX11+P89hqO/og==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "semver": "^7.3.5"
@@ -2710,7 +2683,6 @@
     },
     "node_modules/@npmcli/git": {
       "version": "7.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
@@ -2728,7 +2700,6 @@
     },
     "node_modules/@npmcli/map-workspaces": {
       "version": "5.0.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/name-from-folder": "^4.0.0",
@@ -2742,7 +2713,6 @@
     },
     "node_modules/@npmcli/name-from-folder": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -2750,7 +2720,6 @@
     },
     "node_modules/@npmcli/package-json": {
       "version": "7.0.5",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^7.0.0",
@@ -2767,7 +2736,6 @@
     },
     "node_modules/@npmcli/promise-spawn": {
       "version": "9.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "which": "^6.0.0"
@@ -5474,7 +5442,6 @@
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sidebase/nuxt-auth": {
@@ -6681,7 +6648,6 @@
     },
     "node_modules/@types/http-cache-semantics": {
       "version": "4.2.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -7869,7 +7835,6 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -8281,7 +8246,6 @@
     },
     "node_modules/bin-links": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cmd-shim": "^8.0.0",
@@ -8310,7 +8274,6 @@
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8458,7 +8421,6 @@
     },
     "node_modules/byte-counter": {
       "version": "0.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -8469,7 +8431,6 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -8511,7 +8472,6 @@
     },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -8519,7 +8479,6 @@
     },
     "node_modules/cacheable-request": {
       "version": "13.0.18",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "^4.0.4",
@@ -8536,7 +8495,6 @@
     },
     "node_modules/cacheable-request/node_modules/get-stream": {
       "version": "9.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
@@ -8551,7 +8509,6 @@
     },
     "node_modules/cacheable-request/node_modules/is-stream": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8579,7 +8536,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8591,7 +8548,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -8741,7 +8698,6 @@
     },
     "node_modules/cheerio": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -8765,7 +8721,6 @@
     },
     "node_modules/cheerio-select": {
       "version": "2.1.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -8942,7 +8897,6 @@
     },
     "node_modules/cmd-shim": {
       "version": "8.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -8988,7 +8942,6 @@
     },
     "node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/commondir": {
@@ -9015,7 +8968,6 @@
     },
     "node_modules/compressible": {
       "version": "2.0.18",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9027,7 +8979,6 @@
     },
     "node_modules/compression": {
       "version": "1.8.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9045,7 +8996,6 @@
     },
     "node_modules/compression/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9054,7 +9004,6 @@
     },
     "node_modules/compression/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9069,7 +9018,6 @@
     },
     "node_modules/connect": {
       "version": "3.7.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9084,7 +9032,6 @@
     },
     "node_modules/connect/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -9093,7 +9040,6 @@
     },
     "node_modules/connect/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9106,7 +9052,6 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -9888,7 +9833,6 @@
     },
     "node_modules/decompress-response": {
       "version": "10.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^4.0.0"
@@ -10142,7 +10086,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -10163,7 +10107,6 @@
     },
     "node_modules/edn-data": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -10253,7 +10196,6 @@
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -10262,7 +10204,6 @@
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "^0.6.3",
@@ -10274,7 +10215,6 @@
     },
     "node_modules/encoding-sniffer/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -10325,7 +10265,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10333,7 +10273,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10345,7 +10285,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -11175,7 +11115,6 @@
     },
     "node_modules/finalhandler": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11193,7 +11132,6 @@
     },
     "node_modules/finalhandler/node_modules/debug": {
       "version": "2.6.9",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11202,13 +11140,11 @@
     },
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/finalhandler/node_modules/on-finished": {
       "version": "2.3.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11357,7 +11293,6 @@
     },
     "node_modules/form-data-encoder": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -11486,7 +11421,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -11513,7 +11448,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -11667,7 +11602,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11678,7 +11613,6 @@
     },
     "node_modules/got": {
       "version": "14.6.6",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^7.0.1",
@@ -11794,7 +11728,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11817,7 +11751,6 @@
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.34.0.tgz",
       "integrity": "sha512-6qLylexjmuKa/YYhMiNn/3VejBsdzwmYUGmNpc693/pJzymmbufhkRW/2K6GqFgu0ApRWoqF0NbM6u82jFcOXA==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -11825,7 +11758,6 @@
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.34.0.tgz",
       "integrity": "sha512-tcgan5UNZvu3WwmR3jDAlmwEAR2CMv8cwQVMe5j0NrLQkstf0l3ULbYPuTZWbXxbPa0PyZPiq5LYEcFVmhM9LQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -11842,7 +11774,6 @@
     },
     "node_modules/hosted-git-info": {
       "version": "9.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -11872,7 +11803,6 @@
     },
     "node_modules/htmlparser2": {
       "version": "10.1.0",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -11890,7 +11820,6 @@
     },
     "node_modules/htmlparser2/node_modules/entities": {
       "version": "7.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -11901,7 +11830,6 @@
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
-      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
@@ -11939,7 +11867,6 @@
     },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
@@ -11973,7 +11900,6 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -12067,7 +11993,6 @@
     },
     "node_modules/ini": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -12460,7 +12385,6 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "5.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -12502,7 +12426,6 @@
     },
     "node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
       "license": "ISC",
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -12520,7 +12443,6 @@
     },
     "node_modules/jsonata": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12561,12 +12483,10 @@
     },
     "node_modules/just-diff": {
       "version": "6.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/katex": {
@@ -12592,7 +12512,6 @@
     },
     "node_modules/keyv": {
       "version": "5.6.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -13110,7 +13029,6 @@
     },
     "node_modules/lowercase-keys": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -13319,7 +13237,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -13335,7 +13253,6 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -13954,7 +13871,6 @@
     },
     "node_modules/mimic-response": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -14003,7 +13919,6 @@
     },
     "node_modules/mkdirp": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "mkdirp": "dist/cjs/src/bin.js"
@@ -14131,7 +14046,6 @@
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14403,7 +14317,6 @@
     },
     "node_modules/node-stream-zip": {
       "version": "1.15.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -14448,7 +14361,6 @@
     },
     "node_modules/normalize-url": {
       "version": "8.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -14459,7 +14371,6 @@
     },
     "node_modules/npm-install-checks": {
       "version": "8.0.0",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "semver": "^7.1.1"
@@ -14470,7 +14381,6 @@
     },
     "node_modules/npm-normalize-package-bin": {
       "version": "5.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -14478,7 +14388,6 @@
     },
     "node_modules/npm-package-arg": {
       "version": "13.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "hosted-git-info": "^9.0.0",
@@ -14492,7 +14401,6 @@
     },
     "node_modules/npm-pick-manifest": {
       "version": "11.0.3",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "npm-install-checks": "^8.0.0",
@@ -14825,7 +14733,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -14893,7 +14800,6 @@
     },
     "node_modules/on-headers": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -15093,7 +14999,6 @@
     },
     "node_modules/p-cancelable": {
       "version": "4.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -15135,7 +15040,6 @@
     },
     "node_modules/packageurl-js": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/pad-right": {
@@ -15151,7 +15055,6 @@
     },
     "node_modules/parse-conflict-json": {
       "version": "5.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "json-parse-even-better-errors": "^5.0.0",
@@ -15209,7 +15112,6 @@
     },
     "node_modules/parse5": {
       "version": "7.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -15220,7 +15122,6 @@
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "7.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "domhandler": "^5.0.3",
@@ -15232,7 +15133,6 @@
     },
     "node_modules/parse5-parser-stream": {
       "version": "7.1.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.0.0"
@@ -15243,7 +15143,6 @@
     },
     "node_modules/parse5/node_modules/entities": {
       "version": "6.0.1",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -15892,7 +15791,6 @@
     },
     "node_modules/proc-log": {
       "version": "6.1.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -15919,7 +15817,6 @@
     },
     "node_modules/properties-reader": {
       "version": "3.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -16113,7 +16010,6 @@
     },
     "node_modules/qs": {
       "version": "6.15.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "optional": true,
       "dependencies": {
@@ -16160,7 +16056,6 @@
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -16182,7 +16077,6 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16205,7 +16099,6 @@
     },
     "node_modules/read-cmd-shim": {
       "version": "6.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -16213,7 +16106,6 @@
     },
     "node_modules/read-package-json-fast": {
       "version": "5.0.0",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "json-parse-even-better-errors": "^5.0.0",
@@ -16454,7 +16346,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -16502,7 +16393,6 @@
     },
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve-from": {
@@ -16521,7 +16411,6 @@
     },
     "node_modules/responselike": {
       "version": "4.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^3.0.0"
@@ -16952,7 +16841,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16971,7 +16859,6 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -16987,7 +16874,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17005,7 +16891,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17185,7 +17070,6 @@
       "version": "13.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-13.0.1.tgz",
       "integrity": "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^7.0.3"
@@ -17217,7 +17101,6 @@
     },
     "node_modules/statuses": {
       "version": "1.5.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -17765,7 +17648,6 @@
     },
     "node_modules/treeverse": {
       "version": "3.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -17803,7 +17685,6 @@
     },
     "node_modules/tsx": {
       "version": "4.21.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.27.0",
@@ -17823,7 +17704,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17846,7 +17726,6 @@
     },
     "node_modules/type-fest": {
       "version": "4.41.0",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"
@@ -17857,7 +17736,6 @@
     },
     "node_modules/type-is": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -17927,7 +17805,6 @@
     },
     "node_modules/undici": {
       "version": "7.24.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -18032,7 +17909,6 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -18384,7 +18260,6 @@
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -18393,7 +18268,6 @@
     },
     "node_modules/uuid": {
       "version": "13.0.0",
-      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -18423,7 +18297,6 @@
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -18439,7 +18312,6 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -19106,7 +18978,6 @@
     },
     "node_modules/walk-up-path": {
       "version": "4.0.0",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "20 || >=22"
@@ -19122,7 +18993,6 @@
     },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
@@ -19133,7 +19003,6 @@
     },
     "node_modules/whatwg-encoding/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -19144,7 +19013,6 @@
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -19303,7 +19171,6 @@
     },
     "node_modules/write-file-atomic": {
       "version": "7.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "signal-exit": "^4.0.1"
@@ -19360,7 +19227,6 @@
     },
     "node_modules/xml-js": {
       "version": "1.6.11",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "sax": "^1.2.4"
@@ -19509,7 +19375,6 @@
     },
     "node_modules/yoctocolors": {
       "version": "2.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "spdx-license-list": "^6.11.0",
     "tailwindcss": "^4.2.4",
     "typescript": "^6.0.3",
+    "tsx": "^4.21.0",
+    "@cyclonedx/cdxgen": "^12.2.0",
     "vue": "^3.5.33"
   },
   "devDependencies": {
@@ -87,7 +89,6 @@
     "@cucumber/cucumber": "^12.8.1",
     "@cucumber/gherkin": "^39.0.0",
     "@cucumber/messages": "^32.3.1",
-    "@cyclonedx/cdxgen": "^12.2.0",
     "@iconify-json/lucide": "^1.2.102",
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
@@ -98,7 +99,6 @@
     "markdownlint-cli": "^0.48.0",
     "patch-package": "^8.0.1",
     "swagger-jsdoc": "^6.2.8",
-    "tsx": "^4.21.0",
     "vitest": "^4.1.5"
   }
 }


### PR DESCRIPTION
## Description

Two packages were in `devDependencies` but are required at runtime in production images:

- **`tsx`** — used by the migrator image to execute `schema/scripts/migrate.ts`. With `npm ci --omit=dev`, `tsx` was absent, causing `sh: tsx: not found` and exit code 127 on every migration run.
- **`@cyclonedx/cdxgen`** — imported by `server/services/github-import.service.ts` at runtime for SBOM generation during GitHub imports. Also absent from the production app image, causing the GitHub import endpoint to fail.

Both are moved to `dependencies` so they are included in `npm ci --omit=dev` builds.

Also fixes the recurring CHANGELOG double blank line introduced by the release drafter (the `.strip()` fix in the release script only applies to future releases; existing entries need a one-time correction).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- `package.json`: move `tsx` and `@cyclonedx/cdxgen` from `devDependencies` to `dependencies`
- `package-lock.json`: regenerated
- `CHANGELOG.md`: remove double blank line

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues