### PR TITLE
Fix: enforce token ownership in revocation endpoint (IDOR)

### DIFF
--- a/server/api/admin/users/[userId]/tokens/[tokenId].delete.ts
+++ b/server/api/admin/users/[userId]/tokens/[tokenId].delete.ts
@@ -34,13 +34,16 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'tokenId is required' })
   }
 
-  const revoked = await tokenService.revokeToken(tokenId)
+  const userId = getRouterParam(event, 'userId')
+  if (!userId) {
+    throw createError({ statusCode: 400, message: 'userId is required' })
+  }
+
+  const revoked = await tokenService.revokeToken(tokenId, userId)
 
   if (!revoked) {
     throw createError({ statusCode: 404, message: 'Token not found' })
   }
-
-  const userId = getRouterParam(event, 'userId')
   const currentUser = await getCurrentUser(event)
   const auditRepo = new AuditLogRepository()
   await auditRepo.create({

--- a/server/repositories/token.repository.ts
+++ b/server/repositories/token.repository.ts
@@ -115,19 +115,23 @@ export class TokenRepository extends BaseRepository {
   }
 
   /**
-   * Revoke a token by ID
-   * 
+   * Revoke a token by ID, verifying it belongs to the given user.
+   *
+   * Returns false (404) if the token does not exist or does not belong to userId,
+   * preventing cross-user revocation by superusers.
+   *
    * @param tokenId - Token ID
-   * @returns true if token was revoked, false if not found
+   * @param userId  - User who must own the token
+   * @returns true if token was revoked, false if not found or not owned by userId
    */
-  async revoke(tokenId: string): Promise<boolean> {
+  async revoke(tokenId: string, userId: string): Promise<boolean> {
     const query = `
-      MATCH (t:ApiToken {id: $tokenId})
+      MATCH (u:User {id: $userId})-[:HAS_API_TOKEN]->(t:ApiToken {id: $tokenId})
       SET t.revoked = true
       RETURN t
     `
-    
-    const { records } = await this.executeQuery(query, { tokenId })
+
+    const { records } = await this.executeQuery(query, { tokenId, userId })
     return records.length > 0
   }
 

--- a/server/services/token.service.ts
+++ b/server/services/token.service.ts
@@ -143,13 +143,14 @@ export class TokenService {
   }
 
   /**
-   * Revoke a token by ID
-   * 
+   * Revoke a token by ID, verifying it belongs to the given user.
+   *
    * @param tokenId - Token ID
-   * @returns true if token was revoked, false if not found
+   * @param userId  - User who must own the token
+   * @returns true if token was revoked, false if not found or not owned by userId
    */
-  async revokeToken(tokenId: string): Promise<boolean> {
-    return await this.tokenRepo.revoke(tokenId)
+  async revokeToken(tokenId: string, userId: string): Promise<boolean> {
+    return await this.tokenRepo.revoke(tokenId, userId)
   }
 
   /**

--- a/test/server/repositories/token.repository.spec.ts
+++ b/test/server/repositories/token.repository.spec.ts
@@ -69,7 +69,7 @@ describe('TokenRepository', () => {
   })
 
   describe('revoke()', () => {
-    it('should revoke a token', async () => {
+    it('should revoke a token when userId matches owner', async () => {
       if (!ctx.neo4jAvailable) return
       await repo.create({
         id: `${PREFIX}token-revoke`,
@@ -80,9 +80,25 @@ describe('TokenRepository', () => {
         description: null
       })
 
-      const revoked = await repo.revoke(`${PREFIX}token-revoke`)
+      const revoked = await repo.revoke(`${PREFIX}token-revoke`, `${PREFIX}user`)
 
       expect(revoked).toBe(true)
+    })
+
+    it('should return false when userId does not own the token', async () => {
+      if (!ctx.neo4jAvailable) return
+      await repo.create({
+        id: `${PREFIX}token-revoke-idor`,
+        tokenHash: `${PREFIX}revokehash-idor`,
+        createdBy: `${PREFIX}user`,
+        createdAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 86400000).toISOString(),
+        description: null
+      })
+
+      const revoked = await repo.revoke(`${PREFIX}token-revoke-idor`, `${PREFIX}other-user`)
+
+      expect(revoked).toBe(false)
     })
   })
 

--- a/test/server/services/token.service.spec.ts
+++ b/test/server/services/token.service.spec.ts
@@ -81,11 +81,18 @@ describe('TokenService', () => {
   })
 
   describe('revokeToken()', () => {
-    it('should delegate to repository', async () => {
+    it('should pass both tokenId and userId to repository', async () => {
       vi.mocked(TokenRepository.prototype.revoke).mockResolvedValue(true)
 
-      expect(await service.revokeToken('token-id')).toBe(true)
-      expect(TokenRepository.prototype.revoke).toHaveBeenCalledWith('token-id')
+      expect(await service.revokeToken('token-id', 'user-1')).toBe(true)
+      expect(TokenRepository.prototype.revoke).toHaveBeenCalledWith('token-id', 'user-1')
+    })
+
+    it('should return false when token does not belong to userId', async () => {
+      vi.mocked(TokenRepository.prototype.revoke).mockResolvedValue(false)
+
+      expect(await service.revokeToken('token-id', 'wrong-user')).toBe(false)
+      expect(TokenRepository.prototype.revoke).toHaveBeenCalledWith('token-id', 'wrong-user')
     })
   })
 


### PR DESCRIPTION
## Description

Fixes an IDOR in the token revocation endpoint where a superuser could revoke any user's token by supplying an arbitrary `tokenId` in the URL, regardless of the `userId` path parameter. The `userId` was only used to populate the audit log label — it had no effect on the database operation.

**Before:**
```cypher
MATCH (t:ApiToken {id: $tokenId})
SET t.revoked = true
```

**After:**
```cypher
MATCH (u:User {id: $userId})-[:HAS_API_TOKEN]->(t:ApiToken {id: $tokenId})
SET t.revoked = true
```

The endpoint now returns 404 if the token does not exist or does not belong to the `userId` in the URL. The audit log label now always reflects the actual token owner.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #390

## Changes Made

- `TokenRepository.revoke()` — ownership join added to Cypher; accepts `userId` as second parameter
- `TokenService.revokeToken()` — signature updated to accept and pass through `userId`
- Route handler — `userId` extracted and validated before the revocation call
- Tests — existing `revokeToken` tests updated; new service test covers wrong-owner `false` return; new repository integration test verifies IDOR rejection against live Neo4j

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`