### PR TITLE
feat: populate AuditLog changes map with field-level before/after diffs

### DIFF
--- a/app/pages/audit.vue
+++ b/app/pages/audit.vue
@@ -94,6 +94,11 @@ definePageMeta({ middleware: 'auth' })
 
 const { getSortableHeader } = useSortableTable()
 
+interface AuditChange {
+  before: unknown
+  after: unknown
+}
+
 interface AuditEntry {
   id: string
   entityType: string
@@ -103,6 +108,7 @@ interface AuditEntry {
   userId: string | null
   userName: string | null
   timestamp: string
+  changes: Record<string, AuditChange> | null
 }
 
 interface AuditResponse {
@@ -136,6 +142,11 @@ function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleString()
 }
 
+function formatChangeValue(val: unknown): string {
+  if (val === null || val === undefined) return '—'
+  return String(val)
+}
+
 const columns: TableColumn<AuditEntry>[] = [
   {
     accessorKey: 'operation',
@@ -159,6 +170,46 @@ const columns: TableColumn<AuditEntry>[] = [
     cell: ({ row }) => {
       const label = row.original.entityLabel || row.original.entityId
       return label || '—'
+    }
+  },
+  {
+    accessorKey: 'changes',
+    header: 'Changes',
+    cell: ({ row }) => {
+      const changes = row.original.changes
+      if (!changes || Object.keys(changes).length === 0) {
+        return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      }
+      const entries = Object.entries(changes)
+      const UPopover = resolveComponent('UPopover')
+      const UButton = resolveComponent('UButton')
+      return h(UPopover, {}, {
+        default: () => h(UButton, {
+          variant: 'ghost',
+          size: 'xs',
+          icon: 'i-lucide-diff',
+          label: `${entries.length} field${entries.length > 1 ? 's' : ''}`,
+          color: 'neutral',
+        }),
+        content: () => h('div', { class: 'p-3 min-w-64 max-w-sm' }, [
+          h('table', { class: 'w-full text-xs' }, [
+            h('thead', {}, [
+              h('tr', {}, [
+                h('th', { class: 'text-left pb-1 pr-3 font-medium text-(--ui-text-muted)' }, 'Field'),
+                h('th', { class: 'text-left pb-1 pr-3 font-medium text-(--ui-text-muted)' }, 'Before'),
+                h('th', { class: 'text-left pb-1 font-medium text-(--ui-text-muted)' }, 'After'),
+              ])
+            ]),
+            h('tbody', {}, entries.map(([field, change]) =>
+              h('tr', { key: field, class: 'border-t border-(--ui-border)' }, [
+                h('td', { class: 'py-1 pr-3 font-mono font-medium' }, field),
+                h('td', { class: 'py-1 pr-3 text-(--ui-text-muted) line-through' }, formatChangeValue(change.before)),
+                h('td', { class: 'py-1 text-(--ui-text-highlighted)' }, formatChangeValue(change.after)),
+              ])
+            ))
+          ])
+        ])
+      })
     }
   },
   {

--- a/server/api/systems/[name].patch.ts
+++ b/server/api/systems/[name].patch.ts
@@ -55,6 +55,8 @@
  *       422:
  *         description: Validation error - invalid field values
  */
+import { buildAuditChanges } from '../../utils/audit-diff'
+
 export default defineEventHandler(async (event) => {
   const user = await requireAuthorization(event)
   
@@ -104,10 +106,25 @@ export default defineEventHandler(async (event) => {
   }
 
   const driver = useDriver()
+
+  // Fetch current state before writing so we can diff it
+  const { records: currentRecords } = await driver.executeQuery(`
+    MATCH (s:System {name: $name})
+    RETURN s { .description, .domain, .businessCriticality, .environment } as props
+  `, { name })
+
+  if (currentRecords.length === 0) {
+    throw createError({
+      statusCode: 404,
+      message: `System '${name}' not found`
+    })
+  }
+
+  const currentProps = currentRecords[0]!.get('props') as Record<string, unknown>
   
   // Build dynamic SET clause based on provided fields
   const updates: string[] = []
-  const params: Record<string, string> = { name }
+  const params: Record<string, unknown> = { name }
 
   if (body.description !== undefined) {
     updates.push('s.description = $description')
@@ -127,7 +144,16 @@ export default defineEventHandler(async (event) => {
   }
 
   const changedFields = updates.map(u => u.split(' = ')[0]!.replace('s.', ''))
+
+  // Build the incoming state from only the fields being updated
+  const incomingState: Record<string, unknown> = {}
+  for (const field of changedFields) {
+    incomingState[field] = params[field]
+  }
+  const changes = buildAuditChanges(currentProps, incomingState, changedFields)
+
   params.userId = user.id
+  params.changes = JSON.stringify(changes)
 
   const query = `
     MATCH (s:System {name: $name})
@@ -141,6 +167,7 @@ export default defineEventHandler(async (event) => {
       entityId: s.name,
       entityLabel: s.name,
       changedFields: ${JSON.stringify(changedFields)},
+      changes: $changes,
       source: 'API',
       userId: $userId
     })

--- a/server/api/systems/[name].put.ts
+++ b/server/api/systems/[name].put.ts
@@ -66,6 +66,8 @@
  *       422:
  *         description: Validation error - invalid field values
  */
+import { buildAuditChanges } from '../../utils/audit-diff'
+
 export default defineEventHandler(async (event) => {
   const user = await requireAuthorization(event)
   
@@ -125,6 +127,33 @@ export default defineEventHandler(async (event) => {
     })
   }
   
+  // Fetch current state before writing so we can diff it
+  const { records: currentRecords } = await driver.executeQuery(`
+    MATCH (s:System {name: $name})
+    RETURN s {
+      .domain, .businessCriticality, .environment, .description,
+      ownerTeam: [(s)<-[:OWNS]-(t:Team) | t.name][0]
+    } as props
+  `, { name })
+
+  if (currentRecords.length === 0) {
+    throw createError({
+      statusCode: 404,
+      message: `System '${name}' not found`
+    })
+  }
+
+  const currentProps = currentRecords[0]!.get('props') as Record<string, unknown>
+  const incomingProps: Record<string, unknown> = {
+    domain: body.domain,
+    ownerTeam: body.ownerTeam,
+    businessCriticality: body.businessCriticality,
+    environment: body.environment,
+    description: body.description || null,
+  }
+  const allFields = ['domain', 'ownerTeam', 'businessCriticality', 'environment', 'description']
+  const changes = JSON.stringify(buildAuditChanges(currentProps, incomingProps, allFields))
+
   // Replace entire resource
   const { records } = await driver.executeQuery(`
     MATCH (s:System {name: $name})
@@ -152,6 +181,7 @@ export default defineEventHandler(async (event) => {
       entityId: s.name,
       entityLabel: s.name,
       changedFields: ['domain', 'ownerTeam', 'businessCriticality', 'environment', 'description'],
+      changes: $changes,
       source: 'API',
       userId: $userId
     })
@@ -168,7 +198,8 @@ export default defineEventHandler(async (event) => {
     businessCriticality: body.businessCriticality,
     environment: body.environment,
     description: body.description || null,
-    userId: user.id
+    userId: user.id,
+    changes,
   })
   
   if (records.length === 0) {

--- a/server/database/queries/systems/create.cypher
+++ b/server/database/queries/systems/create.cypher
@@ -29,6 +29,7 @@ CREATE (a:AuditLog {
   entityId: s.name,
   entityLabel: s.name,
   changedFields: ['name', 'domain', 'businessCriticality', 'environment'],
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/database/queries/systems/delete.cypher
+++ b/server/database/queries/systems/delete.cypher
@@ -7,6 +7,7 @@ CREATE (a:AuditLog {
   entityId: s.name,
   entityLabel: s.name,
   changedFields: [],
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/database/queries/teams/create.cypher
+++ b/server/database/queries/teams/create.cypher
@@ -12,6 +12,7 @@ CREATE (a:AuditLog {
   entityId: t.name,
   entityLabel: t.name,
   changedFields: ['name', 'email', 'responsibilityArea'],
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/database/queries/teams/delete.cypher
+++ b/server/database/queries/teams/delete.cypher
@@ -7,6 +7,7 @@ CREATE (a:AuditLog {
   entityId: t.name,
   entityLabel: t.name,
   changedFields: [],
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/database/queries/teams/update.cypher
+++ b/server/database/queries/teams/update.cypher
@@ -11,6 +11,7 @@ CREATE (a:AuditLog {
   entityId: t.name,
   entityLabel: t.name,
   changedFields: $changedFields,
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/database/queries/technologies/create.cypher
+++ b/server/database/queries/technologies/create.cypher
@@ -28,6 +28,7 @@ CREATE (a:AuditLog {
   entityId: t.name,
   entityLabel: t.name,
   changedFields: ['name', 'type', 'domain', 'vendor'],
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/database/queries/technologies/delete.cypher
+++ b/server/database/queries/technologies/delete.cypher
@@ -7,6 +7,7 @@ CREATE (a:AuditLog {
   entityId: t.name,
   entityLabel: t.name,
   changedFields: [],
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/database/queries/technologies/update.cypher
+++ b/server/database/queries/technologies/update.cypher
@@ -27,6 +27,7 @@ CREATE (a:AuditLog {
   entityId: t.name,
   entityLabel: t.name,
   changedFields: ['type', 'domain', 'vendor', 'ownerTeam', 'lastReviewed'],
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/database/queries/technologies/upsert-approval.cypher
+++ b/server/database/queries/technologies/upsert-approval.cypher
@@ -14,6 +14,7 @@ CREATE (al:AuditLog {
   entityId: t.name,
   entityLabel: team.name + ' -> ' + t.name + ' (' + $time + ')',
   changedFields: ['time', 'notes'],
+  changes: $changes,
   source: 'API',
   userId: $userId
 })

--- a/server/repositories/audit-log.repository.ts
+++ b/server/repositories/audit-log.repository.ts
@@ -24,6 +24,7 @@ export interface AuditLog {
   previousStatus: string | null
   newStatus: string | null
   changedFields: string[]
+  changes: Record<string, { before: unknown; after: unknown }> | null
   reason: string | null
   source: string
   userId: string | null
@@ -151,6 +152,12 @@ export class AuditLogRepository extends BaseRepository {
 
   private mapToAuditLog(record: Neo4jRecord): AuditLog {
     const a = record.get('a')
+    // changes is stored as a JSON string (Neo4j does not support nested maps as properties)
+    let changes: Record<string, { before: unknown; after: unknown }> | null = null
+    const raw = a.properties.changes
+    if (typeof raw === 'string' && raw.length > 0) {
+      try { changes = JSON.parse(raw) } catch { changes = null }
+    }
     return {
       id: a.properties.id,
       timestamp: a.properties.timestamp?.toString() || '',
@@ -161,6 +168,7 @@ export class AuditLogRepository extends BaseRepository {
       previousStatus: a.properties.previousStatus || null,
       newStatus: a.properties.newStatus || null,
       changedFields: a.properties.changedFields || [],
+      changes,
       reason: a.properties.reason || null,
       source: a.properties.source || '',
       userId: a.properties.userId || null,
@@ -177,6 +185,7 @@ export class AuditLogRepository extends BaseRepository {
     entityId: string
     entityLabel: string
     changedFields?: string[]
+    changes?: Record<string, { before: unknown; after: unknown }> | null
     source?: string
     userId: string
   }): Promise<void> {
@@ -189,6 +198,7 @@ export class AuditLogRepository extends BaseRepository {
         entityId: $entityId,
         entityLabel: $entityLabel,
         changedFields: $changedFields,
+        changes: $changes,
         source: $source,
         userId: $userId
       })
@@ -198,6 +208,7 @@ export class AuditLogRepository extends BaseRepository {
       entityId: params.entityId,
       entityLabel: params.entityLabel,
       changedFields: params.changedFields || [],
+      changes: params.changes ? JSON.stringify(params.changes) : null,
       source: params.source || 'API',
       userId: params.userId
     })

--- a/server/repositories/system.repository.ts
+++ b/server/repositories/system.repository.ts
@@ -2,6 +2,7 @@ import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
 import type { Repository } from '~~/types/api'
 import { buildOrderByClause, type SortParams, type SortConfig } from '../utils/sorting'
+import { buildCreateChanges } from '../utils/audit-diff'
 
 const systemSortConfig: SortConfig = {
   allowedFields: {
@@ -120,7 +121,13 @@ export class SystemRepository extends BaseRepository {
    */
   async create(params: CreateSystemParams): Promise<string> {
     const query = await loadQuery('systems/create.cypher')
-    const { records } = await this.executeQuery(query, params)
+    const changes = JSON.stringify(buildCreateChanges({
+      name: params.name,
+      domain: params.domain,
+      businessCriticality: params.businessCriticality,
+      environment: params.environment,
+    }))
+    const { records } = await this.executeQuery(query, { ...params, changes })
     
     if (records.length === 0) {
       throw new Error('Failed to create system')
@@ -134,9 +141,9 @@ export class SystemRepository extends BaseRepository {
    * 
    * @param name - System name
    */
-  async delete(name: string, userId: string): Promise<void> {
+  async delete(name: string, userId: string, changes: Record<string, { before: unknown; after: unknown }>): Promise<void> {
     const query = await loadQuery('systems/delete.cypher')
-    await this.executeQuery(query, { name, userId })
+    await this.executeQuery(query, { name, userId, changes: JSON.stringify(changes) })
   }
 
   /**

--- a/server/repositories/team.repository.ts
+++ b/server/repositories/team.repository.ts
@@ -1,6 +1,7 @@
 import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
 import { buildOrderByClause, type SortParams, type SortConfig } from '../utils/sorting'
+import { buildCreateChanges } from '../utils/audit-diff'
 
 const teamSortConfig: SortConfig = {
   allowedFields: {
@@ -186,7 +187,12 @@ export class TeamRepository extends BaseRepository {
     userId: string
   }): Promise<string> {
     const query = await loadQuery('teams/create.cypher')
-    const { records } = await this.executeQuery(query, params)
+    const changes = JSON.stringify(buildCreateChanges({
+      name: params.name,
+      email: params.email,
+      responsibilityArea: params.responsibilityArea,
+    }))
+    const { records } = await this.executeQuery(query, { ...params, changes })
     return records[0]!.get('name')
   }
 
@@ -202,10 +208,11 @@ export class TeamRepository extends BaseRepository {
     email: string | null
     responsibilityArea: string | null
     changedFields: string[]
+    changes: Record<string, { before: unknown; after: unknown }>
     userId: string
   }): Promise<string> {
     const query = await loadQuery('teams/update.cypher')
-    const { records } = await this.executeQuery(query, params)
+    const { records } = await this.executeQuery(query, { ...params, changes: JSON.stringify(params.changes) })
     if (records.length === 0) {
       throw new Error(`Team '${params.name}' not found`)
     }
@@ -243,9 +250,9 @@ export class TeamRepository extends BaseRepository {
    * 
    * @param name - Team name
    */
-  async delete(name: string, userId: string): Promise<void> {
+  async delete(name: string, userId: string, changes: Record<string, { before: unknown; after: unknown }>): Promise<void> {
     const query = await loadQuery('teams/delete.cypher')
-    await this.executeQuery(query, { name, userId })
+    await this.executeQuery(query, { name, userId, changes: JSON.stringify(changes) })
   }
 
   /**

--- a/server/repositories/technology.repository.ts
+++ b/server/repositories/technology.repository.ts
@@ -2,6 +2,7 @@ import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
 import type { Technology } from '~~/types/api'
 import { buildOrderByClause, type SortParams, type SortConfig } from '../utils/sorting'
+import { buildCreateChanges } from '../utils/audit-diff'
 
 const technologySortConfig: SortConfig = {
   allowedFields: {
@@ -131,6 +132,12 @@ export class TechnologyRepository extends BaseRepository {
    */
   async create(params: CreateTechnologyParams): Promise<string> {
     const query = await loadQuery('technologies/create.cypher')
+    const changes = JSON.stringify(buildCreateChanges({
+      name: params.name,
+      type: params.type,
+      domain: params.domain || null,
+      vendor: params.vendor || null,
+    }))
     const { records } = await this.executeQuery(query, {
       name: params.name,
       type: params.type,
@@ -139,7 +146,8 @@ export class TechnologyRepository extends BaseRepository {
       ownerTeam: params.ownerTeam || null,
       componentName: params.componentName || null,
       componentPackageManager: params.componentPackageManager || null,
-      userId: params.userId
+      userId: params.userId,
+      changes,
     })
 
     if (records.length === 0) {
@@ -166,18 +174,18 @@ export class TechnologyRepository extends BaseRepository {
     }
   }
 
-  async update(params: UpdateTechnologyParams): Promise<string> {
+  async update(params: UpdateTechnologyParams & { changes: Record<string, { before: unknown; after: unknown }> }): Promise<string> {
     const query = await loadQuery('technologies/update.cypher')
-    const { records } = await this.executeQuery(query, params)
+    const { records } = await this.executeQuery(query, { ...params, changes: JSON.stringify(params.changes) })
     if (records.length === 0) {
       throw createError({ statusCode: 404, message: `Technology '${params.name}' not found` })
     }
     return records[0]!.get('name')
   }
 
-  async delete(name: string, userId: string): Promise<void> {
+  async delete(name: string, userId: string, changes: Record<string, { before: unknown; after: unknown }>): Promise<void> {
     const query = await loadQuery('technologies/delete.cypher')
-    await this.executeQuery(query, { name, userId })
+    await this.executeQuery(query, { name, userId, changes: JSON.stringify(changes) })
   }
 
   /**
@@ -219,9 +227,25 @@ export class TechnologyRepository extends BaseRepository {
   /**
    * Create or update a team's APPROVES relationship on a technology
    */
-  async upsertApproval(params: UpsertApprovalParams): Promise<{ time: string; team: string }> {
+  /**
+   * Fetch the existing APPROVES relationship for a team→technology pair, if any.
+   */
+  async findExistingApproval(technologyName: string, teamName: string): Promise<{ time: string | null; notes: string | null } | null> {
+    const { records } = await this.executeQuery(`
+      MATCH (team:Team {name: $teamName})-[a:APPROVES]->(t:Technology {name: $technologyName})
+      RETURN a.time as time, a.notes as notes
+    `, { technologyName, teamName })
+
+    if (records.length === 0) return null
+    return {
+      time: records[0]!.get('time') ?? null,
+      notes: records[0]!.get('notes') ?? null,
+    }
+  }
+
+  async upsertApproval(params: UpsertApprovalParams & { changes: Record<string, { before: unknown; after: unknown }> }): Promise<{ time: string; team: string }> {
     const query = await loadQuery('technologies/upsert-approval.cypher')
-    const { records } = await this.executeQuery(query, params)
+    const { records } = await this.executeQuery(query, { ...params, changes: JSON.stringify(params.changes) })
 
     if (records.length === 0) {
       throw new Error('Failed to set approval — technology or team not found')

--- a/server/services/system.service.ts
+++ b/server/services/system.service.ts
@@ -4,6 +4,7 @@ import type { System, CreateSystemParams, RepositoryInput } from '../repositorie
 import type { Repository } from '~~/types/api'
 import { normalizeRepoUrl } from '../utils/repository'
 import type { SortParams } from '../utils/sorting'
+import { buildDeleteChanges } from '../utils/audit-diff'
 
 export interface CreateSystemInput {
   name: string
@@ -132,18 +133,25 @@ export class SystemService {
    * @throws Error if system not found
    */
   async delete(name: string, userId: string): Promise<void> {
-    // Business logic: check if system exists
-    const exists = await this.systemRepo.exists(name)
+    // Fetch current state to capture before-values for the audit log
+    const system = await this.systemRepo.findByName(name)
     
-    if (!exists) {
+    if (!system) {
       throw createError({
         statusCode: 404,
         message: `System '${name}' not found`
       })
     }
+
+    const changes = buildDeleteChanges({
+      name: system.name,
+      domain: system.domain,
+      businessCriticality: system.businessCriticality,
+      environment: system.environment,
+      ownerTeam: system.ownerTeam,
+    })
     
-    // Delete the system
-    await this.systemRepo.delete(name, userId)
+    await this.systemRepo.delete(name, userId, changes)
   }
 
   /**

--- a/server/services/team.service.ts
+++ b/server/services/team.service.ts
@@ -1,6 +1,7 @@
 import { TeamRepository } from '../repositories/team.repository'
 import type { Team, TeamApprovalsResult, TeamConstraintsResult, TeamUsageResult, ApprovalStatus } from '../repositories/team.repository'
 import type { SortParams } from '../utils/sorting'
+import { buildAuditChanges, buildDeleteChanges } from '../utils/audit-diff'
 
 /**
  * Service for team-related business logic
@@ -94,8 +95,8 @@ export class TeamService {
     responsibilityArea?: string | null
     userId: string
   }): Promise<string> {
-    const exists = await this.teamRepo.exists(input.name)
-    if (!exists) {
+    const current = await this.teamRepo.findByName(input.name)
+    if (!current) {
       throw createError({
         statusCode: 404,
         message: `Team '${input.name}' not found`
@@ -125,12 +126,25 @@ export class TeamService {
       })
     }
 
+    const before: Record<string, unknown> = {
+      name: current.name,
+      email: current.email ?? null,
+      responsibilityArea: current.responsibilityArea ?? null,
+    }
+    const after: Record<string, unknown> = {
+      name: newName,
+      email: input.email ?? current.email ?? null,
+      responsibilityArea: input.responsibilityArea ?? current.responsibilityArea ?? null,
+    }
+    const changes = buildAuditChanges(before, after, changedFields)
+
     return await this.teamRepo.update({
       name: input.name,
       newName,
       email: input.email ?? null,
       responsibilityArea: input.responsibilityArea ?? null,
       changedFields,
+      changes,
       userId: input.userId
     })
   }
@@ -147,28 +161,33 @@ export class TeamService {
    * @throws Error if team not found or owns systems
    */
   async delete(name: string, userId: string): Promise<void> {
-    // Business logic: check if team exists
-    const exists = await this.teamRepo.exists(name)
-    
-    if (!exists) {
+    // Fetch current state to capture before-values for the audit log
+    const team = await this.teamRepo.findByName(name)
+
+    if (!team) {
       throw createError({
         statusCode: 404,
         message: `Team '${name}' not found`
       })
     }
-    
+
     // Business logic: check if team owns any systems
     const systemCount = await this.teamRepo.countOwnedSystems(name)
-    
+
     if (systemCount > 0) {
       throw createError({
         statusCode: 409,
         message: `Cannot delete team '${name}' because it owns ${systemCount} system(s). Please reassign or delete the systems first.`
       })
     }
-    
-    // Delete the team
-    await this.teamRepo.delete(name, userId)
+
+    const changes = buildDeleteChanges({
+      name: team.name,
+      email: team.email,
+      responsibilityArea: team.responsibilityArea,
+    })
+
+    await this.teamRepo.delete(name, userId, changes)
   }
 
   /**

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -1,6 +1,7 @@
 import { TechnologyRepository, type TechnologyDetail, type CreateTechnologyParams, type UpdateTechnologyParams, type UpsertApprovalParams } from '../repositories/technology.repository'
 import type { Technology, ComponentType, TechnologyDomain } from '~~/types/api'
 import type { SortParams } from '../utils/sorting'
+import { buildAuditChanges, buildDeleteChanges } from '../utils/audit-diff'
 
 const VALID_TYPES: ComponentType[] = [
   'application', 'framework', 'library', 'container', 'platform',
@@ -147,16 +148,24 @@ export class TechnologyService {
    * @throws 404 if technology not found
    */
   async delete(name: string, userId: string): Promise<void> {
-    const exists = await this.techRepo.exists(name)
+    const tech = await this.techRepo.findByName(name)
 
-    if (!exists) {
+    if (!tech) {
       throw createError({
         statusCode: 404,
         message: `Technology '${name}' not found`
       })
     }
 
-    await this.techRepo.delete(name, userId)
+    const changes = buildDeleteChanges({
+      name: tech.name,
+      type: tech.type,
+      domain: tech.domain ?? null,
+      vendor: tech.vendor ?? null,
+      ownerTeam: tech.ownerTeamName ?? null,
+    })
+
+    await this.techRepo.delete(name, userId, changes)
   }
 
   /**
@@ -184,13 +193,30 @@ export class TechnologyService {
       })
     }
 
-    const exists = await this.techRepo.exists(input.name)
-    if (!exists) {
+    const current = await this.techRepo.findByName(input.name)
+    if (!current) {
       throw createError({
         statusCode: 404,
         message: `Technology '${input.name}' not found`
       })
     }
+
+    const allFields = ['type', 'domain', 'vendor', 'ownerTeam', 'lastReviewed']
+    const before: Record<string, unknown> = {
+      type: current.type ?? null,
+      domain: current.domain ?? null,
+      vendor: current.vendor ?? null,
+      ownerTeam: current.ownerTeamName ?? null,
+      lastReviewed: current.lastReviewed ?? null,
+    }
+    const after: Record<string, unknown> = {
+      type: input.type,
+      domain: input.domain || null,
+      vendor: input.vendor || null,
+      ownerTeam: input.ownerTeam || null,
+      lastReviewed: input.lastReviewed || null,
+    }
+    const changes = buildAuditChanges(before, after, allFields)
 
     const params: UpdateTechnologyParams = {
       name: input.name,
@@ -202,7 +228,7 @@ export class TechnologyService {
       userId: input.userId
     }
 
-    return await this.techRepo.update(params)
+    return await this.techRepo.update({ ...params, changes })
   }
 
   /**
@@ -236,6 +262,18 @@ export class TechnologyService {
       })
     }
 
+    // Fetch existing approval for this team to compute the diff
+    const existing = await this.techRepo.findExistingApproval(input.technologyName, input.teamName)
+    const before: Record<string, unknown> = {
+      time: existing?.time ?? null,
+      notes: existing?.notes ?? null,
+    }
+    const after: Record<string, unknown> = {
+      time: input.time,
+      notes: input.notes ?? null,
+    }
+    const changes = buildAuditChanges(before, after, ['time', 'notes'])
+
     const params: UpsertApprovalParams = {
       technologyName: input.technologyName,
       teamName: input.teamName,
@@ -245,6 +283,6 @@ export class TechnologyService {
       userId: input.userId
     }
 
-    return await this.techRepo.upsertApproval(params)
+    return await this.techRepo.upsertApproval({ ...params, changes })
   }
 }

--- a/server/utils/audit-diff.ts
+++ b/server/utils/audit-diff.ts
@@ -1,0 +1,57 @@
+type AuditChanges = Record<string, { before: unknown; after: unknown }>
+
+/**
+ * Compute a field-level diff between two objects.
+ *
+ * Returns a map of field names to { before, after } for every field whose
+ * value differs. null and undefined are treated as equivalent (both absent).
+ * Only own enumerable properties of `after` are considered; fields present
+ * only in `before` are ignored unless explicitly included via `allFields`.
+ *
+ * @param before - State before the change (or null for CREATE operations)
+ * @param after  - State after the change (or null for DELETE operations)
+ * @param allFields - Explicit list of field names to include (used for CREATE/DELETE)
+ */
+export function buildAuditChanges(
+  before: Record<string, unknown> | null,
+  after: Record<string, unknown> | null,
+  allFields?: string[]
+): AuditChanges {
+  const changes: AuditChanges = {}
+  const fields = allFields ?? Object.keys(after ?? {})
+
+  for (const field of fields) {
+    const beforeVal = before?.[field] ?? null
+    const afterVal = after?.[field] ?? null
+
+    // Treat null and undefined as equivalent — no change
+    if (beforeVal === afterVal) continue
+
+    // Loose equality for primitive values that stringify the same way
+    if (
+      beforeVal !== null &&
+      afterVal !== null &&
+      String(beforeVal) === String(afterVal)
+    ) continue
+
+    changes[field] = { before: beforeVal, after: afterVal }
+  }
+
+  return changes
+}
+
+/**
+ * Build a changes map for a CREATE operation.
+ * Every non-null field gets { before: null, after: value }.
+ */
+export function buildCreateChanges(fields: Record<string, unknown>): AuditChanges {
+  return buildAuditChanges(null, fields, Object.keys(fields))
+}
+
+/**
+ * Build a changes map for a DELETE operation.
+ * Every non-null field gets { before: value, after: null }.
+ */
+export function buildDeleteChanges(fields: Record<string, unknown>): AuditChanges {
+  return buildAuditChanges(fields, null, Object.keys(fields))
+}

--- a/test/server/repositories/system.repository.spec.ts
+++ b/test/server/repositories/system.repository.spec.ts
@@ -143,7 +143,7 @@ describe('SystemRepository', () => {
       await seed(ctx.driver, `CREATE (:System { name: $name, domain: 'Test' })`, { name: `${PREFIX}to-delete` })
 
       expect(await repo.exists(`${PREFIX}to-delete`)).toBe(true)
-      await repo.delete(`${PREFIX}to-delete`, 'test-user')
+      await repo.delete(`${PREFIX}to-delete`, 'test-user', {})
       expect(await repo.exists(`${PREFIX}to-delete`)).toBe(false)
     })
 
@@ -155,7 +155,7 @@ describe('SystemRepository', () => {
         CREATE (s)-[:USES]->(c)
       `, { sys: `${PREFIX}sys-rels`, comp: `${PREFIX}comp` })
 
-      await repo.delete(`${PREFIX}sys-rels`, 'test-user')
+      await repo.delete(`${PREFIX}sys-rels`, 'test-user', {})
 
       const result = await session.run(`
         MATCH (c:Component { name: $comp })

--- a/test/server/repositories/team.repository.spec.ts
+++ b/test/server/repositories/team.repository.spec.ts
@@ -129,7 +129,7 @@ describe('TeamRepository', () => {
       await seed(ctx.driver, `CREATE (:Team { name: $n })`, { n: `${PREFIX}to-delete` })
 
       expect(await repo.exists(`${PREFIX}to-delete`)).toBe(true)
-      await repo.delete(`${PREFIX}to-delete`, 'test-user')
+      await repo.delete(`${PREFIX}to-delete`, 'test-user', {})
       expect(await repo.exists(`${PREFIX}to-delete`)).toBe(false)
     })
   })

--- a/test/server/services/system.service.spec.ts
+++ b/test/server/services/system.service.spec.ts
@@ -176,17 +176,30 @@ describe('SystemService', () => {
 
   describe('delete', () => {
     it('should delete existing system', async () => {
-      vi.mocked(SystemRepository.prototype.exists).mockResolvedValue(true)
+      const mockSystem: System = {
+        name: 'polaris-api',
+        domain: 'Platform',
+        ownerTeam: 'Platform Team',
+        businessCriticality: 'high',
+        environment: 'prod',
+        componentCount: 0,
+        repositoryCount: 0,
+      }
+      vi.mocked(SystemRepository.prototype.findByName).mockResolvedValue(mockSystem)
       vi.mocked(SystemRepository.prototype.delete).mockResolvedValue()
 
       await systemService.delete('polaris-api', 'user-123')
 
-      expect(SystemRepository.prototype.exists).toHaveBeenCalledWith('polaris-api')
-      expect(SystemRepository.prototype.delete).toHaveBeenCalledWith('polaris-api', 'user-123')
+      expect(SystemRepository.prototype.findByName).toHaveBeenCalledWith('polaris-api')
+      expect(SystemRepository.prototype.delete).toHaveBeenCalledWith(
+        'polaris-api',
+        'user-123',
+        expect.any(Object)
+      )
     })
 
     it('should throw error when system does not exist', async () => {
-      vi.mocked(SystemRepository.prototype.exists).mockResolvedValue(false)
+      vi.mocked(SystemRepository.prototype.findByName).mockResolvedValue(null)
 
       await expect(systemService.delete('nonexistent', 'user-123')).rejects.toThrow('not found')
       expect(SystemRepository.prototype.delete).not.toHaveBeenCalled()

--- a/test/server/services/team.service.spec.ts
+++ b/test/server/services/team.service.spec.ts
@@ -50,24 +50,28 @@ describe('TeamService', () => {
 
   describe('delete()', () => {
     it('should delete team that exists and owns no systems', async () => {
-      vi.mocked(TeamRepository.prototype.exists).mockResolvedValue(true)
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(mockTeam)
       vi.mocked(TeamRepository.prototype.countOwnedSystems).mockResolvedValue(0)
       vi.mocked(TeamRepository.prototype.delete).mockResolvedValue(undefined)
 
       await service.delete('Platform', 'user-123')
 
-      expect(TeamRepository.prototype.delete).toHaveBeenCalledWith('Platform', 'user-123')
+      expect(TeamRepository.prototype.delete).toHaveBeenCalledWith(
+        'Platform',
+        'user-123',
+        expect.any(Object)
+      )
     })
 
     it('should throw when team does not exist', async () => {
-      vi.mocked(TeamRepository.prototype.exists).mockResolvedValue(false)
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(null)
 
       await expect(service.delete('nonexistent', 'user-123')).rejects.toThrow()
       expect(TeamRepository.prototype.delete).not.toHaveBeenCalled()
     })
 
     it('should throw when team owns systems', async () => {
-      vi.mocked(TeamRepository.prototype.exists).mockResolvedValue(true)
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(mockTeam)
       vi.mocked(TeamRepository.prototype.countOwnedSystems).mockResolvedValue(3)
 
       await expect(service.delete('Platform', 'user-123')).rejects.toThrow()


### PR DESCRIPTION
## Description

The `changes` map property on `AuditLog` nodes was defined in the schema but never populated. This PR fills it in for every write operation across systems, technologies, and teams, and surfaces the data in the audit log UI.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Fixes #196

## Changes Made

- `server/utils/audit-diff.ts` — new shared utility: `buildAuditChanges` (UPDATE diff), `buildCreateChanges` (`before: null`), `buildDeleteChanges` (`after: null`)
- `server/repositories/audit-log.repository.ts` — added `changes` field to `AuditLog` interface; `mapToAuditLog` deserialises JSON string; `create()` accepts and stores `changes`
- All CREATE Cypher queries (systems, technologies, teams) — accept `$changes` parameter
- All DELETE Cypher queries (systems, technologies, teams) — accept `$changes` parameter
- All UPDATE Cypher queries (technologies/update, technologies/upsert-approval, teams/update) — accept `$changes` parameter
- System repositories/services — fetch entity before delete to capture before-values; pass `changes` through
- Technology repositories/services — same for delete; `update()` and `setApproval()` diff before/after; new `findExistingApproval()` method on repository
- Team repositories/services — same pattern
- `server/api/systems/[name].patch.ts` and `[name].put.ts` — pre-fetch current state, compute diff, pass `changes` to inline Cypher
- `app/pages/audit.vue` — `changes` field on `AuditEntry` interface; new Changes column with `UPopover` showing field/before/after table
- Test updates for changed `delete()` signatures and service mock expectations

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have updated documentation if needed

## Additional Notes

`changes` is stored as a JSON string — Neo4j does not support nested map properties. Deserialisation happens in `mapToAuditLog`. Historical audit entries with no `changes` data render `—` in the UI without errors.

Policy endpoints (`/api/policies`) are not yet implemented and are out of scope for this PR.