### PR TITLE
fix: include cdxgen data files in production image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.27...v0.1.28
 
-
 ## [0.1.23] - 2026-04-23
 
 ## What's Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,9 @@ COPY --from=builder /app/.output ./output
 # process.cwd() is /app (WORKDIR), so copy files to match the expected paths.
 COPY --from=builder /app/server/database/queries ./server/database/queries
 COPY --from=builder /app/server/schemas ./server/schemas
+# cdxgen reads data files relative to its own location at runtime.
+# Nitro externalises the package but does not copy non-JS assets, so copy manually.
+COPY --from=builder /app/node_modules/@cyclonedx/cdxgen/data ./output/server/node_modules/@cyclonedx/cdxgen/data
 
 ENV NODE_ENV=production
 ENV HOST=0.0.0.0

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -65,4 +65,13 @@ export default defineNuxtConfig({
     }
   },
 
+  nitro: {
+    // Keep @cyclonedx/cdxgen as an external module so Nitro does not bundle it.
+    // cdxgen reads data files (JSON mappings) relative to its own location at
+    // runtime — bundling strips those files and causes ENOENT errors in production.
+    externals: {
+      external: ['@cyclonedx/cdxgen']
+    }
+  }
+
 })


### PR DESCRIPTION
## Description

The GitHub import endpoint was failing with:

```
ENOENT: no such file or directory,
open '/app/output/server/node_modules/@cyclonedx/cdxgen/data/lic-mapping.json'
```

`@cyclonedx/cdxgen` reads JSON mapping files (license mappings, known licenses, framework lists, etc.) relative to its own install location at runtime. Nitro bundles the JS files from `node_modules` into `.output/server/` but does not copy non-JS assets, so the `data/` directory is absent in the production image.

**Fix:**
1. Mark `@cyclonedx/cdxgen` as a Nitro external in `nuxt.config.ts` so it is not inlined into the bundle and keeps its `node_modules` directory structure in the output.
2. Explicitly copy the `data/` directory from the builder stage into the runner image at the path Nitro places externals: `output/server/node_modules/@cyclonedx/cdxgen/data`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- `nuxt.config.ts`: add `nitro.externals.external: ['@cyclonedx/cdxgen']`
- `Dockerfile`: copy `node_modules/@cyclonedx/cdxgen/data` into the runner image
- `CHANGELOG.md`: fix recurring double blank line

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues