### PR TITLE
fix: improve component description tooltip readability and scoped npm packages

### DIFF
--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -94,7 +94,7 @@ const ComponentNameCell = defineComponent({
     const name = props.component.name
     const displayName = group ? `${group}/${name}` : name
 
-    function tooltipText() {
+    function tooltipContent() {
       if (state.value.pending) return 'Loading…'
       if (state.value.description) return state.value.description
       if (state.value.fetched) return 'No description available'
@@ -105,10 +105,13 @@ const ComponentNameCell = defineComponent({
       h(
         UTooltip,
         {
-          text: tooltipText(),
-          onMouseenter: fetch
+          onMouseenter: fetch,
+          ui: { content: 'max-w-xs h-auto whitespace-normal bg-inverted text-inverted rounded px-3 py-2 text-xs shadow-md' }
         },
-        () => h('strong', {}, displayName)
+        {
+          default: () => h('strong', {}, displayName),
+          content: () => tooltipContent()
+        }
       )
   }
 })

--- a/server/utils/registry-fetcher.ts
+++ b/server/utils/registry-fetcher.ts
@@ -7,8 +7,10 @@
  */
 
 async function fetchNpm(name: string, group?: string): Promise<string | null> {
-  // npm scoped packages: group="nuxt", name="ui" → @nuxt/ui
-  const packageName = group ? `@${group}/${name}` : name
+  // npm scoped packages: group may be stored with or without the leading "@"
+  // (e.g. "@iconify" or "nuxt"). Normalise to always produce @scope/name.
+  const scope = group ? group.replace(/^@/, '') : null
+  const packageName = scope ? `@${scope}/${name}` : name
   try {
     const data = await $fetch<{ description?: string }>(
       `https://registry.npmjs.org/${encodeURIComponent(packageName)}`

--- a/test/server/api/component-description.spec.ts
+++ b/test/server/api/component-description.spec.ts
@@ -18,7 +18,7 @@ vi.mock('../../../server/utils/registry-fetcher', () => ({
   fetchRegistryDescription: vi.fn()
 }))
 
-import { fetchRegistryDescription } from '../../../server/utils/registry-fetcher'
+import { fetchRegistryDescription } from '../../../server/utils/registry-fetcher' // eslint-disable-line import/first
 
 // Provide H3 functions as globals (Nuxt auto-imports) then load the handler.
 // Top-level await guarantees this happens before describe/it blocks are registered.
@@ -29,7 +29,6 @@ vi.stubGlobal('setResponseStatus', setResponseStatus)
 
 // The handler module must be imported AFTER globals are set because it calls
 // defineEventHandler() at module evaluation time (the `export default` line).
-// eslint-disable-next-line import/first
 const { default: handler } = await import('../../../server/api/components/description.get')
 
 /**


### PR DESCRIPTION
## Description

Two fixes to the component name hover tooltip introduced in #362:

1. **Tooltip readability** — the default `UTooltip` background was semi-transparent, causing table content to bleed through. Switched to the `content` slot with `bg-inverted`/`text-inverted` for a solid opaque background, and replaced the fixed `h-6` height with `h-auto` so wrapped descriptions are not clipped.

2. **Scoped npm packages** — packages like `@iconify/vue` were returning "No description available" because the group is stored in the database as `@iconify` (with the `@`), causing the fetcher to build `@@iconify/vue`. The group is now normalised by stripping any leading `@` before constructing the scoped package name.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Relates to #362

## Changes Made

- `server/utils/registry-fetcher.ts` — strip leading `@` from npm group before building scoped package name
- `app/pages/components/index.vue` — use `UTooltip` `content` slot with `bg-inverted text-inverted h-auto` to fix opaque background and height clipping
- `test/server/api/component-description.spec.ts` — fix `import/first` lint error on the intentionally deferred import

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed