### PR TITLE
feat: surface system criticality and environment in violations views

### DIFF
--- a/app/pages/violations/index.vue
+++ b/app/pages/violations/index.vue
@@ -90,6 +90,8 @@ definePageMeta({ middleware: 'auth' })
 interface Violation {
   team: string
   system: string
+  systemBusinessCriticality: string | null
+  systemEnvironment: string | null
   component: string
   componentVersion: string
   technology: string
@@ -124,6 +126,20 @@ function getSeverityColor(severity: string): 'error' | 'warning' | 'success' | '
     critical: 'error', error: 'error', warning: 'warning', info: 'neutral'
   }
   return colors[severity] || 'neutral'
+}
+
+function getCriticalityColor(criticality: string | null): 'error' | 'warning' | 'success' | 'neutral' {
+  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
+    critical: 'error', high: 'warning', medium: 'success', low: 'neutral'
+  }
+  return colors[criticality || ''] || 'neutral'
+}
+
+function getEnvironmentColor(environment: string | null): 'error' | 'warning' | 'success' | 'neutral' {
+  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
+    prod: 'error', staging: 'warning', test: 'neutral', dev: 'neutral'
+  }
+  return colors[environment || ''] || 'neutral'
 }
 
 const severityItems = ['critical', 'error', 'warning', 'info']
@@ -220,6 +236,26 @@ const columns: TableColumn<Violation>[] = [
         to: `/systems/${encodeURIComponent(row.original.system)}`,
         class: 'hover:underline'
       }, () => row.original.system)
+    }
+  },
+  {
+    id: 'systemBusinessCriticality',
+    accessorFn: row => row.systemBusinessCriticality ?? '',
+    header: ({ column }) => getSortableHeader(column, 'Criticality'),
+    cell: ({ row }) => {
+      const value = row.original.systemBusinessCriticality
+      if (!value) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return h(UBadge, { color: getCriticalityColor(value), variant: 'subtle' }, () => value)
+    }
+  },
+  {
+    id: 'systemEnvironment',
+    accessorFn: row => row.systemEnvironment ?? '',
+    header: ({ column }) => getSortableHeader(column, 'Environment'),
+    cell: ({ row }) => {
+      const value = row.original.systemEnvironment
+      if (!value) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return h(UBadge, { color: getEnvironmentColor(value), variant: 'subtle' }, () => value)
     }
   },
   {

--- a/app/pages/violations/licenses.vue
+++ b/app/pages/violations/licenses.vue
@@ -81,6 +81,20 @@ function getCategoryColor(category: string): 'success' | 'warning' | 'error' | '
   return colors[category?.toLowerCase()] || 'neutral'
 }
 
+function getCriticalityColor(criticality: string | null): 'error' | 'warning' | 'success' | 'neutral' {
+  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
+    critical: 'error', high: 'warning', medium: 'success', low: 'neutral'
+  }
+  return colors[criticality || ''] || 'neutral'
+}
+
+function getEnvironmentColor(environment: string | null): 'error' | 'warning' | 'success' | 'neutral' {
+  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
+    prod: 'error', staging: 'warning', test: 'neutral', dev: 'neutral'
+  }
+  return colors[environment || ''] || 'neutral'
+}
+
 const columns: TableColumn<LicenseViolation>[] = [
   {
     accessorKey: 'componentName',
@@ -115,6 +129,24 @@ const columns: TableColumn<LicenseViolation>[] = [
         to: `/systems/${encodeURIComponent(row.original.systemName)}`,
         class: 'hover:underline'
       }, () => row.original.systemName)
+    }
+  },
+  {
+    accessorKey: 'systemBusinessCriticality',
+    header: ({ column }) => getSortableHeader(column, 'Criticality'),
+    cell: ({ row }) => {
+      const value = row.original.systemBusinessCriticality
+      if (!value) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return h(UBadge, { color: getCriticalityColor(value), variant: 'subtle' }, () => value)
+    }
+  },
+  {
+    accessorKey: 'systemEnvironment',
+    header: ({ column }) => getSortableHeader(column, 'Environment'),
+    cell: ({ row }) => {
+      const value = row.original.systemEnvironment
+      if (!value) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return h(UBadge, { color: getEnvironmentColor(value), variant: 'subtle' }, () => value)
     }
   },
   {

--- a/server/database/queries/version-constraints/find-violations.cypher
+++ b/server/database/queries/version-constraints/find-violations.cypher
@@ -6,6 +6,8 @@ MATCH (team)-[:SUBJECT_TO]->(vc)
 {{WHERE_CONDITIONS}}
 RETURN team.name as teamName,
        sys.name as systemName,
+       sys.businessCriticality as systemBusinessCriticality,
+       sys.environment as systemEnvironment,
        comp.name as componentName,
        comp.version as componentVersion,
        tech.name as technologyName,

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -429,6 +429,8 @@ This API implements **RMM Level 2** with proper use of HTTP methods and status c
           properties: {
             team: { type: 'string' },
             system: { type: 'string' },
+            systemBusinessCriticality: { type: 'string', nullable: true, enum: ['critical', 'high', 'medium', 'low'] },
+            systemEnvironment: { type: 'string', nullable: true, enum: ['dev', 'test', 'staging', 'prod'] },
             component: { type: 'string' },
             componentVersion: { type: 'string' },
             technology: { type: 'string' },

--- a/server/repositories/license.repository.ts
+++ b/server/repositories/license.repository.ts
@@ -30,6 +30,8 @@ export interface LicenseComponent {
 export interface LicenseViolation {
   teamName: string
   systemName: string
+  systemBusinessCriticality: string | null
+  systemEnvironment: string | null
   componentName: string
   componentVersion: string
   componentPurl: string | null
@@ -507,6 +509,8 @@ export class LicenseRepository extends BaseRepository {
       ${whereClause}
       RETURN team.name as teamName,
              sys.name as systemName,
+             sys.businessCriticality as systemBusinessCriticality,
+             sys.environment as systemEnvironment,
              comp.name as componentName,
              comp.version as componentVersion,
              comp.purl as componentPurl,
@@ -525,6 +529,8 @@ export class LicenseRepository extends BaseRepository {
     const data = records.map(record => ({
       teamName: record.get('teamName'),
       systemName: record.get('systemName'),
+      systemBusinessCriticality: record.get('systemBusinessCriticality') || null,
+      systemEnvironment: record.get('systemEnvironment') || null,
       componentName: record.get('componentName'),
       componentVersion: record.get('componentVersion'),
       componentPurl: record.get('componentPurl'),

--- a/server/repositories/version-constraint.repository.ts
+++ b/server/repositories/version-constraint.repository.ts
@@ -35,6 +35,8 @@ const sortConfig: SortConfig = {
 export interface Violation {
   team: string
   system: string
+  systemBusinessCriticality: string | null
+  systemEnvironment: string | null
   component: string
   componentVersion: string
   technology: string
@@ -460,6 +462,8 @@ export class VersionConstraintRepository extends BaseRepository {
     return {
       team: record.get('teamName'),
       system: record.get('systemName'),
+      systemBusinessCriticality: record.get('systemBusinessCriticality') || null,
+      systemEnvironment: record.get('systemEnvironment') || null,
       component: record.get('componentName'),
       componentVersion: record.get('componentVersion'),
       technology: record.get('technologyName'),

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -185,6 +185,8 @@ export interface User {
 export interface LicenseViolation {
   teamName: string
   systemName: string
+  systemBusinessCriticality: BusinessCriticality | null
+  systemEnvironment: SystemEnvironment | null
   componentName: string
   componentVersion: string
   componentPurl: string | null


### PR DESCRIPTION
## Description

Adds `businessCriticality` and `environment` badge columns to both violations tables (`/violations` and `/violations/licenses`). The data already exists on every `System` node and was already traversed by the violations queries — it just wasn't projected or displayed. Engineers can now sort `critical + prod` findings to the top without reading every row.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Closes #388

## Changes Made

- `server/database/queries/version-constraints/find-violations.cypher` — add `sys.businessCriticality` and `sys.environment` to `RETURN` (`sys` node already in scope)
- `server/repositories/version-constraint.repository.ts` — add fields to `Violation` interface and `mapToViolation()`
- `server/repositories/license.repository.ts` — add fields to `LicenseViolation` interface, inline Cypher `RETURN` clause, and inline mapper (the `.cypher` file is not used by this code path)
- `types/api.d.ts` — add `systemBusinessCriticality: BusinessCriticality | null` and `systemEnvironment: SystemEnvironment | null` to `LicenseViolation` (reuses existing union types)
- `app/pages/violations/index.vue` — extend local `Violation` interface; add `getCriticalityColor()` and `getEnvironmentColor()` helpers; add **Criticality** and **Environment** badge columns between System and Team
- `app/pages/violations/licenses.vue` — same helpers and columns
- `server/openapi.ts` — add the two new nullable fields (with enums) to the `Violation` schema

Badge colour mapping matches `systems/index.vue`: `critical` → error, `high` → warning, `medium` → success, `low` → neutral; `prod` → error, `staging` → warning, `dev`/`test` → neutral. Null values render as `—`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed

## Additional Notes

No schema changes, no new relationships, no migrations required.