### PR TITLE
Fix: push filters and SKIP/LIMIT into Neo4j for GET /api/licenses

### DIFF
--- a/server/api/licenses.get.ts
+++ b/server/api/licenses.get.ts
@@ -1,6 +1,6 @@
 import type { ApiResponse } from '~~/types/api'
-import { LicenseRepository } from '../repositories/license.repository'
 import type { License } from '../repositories/license.repository'
+import { licenseService } from '../services/singletons'
 
 /**
  * @openapi
@@ -97,29 +97,32 @@ import type { License } from '../repositories/license.repository'
 export default defineEventHandler(async (event): Promise<ApiResponse<License>> => {
   try {
     const query = getQuery(event)
-    const limit = query.limit ? parseInt(query.limit as string, 10) : 50
-    const offset = query.offset ? parseInt(query.offset as string, 10) : 0
-    const filters = {
+    const rawLimit = query.limit ? parseInt(query.limit as string, 10) : 50
+    const rawOffset = query.offset ? parseInt(query.offset as string, 10) : 0
+
+    if (isNaN(rawLimit) || isNaN(rawOffset)) {
+      return { success: false, error: 'limit and offset must be valid integers', data: [] }
+    }
+
+    const limit = Math.min(Math.max(1, rawLimit), 200)
+    const offset = Math.max(0, rawOffset)
+
+    const result = await licenseService.findAll({
       category: query.category as string | undefined,
       osiApproved: query.osiApproved === 'true' ? true : query.osiApproved === 'false' ? false : undefined,
       deprecated: query.deprecated === 'true' ? true : query.deprecated === 'false' ? false : undefined,
-      search: query.search as string | undefined
-    }
-    
-    const licenseRepo = new LicenseRepository()
-    const allLicenses = await licenseRepo.findAll({
-      ...filters,
+      search: query.search as string | undefined,
       sortBy: query.sortBy as string | undefined,
-      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const,
+      limit,
+      offset
     })
-    const total = allLicenses.length
-    const paginatedLicenses = allLicenses.slice(offset, offset + limit)
-    
+
     return {
       success: true,
-      data: paginatedLicenses,
-      count: paginatedLicenses.length,
-      total
+      data: result.data,
+      count: result.count,
+      total: result.total
     }
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Failed to fetch licenses'


### PR DESCRIPTION
## Description

`GET /api/licenses` was fetching all license rows from Neo4j and applying filters and pagination in Node.js. The route handler bypassed `LicenseService` entirely, called `LicenseRepository` directly without passing `limit`/`offset`, and sliced the full result in memory.

`LicenseRepository.findAll()` already accepted all filters (`category`, `osiApproved`, `deprecated`, `allowed`, `search`) and already applied `SKIP`/`LIMIT` in Cypher. `LicenseService.findAll()` already called a separate `count()` query for the correct total. The fix was entirely in the route handler.

**Before:**
```ts
const licenseRepo = new LicenseRepository()
const allLicenses = await licenseRepo.findAll({ ...filters })  // no limit/offset
const total = allLicenses.length                               // wrong: always full count
const paginatedLicenses = allLicenses.slice(offset, offset + limit)
```

**After:**
```ts
const result = await licenseService.findAll({ ...filters, limit, offset })
// SKIP/LIMIT applied in Neo4j; total from count() query
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #434
Relates to #367 (parent pagination issue; other endpoints fixed in #435)

## Changes Made

- `server/api/licenses.get.ts` — use `licenseService` singleton instead of direct repository instantiation; pass `limit`/`offset` into the service; validate and clamp `limit` to `[1, 200]`; remove Node.js `.slice()`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues