### PR TITLE
fix: exclude metadata.component from CycloneDX SBOM processing

### DIFF
--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -126,17 +126,14 @@ export class SBOMService {
   }
 
   /**
-   * Extract components from CycloneDX SBOM
+   * Extract components from CycloneDX SBOM.
+   *
+   * `metadata.component` is the subject of the SBOM (the scanned system
+   * itself) and is intentionally excluded — it is not a dependency.
    */
   private extractCycloneDXComponents(sbom: Record<string, unknown>): ExtractedComponent[] {
     const components: ExtractedComponent[] = []
-    
-    // Extract main component from metadata
-    const metadata = sbom.metadata as Record<string, unknown> | undefined
-    if (metadata?.component) {
-      components.push(this.mapCycloneDXComponent(metadata.component as Record<string, unknown>))
-    }
-    
+
     // Extract components array (with nested components)
     const componentsArray = sbom.components as unknown[] | undefined
     if (componentsArray && Array.isArray(componentsArray)) {

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -185,9 +185,9 @@ describe('SBOMService', () => {
       })
 
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
-      expect(persistCall.components).toHaveLength(2) // metadata.component + components[0]
-      expect(persistCall.components[0].name).toBe('test-app')
-      expect(persistCall.components[1].name).toBe('lodash')
+      // metadata.component is the scanned system itself and is excluded
+      expect(persistCall.components).toHaveLength(1)
+      expect(persistCall.components[0].name).toBe('lodash')
     })
 
     it('should extract components from SPDX packages', async () => {
@@ -223,7 +223,8 @@ describe('SBOMService', () => {
       })
 
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
-      expect(persistCall.components[1].packageManager).toBe('npm')
+      // metadata.component excluded; components[0] is lodash
+      expect(persistCall.components[0].packageManager).toBe('npm')
     })
 
     it('should extract hashes correctly from CycloneDX', async () => {
@@ -324,7 +325,8 @@ describe('SBOMService', () => {
       })
 
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
-      expect(persistCall.components).toHaveLength(3) // metadata + component + nested
+      // metadata.component excluded; component + nested = 2
+      expect(persistCall.components).toHaveLength(2)
       expect(persistCall.components.some(c => c.name === 'nested-lib')).toBe(true)
     })
   })


### PR DESCRIPTION
## Description

Polaris appeared 3 times on the components page, each with a different version, none matching the current release.

## Root Cause

In CycloneDX, `metadata.component` is the **subject** of the SBOM — the system being scanned — not a dependency. `extractCycloneDXComponents` was including it alongside the actual dependency components.

Because the `Component` MERGE key is `(name, version, packageManager)`, and the version in `package.json` changes with each release, every GitHub import run created a **new** `Component` node for polaris rather than updating an existing one. Three imports → three entries.

## Fix

Remove the `metadata.component` extraction. Only `sbom.components` (the dependency list) is processed.

## Cleanup Required

The three existing duplicate polaris component nodes in production will not be removed automatically. They should be cleaned up manually via Cypher:

```cypher
MATCH (c:Component {name: 'polaris'})
WHERE c.version <> '0.1.28'  // keep only the current version if desired, or delete all
DETACH DELETE c
```

Or simply re-import polaris after merging — the old nodes will remain but no new duplicates will be created.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/services/sbom.service.ts`: removed `metadata.component` extraction from `extractCycloneDXComponents`
- `test/server/services/sbom.service.spec.ts`: updated test expectations to reflect correct behaviour

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues