### PR TITLE
fix: replace deprecated Neo4j dbms.memory settings with server.memory equivalents

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -15,8 +15,8 @@ services:
       NEO4J_AUTH: neo4j/devpassword
       NEO4J_PLUGINS: '["apoc"]'
       NEO4J_dbms_security_procedures_unrestricted: apoc.*
-      NEO4J_dbms_memory_heap_initial__size: 512m
-      NEO4J_dbms_memory_heap_max__size: 2G
+      NEO4J_server_memory_heap_initial__size: 512m
+      NEO4J_server_memory_heap_max__size: 2G
     volumes:
       - ../.data/neo4j/data:/data
       - ../.data/neo4j/logs:/logs

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -17,8 +17,8 @@ services:
       NEO4J_AUTH: neo4j/$${NEO4J_PASSWORD}
       NEO4J_PLUGINS: '["apoc"]'
       NEO4J_dbms_security_procedures_unrestricted: apoc.*
-      NEO4J_dbms_memory_heap_initial__size: 512m
-      NEO4J_dbms_memory_heap_max__size: 2G
+      NEO4J_server_memory_heap_initial__size: 512m
+      NEO4J_server_memory_heap_max__size: 2G
     volumes:
       - /opt/polaris/data/neo4j/data:/data
       - /opt/polaris/data/neo4j/logs:/logs

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       NEO4J_AUTH: neo4j/${NEO4J_PASSWORD}
       NEO4J_PLUGINS: '["apoc"]'
       NEO4J_dbms_security_procedures_unrestricted: apoc.*
-      NEO4J_dbms_memory_heap_initial__size: 256m
-      NEO4J_dbms_memory_heap_max__size: 512m
-      NEO4J_dbms_memory_pagecache_size: 256m
+      NEO4J_server_memory_heap_initial__size: 256m
+      NEO4J_server_memory_heap_max__size: 512m
+      NEO4J_server_memory_pagecache__size: 256m
     volumes:
       - /opt/polaris/data/neo4j/data:/data
       - /opt/polaris/data/neo4j/logs:/logs


### PR DESCRIPTION
## Description

Replace deprecated `dbms.memory.*` Neo4j environment variable names with their Neo4j 5 `server.memory.*` equivalents. This eliminates three deprecation warnings logged on every container start.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #346

## Changes Made

- `infra/docker-compose.yml`: rename heap initial/max and pagecache variables
- `infra/ansible/templates/docker-compose.yml.j2`: rename heap initial/max variables
- `.devcontainer/docker-compose.yml`: rename heap initial/max variables (consistency)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues

## Additional Notes

The pagecache key also required a double-underscore before `size` (`pagecache__size`) to correctly encode the dot in `server.memory.pagecache.size` per Neo4j's env-var naming convention.