### PR TITLE
Fix: defer useDriver() call to query time to avoid TDZ ReferenceError

### DIFF
--- a/server/repositories/base.repository.ts
+++ b/server/repositories/base.repository.ts
@@ -5,16 +5,23 @@ import type { Driver, QueryResult } from 'neo4j-driver'
  * All repositories should extend this class
  */
 export abstract class BaseRepository {
-  protected driver: Driver
+  // When an injected driver is provided (tests), store it directly.
+  // Otherwise keep undefined and resolve via useDriver() on first use,
+  // so the nuxt-neo4j plugin has time to initialise _driver before any
+  // query runs (avoids "Cannot access '_driver' before initialization").
+  private _injectedDriver: Driver | undefined
 
   constructor(driver?: Driver) {
-    // Allow driver injection for testing, otherwise use Nuxt composable
-    this.driver = driver || useDriver() // Singleton driver from nuxt-neo4j
+    this._injectedDriver = driver
+  }
+
+  protected get driver(): Driver {
+    return this._injectedDriver ?? useDriver()
   }
 
   /**
    * Execute a Cypher query with parameters
-   * 
+   *
    * @param query - Cypher query string
    * @param params - Query parameters
    * @returns Query result with records
@@ -28,10 +35,10 @@ export abstract class BaseRepository {
 
   /**
    * Execute a Cypher query using a session transaction
-   * 
+   *
    * This method is useful for complex queries with nested data structures
    * that may not work well with executeQuery.
-   * 
+   *
    * @param query - Cypher query string
    * @param params - Query parameters
    * @returns Query result with records

--- a/test/fixtures/neo4j-test-helper.ts
+++ b/test/fixtures/neo4j-test-helper.ts
@@ -5,15 +5,17 @@
  * and consistent setup/teardown across all repository test files.
  */
 import neo4j, { type Driver, type Session } from 'neo4j-driver'
-import { loadQuery, injectWhereConditions } from '../../server/utils/query-loader'
+import { loadQuery, injectOrderBy, injectWhereConditions } from '../../server/utils/query-loader'
 import { cleanupTestData } from './db-cleanup'
 
 // Wire Nuxt auto-imports that repositories expect as globals
 declare global {
   var loadQuery: (path: string) => Promise<string>
+  var injectOrderBy: (query: string, orderBy: string) => string
   var injectWhereConditions: (query: string, conditions: string[]) => string
 }
 global.loadQuery = loadQuery
+global.injectOrderBy = injectOrderBy
 global.injectWhereConditions = injectWhereConditions
 
 const NEO4J_URI = process.env.NEO4J_URI || 'bolt://localhost:7687'


### PR DESCRIPTION
## Description

Fixes a production crash where all API routes fail on startup with:

```
ReferenceError: Cannot access '_driver' before initialization
    at useDriver (nitro.mjs:10206:3)
    at new BaseRepository (nitro.mjs:5529:29)
    at new TechnologyRepository (nitro.mjs:5598:1)
    at new TechnologyService (nitro.mjs:5822:21)
```

`singletons.ts` instantiates all services at module load time. In the production bundle, that module is evaluated before the `nuxt-neo4j` plugin runs and assigns `_driver`. Calling `useDriver()` in the `BaseRepository` constructor therefore hits the temporal dead zone of the `let _driver` declaration.

The fix replaces the constructor assignment with a lazy `get driver()` accessor. `useDriver()` is now only called at the moment a query executes (during a request), by which point the plugin has already initialised `_driver`. Injected drivers (used in tests) are stored directly and bypass the getter, so the test injection pattern is unchanged.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `server/repositories/base.repository.ts`: store optional injected driver in `_injectedDriver`; expose `driver` as a lazy getter that falls back to `useDriver()`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues