### PR TITLE
feat: hover tooltip on component name fetches registry description

### DIFF
--- a/app/composables/useComponentDescription.ts
+++ b/app/composables/useComponentDescription.ts
@@ -1,0 +1,77 @@
+import { ref } from 'vue'
+import type { Component } from '~~/types/api'
+
+interface DescriptionState {
+  description: string | null
+  pending: boolean
+  fetched: boolean
+}
+
+// Client-side cache: avoids re-fetching the same package within a page session.
+// Keyed by `packageManager:group/name` or `packageManager:name`.
+const clientCache = new Map<string, string | null>()
+
+function cacheKey(component: Component): string {
+  const { packageManager, name, group } = component
+  const pm = packageManager ?? 'unknown'
+  return group ? `${pm}:${group}/${name}` : `${pm}:${name}`
+}
+
+/**
+ * Provides lazy-loaded package description for a component.
+ *
+ * If the component already has a description in the database, it is returned
+ * immediately. Otherwise, `fetch()` triggers a server-side registry lookup on
+ * first call and caches the result for the lifetime of the page session.
+ */
+export function useComponentDescription(component: Component) {
+  const key = cacheKey(component)
+
+  const state = ref<DescriptionState>({
+    description: component.description ?? null,
+    pending: false,
+    fetched: component.description != null
+  })
+
+  async function fetch() {
+    // Already have a description (from DB or prior fetch)
+    if (state.value.fetched) return
+
+    // Check client-side session cache
+    if (clientCache.has(key)) {
+      state.value.description = clientCache.get(key) ?? null
+      state.value.fetched = true
+      return
+    }
+
+    state.value.pending = true
+
+    try {
+      const query: Record<string, string> = {
+        name: component.name,
+        packageManager: component.packageManager ?? 'unknown'
+      }
+      if (component.group) query.group = component.group
+
+      const result = await $fetch<{ description: string | null }>(
+        '/api/components/description',
+        { query }
+      )
+
+      const description = result?.description ?? null
+      state.value.description = description
+      clientCache.set(key, description)
+    } catch {
+      state.value.description = null
+      clientCache.set(key, null)
+    } finally {
+      state.value.pending = false
+      state.value.fetched = true
+    }
+  }
+
+  return {
+    state,
+    fetch
+  }
+}

--- a/app/composables/useComponentDescription.ts
+++ b/app/composables/useComponentDescription.ts
@@ -11,6 +11,10 @@ interface DescriptionState {
 // Keyed by `packageManager:group/name` or `packageManager:name`.
 const clientCache = new Map<string, string | null>()
 
+// Tracks in-flight promises so that concurrent fetch() calls for the same key
+// reuse the existing request instead of firing duplicate network requests.
+const inFlightRequests = new Map<string, Promise<void>>()
+
 function cacheKey(component: Component): string {
   const { packageManager, name, group } = component
   const pm = packageManager ?? 'unknown'
@@ -44,30 +48,47 @@ export function useComponentDescription(component: Component) {
       return
     }
 
+    // If a request for this key is already in-flight, wait for it to complete
+    // and then pick up the cached result rather than firing a duplicate request.
+    if (inFlightRequests.has(key)) {
+      await inFlightRequests.get(key)
+      if (clientCache.has(key)) {
+        state.value.description = clientCache.get(key) ?? null
+        state.value.fetched = true
+      }
+      return
+    }
+
     state.value.pending = true
 
-    try {
-      const query: Record<string, string> = {
-        name: component.name,
-        packageManager: component.packageManager ?? 'unknown'
+    const request = (async () => {
+      try {
+        const query: Record<string, string> = {
+          name: component.name,
+          packageManager: component.packageManager ?? 'unknown'
+        }
+        if (component.group) query.group = component.group
+
+        const result = await $fetch<{ description: string | null }>(
+          '/api/components/description',
+          { query }
+        )
+
+        const description = result?.description ?? null
+        state.value.description = description
+        clientCache.set(key, description)
+      } catch {
+        state.value.description = null
+        clientCache.set(key, null)
+      } finally {
+        state.value.pending = false
+        state.value.fetched = true
+        inFlightRequests.delete(key)
       }
-      if (component.group) query.group = component.group
+    })()
 
-      const result = await $fetch<{ description: string | null }>(
-        '/api/components/description',
-        { query }
-      )
-
-      const description = result?.description ?? null
-      state.value.description = description
-      clientCache.set(key, description)
-    } catch {
-      state.value.description = null
-      clientCache.set(key, null)
-    } finally {
-      state.value.pending = false
-      state.value.fetched = true
-    }
+    inFlightRequests.set(key, request)
+    await request
   }
 
   return {

--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -70,7 +70,7 @@
 </template>
 
 <script setup lang="ts">
-import { h, resolveComponent } from 'vue'
+import { h, resolveComponent, defineComponent, ref } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
 import type { ApiResponse, Component } from '~~/types/api'
 
@@ -80,17 +80,44 @@ const { getSortableHeader } = useSortableTable()
 const UBadge = resolveComponent('UBadge')
 const UButton = resolveComponent('UButton')
 const UDropdownMenu = resolveComponent('UDropdownMenu')
+const UTooltip = resolveComponent('UTooltip')
+
+// Inline component so each row gets its own reactive description state.
+const ComponentNameCell = defineComponent({
+  props: {
+    component: { type: Object as () => Component, required: true }
+  },
+  setup(props) {
+    const { state, fetch } = useComponentDescription(props.component)
+
+    const group = props.component.group
+    const name = props.component.name
+    const displayName = group ? `${group}/${name}` : name
+
+    function tooltipText() {
+      if (state.value.pending) return 'Loading…'
+      if (state.value.description) return state.value.description
+      if (state.value.fetched) return 'No description available'
+      return 'Hover to load description'
+    }
+
+    return () =>
+      h(
+        UTooltip,
+        {
+          text: tooltipText(),
+          onMouseenter: fetch
+        },
+        () => h('strong', {}, displayName)
+      )
+  }
+})
 
 const columns: TableColumn<Component>[] = [
   {
     accessorKey: 'name',
     header: ({ column }) => getSortableHeader(column, 'Name'),
-    cell: ({ row }) => {
-      const group = row.original.group
-      const name = row.getValue('name') as string
-      const displayName = group ? `${group}/${name}` : name
-      return h('strong', {}, displayName)
-    }
+    cell: ({ row }) => h(ComponentNameCell, { component: row.original })
   },
   {
     accessorKey: 'version',

--- a/server/api/components/description.get.ts
+++ b/server/api/components/description.get.ts
@@ -86,6 +86,9 @@ export default defineEventHandler(async (event) => {
     return { description: cached.description }
   }
 
+  if (cached) {
+    cache.delete(key)
+  }
   const description = await fetchRegistryDescription(name, packageManager, group)
 
   cache.set(key, { description, expiresAt: Date.now() + TTL_MS })

--- a/server/api/components/description.get.ts
+++ b/server/api/components/description.get.ts
@@ -1,0 +1,84 @@
+import { fetchRegistryDescription } from '../../utils/registry-fetcher'
+
+interface CacheEntry {
+  description: string | null
+  expiresAt: number
+}
+
+// Module-level in-memory cache. Shared across all requests within a server
+// process lifetime. Keys are `packageManager:group/name` or `packageManager:name`.
+const cache = new Map<string, CacheEntry>()
+
+const TTL_MS = 60 * 60 * 1000 // 1 hour
+
+function cacheKey(packageManager: string, name: string, group?: string): string {
+  return group ? `${packageManager}:${group}/${name}` : `${packageManager}:${name}`
+}
+
+/**
+ * @openapi
+ * /components/description:
+ *   get:
+ *     tags:
+ *       - Components
+ *     summary: Fetch package description from registry
+ *     description: |
+ *       Returns the description for a package from its public registry (npm, PyPI,
+ *       NuGet, Cargo, etc.). Results are cached server-side for 1 hour. Returns null
+ *       when the registry is unsupported or the package has no description.
+ *     parameters:
+ *       - in: query
+ *         name: name
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Package name
+ *       - in: query
+ *         name: packageManager
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Package manager (npm, pypi, maven, nuget, cargo, golang)
+ *       - in: query
+ *         name: group
+ *         schema:
+ *           type: string
+ *         description: Package group or scope (e.g. npm scope without @, Maven groupId)
+ *     responses:
+ *       200:
+ *         description: Description retrieved (may be null)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 description:
+ *                   type: string
+ *                   nullable: true
+ *       400:
+ *         description: Missing required parameters
+ */
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event)
+  const name = query.name as string | undefined
+  const packageManager = query.packageManager as string | undefined
+  const group = query.group as string | undefined
+
+  if (!name || !packageManager) {
+    setResponseStatus(event, 400)
+    return { error: 'name and packageManager are required' }
+  }
+
+  const key = cacheKey(packageManager, name, group)
+  const cached = cache.get(key)
+
+  if (cached && cached.expiresAt > Date.now()) {
+    return { description: cached.description }
+  }
+
+  const description = await fetchRegistryDescription(name, packageManager, group)
+
+  cache.set(key, { description, expiresAt: Date.now() + TTL_MS })
+
+  return { description }
+})

--- a/server/api/components/description.get.ts
+++ b/server/api/components/description.get.ts
@@ -11,8 +11,18 @@ const cache = new Map<string, CacheEntry>()
 
 const TTL_MS = 60 * 60 * 1000 // 1 hour
 
+function normalizeCacheKeyPart(value: string): string {
+  return value.trim().toLowerCase()
+}
+
 function cacheKey(packageManager: string, name: string, group?: string): string {
-  return group ? `${packageManager}:${group}/${name}` : `${packageManager}:${name}`
+  const normalizedPackageManager = normalizeCacheKeyPart(packageManager)
+  const normalizedName = normalizeCacheKeyPart(name)
+  const normalizedGroup = group ? normalizeCacheKeyPart(group) : undefined
+
+  return normalizedGroup
+    ? `${normalizedPackageManager}:${normalizedGroup}/${normalizedName}`
+    : `${normalizedPackageManager}:${normalizedName}`
 }
 
 /**

--- a/server/utils/registry-fetcher.ts
+++ b/server/utils/registry-fetcher.ts
@@ -31,22 +31,12 @@ async function fetchPypi(name: string): Promise<string | null> {
 }
 
 async function fetchMaven(name: string, group?: string): Promise<string | null> {
-  try {
-    const q = group
-      ? `g:${encodeURIComponent(group)}+AND+a:${encodeURIComponent(name)}`
-      : `a:${encodeURIComponent(name)}`
-    const data = await $fetch<{
-      response?: { docs?: Array<{ ec?: string[] }> }
-    }>(`https://search.maven.org/solrsearch/select?q=${q}&rows=1&wt=json`)
-    const doc = data?.response?.docs?.[0]
-    // ec is an array of classifier strings, not a description — Maven Central
-    // does not expose package descriptions via the search API. Return null so
-    // the tooltip shows the fallback rather than a useless classifier list.
-    if (doc) return null
-    return null
-  } catch {
-    return null
-  }
+  // Maven Central search does not provide package descriptions in a usable
+  // form for this utility, so Maven descriptions are intentionally unsupported.
+  // Short-circuit to avoid unnecessary external requests and latency.
+  void name
+  void group
+  return null
 }
 
 async function fetchNuget(name: string): Promise<string | null> {

--- a/server/utils/registry-fetcher.ts
+++ b/server/utils/registry-fetcher.ts
@@ -30,12 +30,10 @@ async function fetchPypi(name: string): Promise<string | null> {
   }
 }
 
-async function fetchMaven(name: string, group?: string): Promise<string | null> {
+async function fetchMaven(_name: string, _group?: string): Promise<string | null> {
   // Maven Central search does not provide package descriptions in a usable
   // form for this utility, so Maven descriptions are intentionally unsupported.
   // Short-circuit to avoid unnecessary external requests and latency.
-  void name
-  void group
   return null
 }
 

--- a/server/utils/registry-fetcher.ts
+++ b/server/utils/registry-fetcher.ts
@@ -1,0 +1,126 @@
+/**
+ * Package registry description fetchers.
+ *
+ * Each fetcher retrieves the short description for a package from its public
+ * registry API. All fetchers return null on any error (network failure, 404,
+ * unexpected response shape) so callers never need to handle exceptions.
+ */
+
+async function fetchNpm(name: string, group?: string): Promise<string | null> {
+  // npm scoped packages: group="nuxt", name="ui" → @nuxt/ui
+  const packageName = group ? `@${group}/${name}` : name
+  try {
+    const data = await $fetch<{ description?: string }>(
+      `https://registry.npmjs.org/${encodeURIComponent(packageName)}`
+    )
+    return data?.description || null
+  } catch {
+    return null
+  }
+}
+
+async function fetchPypi(name: string): Promise<string | null> {
+  try {
+    const data = await $fetch<{ info?: { summary?: string } }>(
+      `https://pypi.org/pypi/${encodeURIComponent(name)}/json`
+    )
+    return data?.info?.summary || null
+  } catch {
+    return null
+  }
+}
+
+async function fetchMaven(name: string, group?: string): Promise<string | null> {
+  try {
+    const q = group
+      ? `g:${encodeURIComponent(group)}+AND+a:${encodeURIComponent(name)}`
+      : `a:${encodeURIComponent(name)}`
+    const data = await $fetch<{
+      response?: { docs?: Array<{ ec?: string[] }> }
+    }>(`https://search.maven.org/solrsearch/select?q=${q}&rows=1&wt=json`)
+    const doc = data?.response?.docs?.[0]
+    // ec is an array of classifier strings, not a description — Maven Central
+    // does not expose package descriptions via the search API. Return null so
+    // the tooltip shows the fallback rather than a useless classifier list.
+    if (doc) return null
+    return null
+  } catch {
+    return null
+  }
+}
+
+async function fetchNuget(name: string): Promise<string | null> {
+  try {
+    const lowerName = name.toLowerCase()
+    const data = await $fetch<{
+      items?: Array<{
+        items?: Array<{
+          catalogEntry?: { description?: string }
+        }>
+      }>
+    }>(`https://api.nuget.org/v3/registration5/${encodeURIComponent(lowerName)}/index.json`)
+    return data?.items?.[0]?.items?.[0]?.catalogEntry?.description || null
+  } catch {
+    return null
+  }
+}
+
+async function fetchCargo(name: string): Promise<string | null> {
+  try {
+    const data = await $fetch<{ crate?: { description?: string } }>(
+      `https://crates.io/api/v1/crates/${encodeURIComponent(name)}`,
+      { headers: { 'User-Agent': 'Polaris/1.0 (https://github.com/localgod/polaris)' } }
+    )
+    return data?.crate?.description || null
+  } catch {
+    return null
+  }
+}
+
+async function fetchGolang(name: string, group?: string): Promise<string | null> {
+  // Go module paths are typically group/name (e.g. github.com/gin-gonic/gin)
+  const modulePath = group ? `${group}/${name}` : name
+  try {
+    const html = await $fetch<string>(
+      `https://pkg.go.dev/${modulePath}`,
+      { responseType: 'text' }
+    )
+    // Extract <meta name="description" content="...">
+    const match = html.match(/<meta\s+name="description"\s+content="([^"]+)"/i)
+    return match?.[1] || null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Fetch the description for a package from its public registry.
+ *
+ * Returns null when the package manager is unsupported, the registry is
+ * unreachable, or the package has no description.
+ */
+export async function fetchRegistryDescription(
+  name: string,
+  packageManager: string,
+  group?: string
+): Promise<string | null> {
+  const pm = packageManager.toLowerCase()
+
+  switch (pm) {
+    case 'npm':
+      return fetchNpm(name, group)
+    case 'pypi':
+      return fetchPypi(name)
+    case 'maven':
+      return fetchMaven(name, group)
+    case 'nuget':
+      return fetchNuget(name)
+    case 'cargo':
+      return fetchCargo(name)
+    case 'golang':
+    case 'go':
+      return fetchGolang(name, group)
+    default:
+      return null
+  }
+}

--- a/server/utils/registry-fetcher.ts
+++ b/server/utils/registry-fetcher.ts
@@ -49,7 +49,9 @@ async function fetchNuget(name: string): Promise<string | null> {
         }>
       }>
     }>(`https://api.nuget.org/v3/registration5/${encodeURIComponent(lowerName)}/index.json`)
-    return data?.items?.[0]?.items?.[0]?.catalogEntry?.description || null
+    const lastPage = data?.items?.at(-1)
+    const latestItem = lastPage?.items?.at(-1)
+    return latestItem?.catalogEntry?.description || null
   } catch {
     return null
   }

--- a/test/server/api/component-description.spec.ts
+++ b/test/server/api/component-description.spec.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createEvent } from 'h3'
+import { IncomingMessage, ServerResponse } from 'node:http'
+import { Socket } from 'node:net'
+
+/**
+ * Unit tests for GET /api/components/description.
+ *
+ * The handler relies on H3 functions that Nuxt auto-imports at runtime.
+ * We provide those as globals before the handler module is evaluated,
+ * using top-level await so the ordering is guaranteed in ESM.
+ */
+
+// Mock fetchRegistryDescription before the handler module is loaded.
+// vi.mock() is hoisted by Vitest above all imports, so the mock is in place
+// before any module code runs.
+vi.mock('../../../server/utils/registry-fetcher', () => ({
+  fetchRegistryDescription: vi.fn()
+}))
+
+import { fetchRegistryDescription } from '../../../server/utils/registry-fetcher'
+
+// Provide H3 functions as globals (Nuxt auto-imports) then load the handler.
+// Top-level await guarantees this happens before describe/it blocks are registered.
+const { defineEventHandler, getQuery, setResponseStatus } = await import('h3')
+vi.stubGlobal('defineEventHandler', defineEventHandler)
+vi.stubGlobal('getQuery', getQuery)
+vi.stubGlobal('setResponseStatus', setResponseStatus)
+
+// eslint-disable-next-line import/first
+const { default: handler } = await import('../../../server/api/components/description.get')
+
+/**
+ * Creates a minimal H3 event whose query string is built from the supplied params.
+ * Uses unique package names per test to prevent cross-test cache pollution because
+ * the handler maintains a module-level in-memory cache.
+ */
+function createMockEvent(params: Record<string, string>) {
+  const qs = new URLSearchParams(params).toString()
+  const socket = new Socket()
+  const req = new IncomingMessage(socket)
+  req.url = `/api/components/description?${qs}`
+  const res = new ServerResponse(req)
+  return createEvent(req, res)
+}
+
+describe('GET /api/components/description', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('parameter validation', () => {
+    it('returns 400 when name is missing', async () => {
+      const event = createMockEvent({ packageManager: 'npm' })
+      const result = await handler(event)
+
+      expect(event.node.res.statusCode).toBe(400)
+      expect(result).toMatchObject({ error: expect.any(String) })
+    })
+
+    it('returns 400 when packageManager is missing', async () => {
+      const event = createMockEvent({ name: 'react' })
+      const result = await handler(event)
+
+      expect(event.node.res.statusCode).toBe(400)
+      expect(result).toMatchObject({ error: expect.any(String) })
+    })
+
+    it('returns 400 when both parameters are missing', async () => {
+      const event = createMockEvent({})
+      const result = await handler(event)
+
+      expect(event.node.res.statusCode).toBe(400)
+      expect(result).toMatchObject({ error: expect.any(String) })
+    })
+  })
+
+  describe('registry lookup', () => {
+    it('returns description from the registry for a supported package manager', async () => {
+      vi.mocked(fetchRegistryDescription).mockResolvedValue('A JavaScript library')
+
+      const event = createMockEvent({ name: 'desc-test-unique-1', packageManager: 'npm' })
+      const result = await handler(event)
+
+      expect(result).toEqual({ description: 'A JavaScript library' })
+      expect(fetchRegistryDescription).toHaveBeenCalledWith('desc-test-unique-1', 'npm', undefined)
+    })
+
+    it('passes group param to the registry fetcher', async () => {
+      vi.mocked(fetchRegistryDescription).mockResolvedValue(null)
+
+      const event = createMockEvent({ name: 'desc-test-unique-2', packageManager: 'maven', group: 'org.example' })
+      await handler(event)
+
+      expect(fetchRegistryDescription).toHaveBeenCalledWith('desc-test-unique-2', 'maven', 'org.example')
+    })
+
+    it('returns null description when the registry has no description', async () => {
+      vi.mocked(fetchRegistryDescription).mockResolvedValue(null)
+
+      const event = createMockEvent({ name: 'desc-test-unique-3', packageManager: 'cargo' })
+      const result = await handler(event)
+
+      expect(result).toEqual({ description: null })
+    })
+  })
+
+  describe('caching', () => {
+    it('serves cached result on second request without calling registry again', async () => {
+      vi.mocked(fetchRegistryDescription).mockResolvedValue('Cached description')
+
+      const params = { name: 'desc-test-unique-4', packageManager: 'npm' }
+
+      // First request — cache miss, registry is called
+      const result1 = await handler(createMockEvent(params))
+      expect(result1).toEqual({ description: 'Cached description' })
+      expect(fetchRegistryDescription).toHaveBeenCalledTimes(1)
+
+      // Second request with identical params — cache hit, no second registry call
+      const result2 = await handler(createMockEvent(params))
+      expect(result2).toEqual({ description: 'Cached description' })
+      expect(fetchRegistryDescription).toHaveBeenCalledTimes(1)
+    })
+
+    it('treats packageManager case-insensitively in the cache key', async () => {
+      vi.mocked(fetchRegistryDescription).mockResolvedValue('Case-insensitive pkg')
+
+      // First request uses uppercase packageManager — populates cache
+      await handler(createMockEvent({ name: 'desc-test-unique-5', packageManager: 'NPM' }))
+      expect(fetchRegistryDescription).toHaveBeenCalledTimes(1)
+
+      // Second request with lowercase — normalised cache key matches, no new fetch
+      await handler(createMockEvent({ name: 'desc-test-unique-5', packageManager: 'npm' }))
+      expect(fetchRegistryDescription).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/test/server/api/component-description.spec.ts
+++ b/test/server/api/component-description.spec.ts
@@ -27,13 +27,19 @@ vi.stubGlobal('defineEventHandler', defineEventHandler)
 vi.stubGlobal('getQuery', getQuery)
 vi.stubGlobal('setResponseStatus', setResponseStatus)
 
+// The handler module must be imported AFTER globals are set because it calls
+// defineEventHandler() at module evaluation time (the `export default` line).
 // eslint-disable-next-line import/first
 const { default: handler } = await import('../../../server/api/components/description.get')
 
 /**
  * Creates a minimal H3 event whose query string is built from the supplied params.
- * Uses unique package names per test to prevent cross-test cache pollution because
- * the handler maintains a module-level in-memory cache.
+ * The handler maintains a module-level in-memory cache for the lifetime of the
+ * test run, so callers must supply a unique `params.name` per test to prevent
+ * one test's cached result from leaking into another.
+ *
+ * @param params - Query parameters to include (e.g. `{ name, packageManager, group }`).
+ *                 `params.name` must be unique across all tests to avoid cache pollution.
  */
 function createMockEvent(params: Record<string, string>) {
   const qs = new URLSearchParams(params).toString()


### PR DESCRIPTION
## Description

Hovering a component name on the `/components` page now shows a tooltip with the package description. If the component already has a description stored in the database it is shown immediately with no network request. Otherwise a server-side lookup is made to the appropriate public registry and the result is cached for 1 hour.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- `server/utils/registry-fetcher.ts` — per-registry description fetch logic for npm, PyPI, NuGet, Cargo, and Golang. Each fetcher returns `null` on any error so the tooltip always degrades gracefully.
- `server/api/components/description.get.ts` — new `GET /api/components/description` route with a module-level in-memory cache (1h TTL, keyed by `packageManager:group/name`). Fetches happen server-side to avoid CORS and share the cache across all users.
- `app/composables/useComponentDescription.ts` — lazy-fetch composable with a client-side session cache so re-hovering the same row within a page visit does not re-fetch.
- `app/pages/components/index.vue` — name cell replaced with an inline `defineComponent` that wraps the name in `UTooltip`. The `mouseenter` event triggers the fetch; the tooltip shows a loading state, the description, or "No description available".

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed

## Additional Notes

Maven is included in the registry fetcher but returns `null` — Maven Central's search API exposes classifier strings rather than human-readable descriptions, so there is nothing useful to display. All other unsupported package managers also return `null` and show the "No description available" fallback.
