### PR TITLE
feat: dependency graph, SBOM pipeline fixes, and component filtering

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.2"
+setups.@nuxt/test-utils="4.0.3"

--- a/app/components/SystemDependencyGraph.vue
+++ b/app/components/SystemDependencyGraph.vue
@@ -1,0 +1,581 @@
+<template>
+  <div class="space-y-4">
+    <!-- Empty state -->
+    <div v-if="!hasNodes" class="text-center py-12 text-(--ui-text-muted)">
+      <UIcon name="i-lucide-share-2" class="text-4xl mb-3" />
+      <p>No components found for this system.</p>
+    </div>
+
+    <template v-else>
+      <!-- Legend -->
+      <div class="flex flex-wrap gap-3 text-sm">
+        <div v-for="pm in packageManagers" :key="pm" class="flex items-center gap-1.5">
+          <span
+            class="inline-block w-3 h-3 rounded-full flex-shrink-0"
+            :style="{ backgroundColor: pmColor(pm) }"
+          />
+          <span class="text-(--ui-text-muted)">{{ pm }}</span>
+        </div>
+        <div class="flex items-center gap-1.5">
+          <span class="inline-block w-3 h-3 rounded-sm flex-shrink-0" style="background:var(--ui-primary);opacity:0.5" />
+          <span class="text-(--ui-text-muted)">technology</span>
+        </div>
+      </div>
+
+      <!-- SVG canvas -->
+      <div
+        ref="containerRef"
+        class="relative border border-(--ui-border) rounded-lg bg-(--ui-bg-elevated)"
+        style="height:520px;overflow:hidden;"
+        @dblclick="resetZoom"
+      >
+        <svg ref="svgRef" style="width:100%;height:100%;" />
+
+        <div
+          v-if="tooltip.visible"
+          class="absolute pointer-events-none z-10 px-2 py-1 rounded text-xs bg-(--ui-bg) border border-(--ui-border) shadow-sm text-(--ui-text) max-w-48"
+          :style="{ left: tooltip.x + 'px', top: tooltip.y + 'px' }"
+        >{{ tooltip.text }}</div>
+
+        <p class="absolute bottom-2 right-3 text-xs text-(--ui-text-muted) pointer-events-none select-none">
+          Scroll to zoom · Drag to pan · Double-click to reset
+        </p>
+      </div>
+
+      <!-- Component detail panel -->
+      <UCard v-if="selectedNode && selectedNode.type === 'component'">
+        <template #header>
+          <div class="flex justify-between items-start">
+            <div>
+              <h3 class="font-semibold text-base">{{ selectedNode.label }}</h3>
+              <p v-if="selectedNode.version" class="text-sm text-(--ui-text-muted)">v{{ selectedNode.version }}</p>
+            </div>
+            <UButton icon="i-lucide-x" variant="ghost" size="xs" color="neutral" @click="selectedNode = null" />
+          </div>
+        </template>
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+          <div v-if="selectedNode.packageManager">
+            <span class="text-(--ui-text-muted) block">Package Manager</span>
+            <span class="font-medium">{{ selectedNode.packageManager }}</span>
+          </div>
+          <div v-if="selectedNode.componentType">
+            <span class="text-(--ui-text-muted) block">Type</span>
+            <span class="font-medium">{{ selectedNode.componentType }}</span>
+          </div>
+          <div v-if="selectedNode.scope">
+            <span class="text-(--ui-text-muted) block">Scope</span>
+            <span class="font-medium">{{ selectedNode.scope }}</span>
+          </div>
+          <div v-if="selectedNode.technologyName">
+            <span class="text-(--ui-text-muted) block">Technology</span>
+            <NuxtLink
+              :to="`/technologies/${encodeURIComponent(selectedNode.technologyName)}`"
+              class="font-medium hover:underline text-(--ui-primary)"
+            >{{ selectedNode.technologyName }}</NuxtLink>
+          </div>
+          <div v-if="selectedNode.purl" class="col-span-2 sm:col-span-3">
+            <span class="text-(--ui-text-muted) block">PURL</span>
+            <code class="text-xs break-all">{{ selectedNode.purl }}</code>
+          </div>
+          <div v-if="selectedNode.cpe" class="col-span-2 sm:col-span-3">
+            <span class="text-(--ui-text-muted) block">CPE</span>
+            <code class="text-xs break-all">{{ selectedNode.cpe }}</code>
+          </div>
+          <div v-if="selectedNode.description" class="col-span-2 sm:col-span-3">
+            <span class="text-(--ui-text-muted) block">Description</span>
+            <span>{{ selectedNode.description }}</span>
+          </div>
+        </div>
+        <div v-if="selectedNode.licenses && selectedNode.licenses.length > 0" class="mt-4">
+          <span class="text-(--ui-text-muted) text-sm block mb-1">Licenses</span>
+          <div class="flex flex-wrap gap-2">
+            <UBadge
+              v-for="lic in selectedNode.licenses"
+              :key="lic.id ?? lic.name"
+              :color="lic.allowed === false ? 'error' : 'success'"
+              variant="subtle"
+              size="sm"
+            >{{ lic.id ?? lic.name }}</UBadge>
+          </div>
+        </div>
+        <template #footer>
+          <UButton
+            :to="`/components?search=${encodeURIComponent(selectedNode.label)}`"
+            variant="outline"
+            size="sm"
+            icon="i-lucide-external-link"
+            label="View in component list"
+          />
+        </template>
+      </UCard>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import * as d3 from 'd3'
+
+// ── Props ──────────────────────────────────────────────────────────────────
+
+interface GraphNode {
+  id: string
+  label: string
+  type: 'system' | 'group' | 'component' | 'technology'
+  packageManager?: string | null
+  count?: number
+  version?: string | null
+  componentType?: string | null
+  scope?: string | null
+  purl?: string | null
+  cpe?: string | null
+  group?: string | null
+  description?: string | null
+  licenses?: Array<{ id?: string; name?: string; allowed?: boolean }>
+  technologyName?: string | null
+  direct?: boolean
+  dependsOn?: string[]
+  x?: number
+  y?: number
+  fx?: number | null
+  fy?: number | null
+}
+
+interface GraphEdge {
+  source: string | GraphNode
+  target: string | GraphNode
+}
+
+const props = defineProps<{
+  systemName: string
+  nodes: GraphNode[]
+  edges: GraphEdge[]
+}>()
+
+// ── Template refs ──────────────────────────────────────────────────────────
+
+const svgRef = ref<SVGSVGElement | null>(null)
+const containerRef = ref<HTMLDivElement | null>(null)
+
+// ── Derived data ───────────────────────────────────────────────────────────
+
+const hasNodes = computed(() => props.nodes.length > 0)
+
+// ── Colors ─────────────────────────────────────────────────────────────────
+
+const PM_COLORS: Record<string, string> = {
+  npm: '#cb3837', yarn: '#2c8ebb', maven: '#c71a36', gradle: '#02303a',
+  pypi: '#3572a5', cargo: '#dea584', nuget: '#004880', gem: '#cc342d',
+  go: '#00add8', composer: '#885630', unknown: '#6b7280',
+}
+
+function pmColor(pm: string | null | undefined): string {
+  return PM_COLORS[(pm ?? 'unknown').toLowerCase()] ?? PM_COLORS.unknown
+}
+
+const packageManagers = computed(() =>
+  [...new Set(props.nodes.filter(n => n.type === 'group').map(n => n.packageManager ?? 'unknown'))]
+)
+
+// ── Expand / collapse ──────────────────────────────────────────────────────
+
+const expandedGroups = ref(new Set<string>())
+const expandedComponents = ref(new Set<string>())
+
+// Whether any component in the graph has direct=true (i.e. DEPENDS_ON data exists)
+const hasDependencyData = computed(() =>
+  props.nodes.some(n => n.type === 'component' && n.direct === true)
+)
+
+// Fallback cap when no DEPENDS_ON data exists
+const GROUP_DISPLAY_LIMIT = 50
+
+// Stable id→node map; only rebuilt when props.nodes changes (not on every toggle)
+const nodeById = computed(() => new Map(props.nodes.map(n => [n.id, n])))
+
+// Pre-computed direct-dep count per package manager for tooltip use
+const directCountByPm = computed(() => {
+  const map = new Map<string, number>()
+  for (const n of props.nodes) {
+    if (n.type === 'component' && n.direct) {
+      const pm = n.packageManager ?? 'unknown'
+      map.set(pm, (map.get(pm) ?? 0) + 1)
+    }
+  }
+  return map
+})
+
+function toggleGroup(groupId: string) {
+  const next = new Set(expandedGroups.value)
+  if (next.has(groupId)) {
+    next.delete(groupId)
+    // Collapse all component expansions belonging to this group
+    const pm = groupId.replace(/^group:/, '')
+    const compNext = new Set(expandedComponents.value)
+    for (const id of compNext) {
+      const node = nodeById.value.get(id)
+      if (node && (node.packageManager ?? 'unknown') === pm) compNext.delete(id)
+    }
+    expandedComponents.value = compNext
+    selectedNode.value = null
+  } else {
+    next.add(groupId)
+  }
+  expandedGroups.value = next
+}
+
+function toggleComponent(compId: string) {
+  const next = new Set(expandedComponents.value)
+  if (next.has(compId)) {
+    // Collapse this component and all its descendants
+    collapseDescendants(compId, next)
+    next.delete(compId)
+  } else {
+    next.add(compId)
+  }
+  expandedComponents.value = next
+}
+
+function collapseDescendants(compId: string, set: Set<string>) {
+  const node = nodeById.value.get(compId)
+  if (!node?.dependsOn) return
+  for (const childId of node.dependsOn) {
+    if (set.has(childId)) {
+      collapseDescendants(childId, set)
+      set.delete(childId)
+    }
+  }
+}
+
+// ── Visible nodes / edges ──────────────────────────────────────────────────
+
+const visibleNodes = computed<GraphNode[]>(() => {
+  const expanded = expandedGroups.value
+  const expandedComps = expandedComponents.value
+  const byId = nodeById.value
+
+  // Collect visible component IDs
+  const visibleCompIds = new Set<string>()
+
+  for (const groupId of expanded) {
+    const pm = groupId.replace(/^group:/, '')
+    const groupComps = props.nodes.filter(
+      n => n.type === 'component' && (n.packageManager ?? 'unknown') === pm
+    )
+
+    if (hasDependencyData.value) {
+      // Show only direct deps of the system for this group
+      groupComps.filter(n => n.direct).forEach(n => visibleCompIds.add(n.id))
+    } else {
+      // Fallback: no DEPENDS_ON data — show first N alphabetically
+      groupComps
+        .sort((a, b) => (a.label ?? '').localeCompare(b.label ?? ''))
+        .slice(0, GROUP_DISPLAY_LIMIT)
+        .forEach(n => visibleCompIds.add(n.id))
+    }
+  }
+
+  // For each expanded component, add its direct dependencies (cycle-safe)
+  const visited = new Set<string>()
+  function addDependencies(compId: string) {
+    if (visited.has(compId)) return
+    visited.add(compId)
+    if (!expandedComps.has(compId)) return
+    const node = byId.get(compId)
+    if (!node?.dependsOn) return
+    for (const depId of node.dependsOn) {
+      visibleCompIds.add(depId)
+      addDependencies(depId)
+    }
+  }
+  for (const compId of expandedComps) {
+    addDependencies(compId)
+  }
+
+  // Pre-build the set of visible tech names to avoid O(n²) scan in the filter
+  const visibleTechNames = new Set<string>()
+  for (const id of visibleCompIds) {
+    const techName = byId.get(id)?.technologyName
+    if (techName) visibleTechNames.add(techName)
+  }
+
+  return props.nodes.filter(n => {
+    if (n.type === 'system' || n.type === 'group') return true
+    if (n.type === 'component') return visibleCompIds.has(n.id)
+    if (n.type === 'technology') return visibleTechNames.has(n.label)
+    return false
+  })
+})
+
+const visibleNodeIds = computed(() => new Set(visibleNodes.value.map(n => n.id)))
+
+const visibleEdges = computed<GraphEdge[]>(() =>
+  props.edges.filter(e => {
+    const src = typeof e.source === 'string' ? e.source : (e.source as GraphNode).id
+    const tgt = typeof e.target === 'string' ? e.target : (e.target as GraphNode).id
+    return visibleNodeIds.value.has(src) && visibleNodeIds.value.has(tgt)
+  })
+)
+
+// ── D3 state ───────────────────────────────────────────────────────────────
+
+const positionCache = new Map<string, { x: number; y: number }>()
+let simulation: d3.Simulation<GraphNode, undefined> | null = null
+let zoomBehavior: d3.ZoomBehavior<SVGSVGElement, unknown> | null = null
+let gRoot: d3.Selection<SVGGElement, unknown, null, undefined> | null = null
+let gLink: d3.Selection<SVGGElement, unknown, null, undefined> | null = null
+let gNode: d3.Selection<SVGGElement, unknown, null, undefined> | null = null
+
+const tooltip = ref({ visible: false, x: 0, y: 0, text: '' })
+const selectedNode = ref<GraphNode | null>(null)
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function nodeRadius(n: GraphNode): number {
+  if (n.type === 'system') return 22
+  if (n.type === 'group') return 18
+  if (n.type === 'technology') return 12
+  // Transitive deps (when dependency data exists) are smaller
+  if (n.type === 'component' && hasDependencyData.value && !n.direct) return 5
+  return 7
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s
+}
+
+// ── SVG init ───────────────────────────────────────────────────────────────
+
+function initSvg(): boolean {
+  const svgEl = svgRef.value
+  if (!svgEl) return false
+
+  const svg = d3.select(svgEl)
+  svg.selectAll('*').remove()
+
+  gRoot = svg.append('g').attr('class', 'root')
+  gLink = gRoot.append('g').attr('class', 'links')
+  gNode = gRoot.append('g').attr('class', 'nodes')
+
+  zoomBehavior = d3.zoom<SVGSVGElement, unknown>()
+    .scaleExtent([0.15, 4])
+    .on('zoom', event => gRoot!.attr('transform', event.transform))
+
+  svg.call(zoomBehavior)
+  return true
+}
+
+// ── Graph update ───────────────────────────────────────────────────────────
+
+function updateGraph() {
+  if (!gLink || !gNode) return
+  if (visibleNodes.value.length === 0) return
+
+  const containerEl = containerRef.value
+  const width = containerEl?.clientWidth || 800
+  const height = containerEl?.clientHeight || 520
+
+  const simNodes: GraphNode[] = visibleNodes.value.map(n => {
+    const cached = positionCache.get(n.id)
+    return {
+      ...n,
+      x: cached?.x ?? width / 2 + (Math.random() - 0.5) * 80,
+      y: cached?.y ?? height / 2 + (Math.random() - 0.5) * 80,
+    }
+  })
+
+  const nodeById = new Map(simNodes.map(n => [n.id, n]))
+  const simEdges = visibleEdges.value
+    .map(e => {
+      const src = typeof e.source === 'string' ? e.source : (e.source as GraphNode).id
+      const tgt = typeof e.target === 'string' ? e.target : (e.target as GraphNode).id
+      return { source: nodeById.get(src)!, target: nodeById.get(tgt)! }
+    })
+    .filter(e => e.source && e.target)
+
+  if (simulation) simulation.stop()
+
+  const drag = d3.drag<SVGGElement, GraphNode>()
+    .on('start', (event, d) => {
+      if (!event.active) simulation?.alphaTarget(0.3).restart()
+      d.fx = d.x; d.fy = d.y
+    })
+    .on('drag', (event, d) => { d.fx = event.x; d.fy = event.y })
+    .on('end', (event, d) => {
+      if (!event.active) simulation?.alphaTarget(0)
+      d.fx = null; d.fy = null
+    })
+
+  const linkSel = gLink!
+    .selectAll<SVGLineElement, { source: GraphNode; target: GraphNode }>('line')
+    .data(simEdges, d => `${d.source.id}→${d.target.id}`)
+  linkSel.exit().remove()
+  const links = linkSel.enter().append('line')
+    .attr('stroke', 'var(--ui-border)')
+    .attr('stroke-width', 1.5)
+    .attr('stroke-opacity', 0.7)
+    .merge(linkSel)
+
+  const nodeSel = gNode!
+    .selectAll<SVGGElement, GraphNode>('g.node')
+    .data(simNodes, d => d.id)
+  nodeSel.exit().remove()
+
+  const nodeEnter = nodeSel.enter().append('g')
+    .attr('class', 'node')
+    .attr('cursor', 'pointer')
+    .call(drag)
+    .on('click', (_event, d) => {
+      if (d.type === 'group') {
+        toggleGroup(d.id)
+      } else if (d.type === 'component') {
+        if (d.dependsOn && d.dependsOn.length > 0) {
+          // Has dependencies — drill down instead of opening detail panel
+          toggleComponent(d.id)
+        } else {
+          // Leaf node — open detail panel
+          selectedNode.value = selectedNode.value?.id === d.id ? null : d
+        }
+      }
+    })
+
+    .on('mouseover', (event: MouseEvent, d: GraphNode) => {
+      const cEl = containerRef.value
+      if (!cEl) return
+      const r = cEl.getBoundingClientRect()
+      tooltip.value = {
+        visible: true,
+        x: event.clientX - r.left + 12,
+        y: event.clientY - r.top - 8,
+        text: d.type === 'group'
+          ? (() => {
+              const total = d.count ?? 0
+              const isExpanded = expandedGroups.value.has(d.id)
+              if (!isExpanded) {
+                if (hasDependencyData.value) {
+                  const directCount = directCountByPm.value.get(d.packageManager ?? 'unknown') ?? 0
+                  return `${d.packageManager} — ${directCount} direct of ${total} total — click to expand`
+                }
+                return `${d.packageManager} — ${total} component${total === 1 ? '' : 's'} — click to expand`
+              }
+              return `${d.packageManager} — click to collapse`
+            })()
+          : d.type === 'component'
+            ? (() => {
+                const base = `${d.label}${d.version ? ' v' + d.version : ''}`
+                if (!hasDependencyData.value) return base
+                const tag = d.direct ? ' (direct)' : ' (transitive)'
+                const deps = d.dependsOn?.length ?? 0
+                return deps > 0 ? `${base}${tag} — ${deps} dep${deps === 1 ? '' : 's'} — click to ${expandedComponents.value.has(d.id) ? 'collapse' : 'expand'}` : `${base}${tag}`
+              })()
+            : d.label,
+      }
+    })
+    .on('mousemove', (event: MouseEvent) => {
+      const cEl = containerRef.value
+      if (!cEl) return
+      const r = cEl.getBoundingClientRect()
+      tooltip.value.x = event.clientX - r.left + 12
+      tooltip.value.y = event.clientY - r.top - 8
+    })
+    .on('mouseout', () => { tooltip.value.visible = false })
+
+  nodeEnter.each(function(d) {
+    const g = d3.select(this)
+    if (d.type === 'system') {
+      g.append('polygon').attr('points', `0,${-22} ${22},0 0,${22} ${-22},0`)
+        .attr('fill', 'var(--ui-primary)').attr('stroke', 'var(--ui-bg)').attr('stroke-width', 2)
+    } else if (d.type === 'group') {
+      g.append('circle').attr('r', 18)
+        .attr('fill', pmColor(d.packageManager)).attr('fill-opacity', 0.85)
+        .attr('stroke', 'var(--ui-bg)').attr('stroke-width', 2)
+    } else if (d.type === 'technology') {
+      g.append('rect').attr('x', -10).attr('y', -10).attr('width', 20).attr('height', 20).attr('rx', 3)
+        .attr('fill', 'var(--ui-primary)').attr('fill-opacity', 0.4)
+        .attr('stroke', 'var(--ui-primary)').attr('stroke-width', 1.5)
+    } else {
+      // Direct deps: full size + white ring; transitive: smaller + dimmed
+      const isDirect = !hasDependencyData.value || d.direct === true
+      const r = isDirect ? 7 : 5
+      const opacity = isDirect ? 0.9 : 0.5
+      g.append('circle').attr('r', r)
+        .attr('fill', pmColor(d.packageManager)).attr('fill-opacity', opacity)
+        .attr('stroke', isDirect ? 'var(--ui-bg)' : 'none').attr('stroke-width', 1.5)
+    }
+    g.append('text')
+      .attr('dy', d.type === 'system' ? 32 : d.type === 'group' ? 28 : 18)
+      .attr('text-anchor', 'middle').attr('font-size', 10)
+      .attr('fill', 'var(--ui-text)').attr('pointer-events', 'none').attr('user-select', 'none')
+      .text(d.type === 'group'
+        ? truncate(`${d.packageManager ?? 'unknown'} (${d.count})`, 16)
+        : truncate(d.label, 14))
+  })
+
+  const nodes = nodeEnter.merge(nodeSel)
+
+  simulation = d3.forceSimulation<GraphNode>(simNodes)
+    .force('link', d3.forceLink<GraphNode, { source: GraphNode; target: GraphNode }>(simEdges)
+      .id(d => d.id)
+      .distance(d => {
+        const s = d.source as GraphNode; const t = d.target as GraphNode
+        if (s.type === 'system' || t.type === 'system') return 130
+        if (s.type === 'group' || t.type === 'group') return 90
+        return 60
+      })
+    )
+    .force('charge', d3.forceManyBody<GraphNode>().strength(d => {
+      if (d.type === 'system') return -600
+      if (d.type === 'group') return -300
+      return -80
+    }))
+    .force('center', d3.forceCenter(width / 2, height / 2))
+    .force('collide', d3.forceCollide<GraphNode>().radius(d => nodeRadius(d) + 8))
+    .on('tick', () => {
+      simNodes.forEach(n => {
+        if (n.x !== undefined && n.y !== undefined) positionCache.set(n.id, { x: n.x, y: n.y })
+      })
+      links
+        .attr('x1', d => (d.source as GraphNode).x ?? 0)
+        .attr('y1', d => (d.source as GraphNode).y ?? 0)
+        .attr('x2', d => (d.target as GraphNode).x ?? 0)
+        .attr('y2', d => (d.target as GraphNode).y ?? 0)
+      nodes.attr('transform', d => `translate(${d.x ?? 0},${d.y ?? 0})`)
+    })
+}
+
+// ── Reset zoom ─────────────────────────────────────────────────────────────
+
+function resetZoom() {
+  const svgEl = svgRef.value
+  if (!svgEl || !zoomBehavior) return
+  d3.select(svgEl).transition().duration(400).call(zoomBehavior.transform, d3.zoomIdentity)
+}
+
+// ── Render ─────────────────────────────────────────────────────────────────
+
+function render() {
+  if (!hasNodes.value) return
+  if (!gLink || !gNode) {
+    if (!initSvg()) return
+  }
+  updateGraph()
+}
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+
+onMounted(() => render())
+
+watch(svgRef, (el) => { if (el) render() }, { flush: 'post' })
+
+// Watch only the derived computeds — they already depend on props.nodes/edges
+// and expand state, so watching the raw props too would double-fire render().
+watch(
+  [visibleNodes, visibleEdges],
+  () => render(),
+  { flush: 'post' }
+)
+
+onBeforeUnmount(() => {
+  simulation?.stop()
+})
+</script>

--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -71,6 +71,7 @@
 
 <script setup lang="ts">
 import { h, resolveComponent, defineComponent, ref } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
 import type { TableColumn } from '@nuxt/ui'
 import type { ApiResponse, Component } from '~~/types/api'
 
@@ -90,10 +91,6 @@ const ComponentNameCell = defineComponent({
   setup(props) {
     const { state, fetch } = useComponentDescription(props.component)
 
-    const group = props.component.group
-    const name = props.component.name
-    const displayName = group ? `${group}/${name}` : name
-
     function tooltipContent() {
       if (state.value.pending) return 'Loading…'
       if (state.value.description) return state.value.description
@@ -101,8 +98,14 @@ const ComponentNameCell = defineComponent({
       return 'Hover to load description'
     }
 
-    return () =>
-      h(
+    return () => {
+      // Read from props inside the render function so the display name
+      // updates when the row is reused with a different component.
+      const displayName = props.component.group
+        ? `${props.component.group}/${props.component.name}`
+        : props.component.name
+
+      return h(
         UTooltip,
         {
           onMouseenter: fetch,
@@ -113,6 +116,7 @@ const ComponentNameCell = defineComponent({
           content: () => tooltipContent()
         }
       )
+    }
   }
 })
 
@@ -230,8 +234,6 @@ const columns: TableColumn<Component>[] = [
 
 const sorting = ref([])
 
-watch(sorting, () => { page.value = 1 })
-
 const route = useRoute()
 const licenseFilter = computed(() => route.query.license as string | undefined)
 const systemFilter = computed(() => route.query.system as string | undefined)
@@ -241,39 +243,30 @@ const pageSize = 20
 
 const searchInput = ref('')
 const debouncedSearch = ref('')
-let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
-watch(searchInput, (value) => {
-  if (debounceTimer) clearTimeout(debounceTimer)
-  debounceTimer = setTimeout(() => {
-    debouncedSearch.value = value
-    page.value = 1
-  }, 300)
-})
+// Reset page when any filter changes
+watch([debouncedSearch, licenseFilter, systemFilter, sorting], () => { page.value = 1 })
 
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = {
-    limit: pageSize,
-    offset: (page.value - 1) * pageSize
-  }
-  if (debouncedSearch.value) {
-    params.search = debouncedSearch.value
-  }
-  if (licenseFilter.value) {
-    params.license = licenseFilter.value
-  }
-  if (systemFilter.value) {
-    params.system = systemFilter.value
-  }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
-})
+const updateSearch = useDebounceFn((value: string) => { debouncedSearch.value = value }, 300)
+watch(searchInput, updateSearch)
 
+const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
+const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
+const offset = computed(() => (page.value - 1) * pageSize)
+
+// Pass individual refs/computeds as query values so Nuxt tracks each one
+// as a reactive dependency for the fetch key — passing a computed object
+// does not work because reactive() unwraps it at setup time.
 const { data, pending, error } = await useFetch<ApiResponse<Component>>('/api/components', {
-  query: queryParams
+  query: {
+    limit: pageSize,
+    offset,
+    search: debouncedSearch,
+    license: licenseFilter,
+    system: systemFilter,
+    sortBy,
+    sortOrder,
+  },
 })
 
 const components = computed(() => data.value?.data || [])

--- a/app/pages/systems/[name]/index.vue
+++ b/app/pages/systems/[name]/index.vue
@@ -115,6 +115,25 @@
           />
         </div>
       </UCard>
+
+      <UCard v-if="data.data.componentCount > 0">
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon name="i-lucide-share-2" class="w-5 h-5 text-(--ui-primary)" />
+            <h2 class="text-lg font-semibold">Dependency Graph</h2>
+          </div>
+          <p class="text-sm text-(--ui-text-muted) mt-1">
+            Click a group to show direct dependencies. Click a component to drill into its dependencies.
+          </p>
+        </template>
+        <ClientOnly>
+          <SystemDependencyGraph
+            :system-name="data.data.name"
+            :nodes="graphData?.data?.nodes ?? []"
+            :edges="graphData?.data?.edges ?? []"
+          />
+        </ClientOnly>
+      </UCard>
     </template>
   </div>
 </template>
@@ -138,7 +157,40 @@ interface SystemResponse {
   data: System
 }
 
+interface GraphNode {
+  id: string
+  label: string
+  type: 'system' | 'group' | 'component' | 'technology'
+  packageManager?: string | null
+  count?: number
+  version?: string | null
+  componentType?: string | null
+  scope?: string | null
+  purl?: string | null
+  cpe?: string | null
+  group?: string | null
+  description?: string | null
+  licenses?: Array<{ id?: string; name?: string; allowed?: boolean }>
+  technologyName?: string | null
+}
+
+interface GraphEdge {
+  source: string
+  target: string
+}
+
+interface GraphResponse {
+  success: boolean
+  data: { nodes: GraphNode[]; edges: GraphEdge[] }
+}
+
 const { data, pending, error } = await useFetch<SystemResponse>(() => `/api/systems/${encodeURIComponent(route.params.name as string)}`)
+
+// Graph data fetched in parallel — passed as a prop so the graph component
+// stays purely presentational (no async setup, no hydration conflicts).
+const { data: graphData } = useFetch<GraphResponse>(
+  () => `/api/systems/${encodeURIComponent(route.params.name as string)}/graph`
+)
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleString()

--- a/app/pages/systems/index.vue
+++ b/app/pages/systems/index.vue
@@ -269,7 +269,10 @@ const columns: TableColumn<System>[] = [
     cell: ({ row }) => {
       const system = row.original
       return h('div', {}, [
-        h('strong', {}, system.name),
+        h(resolveComponent('NuxtLink'), {
+          to: `/systems/${encodeURIComponent(system.name)}`,
+          class: 'font-semibold hover:underline'
+        }, () => system.name),
         h('p', { class: 'text-sm text-(--ui-text-muted)' }, system.domain)
       ])
     }
@@ -324,19 +327,18 @@ const columns: TableColumn<System>[] = [
 ]
 
 const sorting = ref([])
-watch(sorting, () => { page.value = 1 })
 const page = ref(1)
 const pageSize = 20
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = { limit: pageSize, offset: (page.value - 1) * pageSize }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
-})
 
-const { data, pending, error } = await useFetch<SystemsResponse>('/api/systems', { query: queryParams })
+watch(sorting, () => { page.value = 1 })
+
+const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
+const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
+const offset = computed(() => (page.value - 1) * pageSize)
+
+const { data, pending, error } = await useFetch<SystemsResponse>('/api/systems', {
+  query: { limit: pageSize, offset, sortBy, sortOrder }
+})
 
 const systems = computed(() => data.value?.data || [])
 const total = computed(() => data.value?.total || data.value?.count || 0)

--- a/app/pages/technologies/index.vue
+++ b/app/pages/technologies/index.vue
@@ -729,19 +729,18 @@ async function confirmLinkComponent() {
 }
 
 const sorting = ref([])
-watch(sorting, () => { page.value = 1 })
 const page = ref(1)
 const pageSize = 20
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = { limit: pageSize, offset: (page.value - 1) * pageSize }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
-})
 
-const { data, pending, error } = await useFetch<ApiResponse<Technology>>('/api/technologies', { query: queryParams })
+watch(sorting, () => { page.value = 1 })
+
+const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
+const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
+const offset = computed(() => (page.value - 1) * pageSize)
+
+const { data, pending, error } = await useFetch<ApiResponse<Technology>>('/api/technologies', {
+  query: { limit: pageSize, offset, sortBy, sortOrder }
+})
 
 const technologies = computed(() => data.value?.data || [])
 const total = computed(() => data.value?.total || data.value?.count || 0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@nuxt/ui": "4.7.1",
         "@sidebase/nuxt-auth": "1.2.0",
         "ajv": "^8.20.0",
+        "d3": "^7.9.0",
         "eslint": "^10.3.0",
         "mermaid": "^11.13.0",
         "next-auth": "4.22.5",
@@ -37,6 +38,7 @@
         "@cucumber/messages": "^32.3.1",
         "@iconify-json/lucide": "^1.2.105",
         "@playwright/test": "^1.59.1",
+        "@types/d3": "^7.4.3",
         "@types/node": "^25.6.0",
         "@types/semver": "^7.7.1",
         "@types/swagger-jsdoc": "^6.0.4",
@@ -6670,6 +6672,8 @@
     },
     "node_modules/@types/d3": {
       "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
       "license": "MIT",
       "dependencies": {
         "@types/d3-array": "*",
@@ -9632,6 +9636,8 @@
     },
     "node_modules/d3": {
       "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
       "license": "ISC",
       "dependencies": {
         "d3-array": "3",

--- a/package.json
+++ b/package.json
@@ -65,12 +65,14 @@
     "docs:api": "tsx server/scripts/generate-openapi.ts"
   },
   "dependencies": {
+    "@cyclonedx/cdxgen": "^12.3.2",
     "@nuxt/eslint": "^1.13.0",
     "@nuxt/image": "^2.0.0",
     "@nuxt/test-utils": "^4.0.3",
     "@nuxt/ui": "4.7.1",
     "@sidebase/nuxt-auth": "1.2.0",
     "ajv": "^8.20.0",
+    "d3": "^7.9.0",
     "eslint": "^10.3.0",
     "mermaid": "^11.13.0",
     "next-auth": "4.22.5",
@@ -80,9 +82,8 @@
     "spdx-expression-parse": "^4.0.0",
     "spdx-license-list": "^6.11.0",
     "tailwindcss": "^4.2.4",
-    "typescript": "^6.0.3",
     "tsx": "^4.21.0",
-    "@cyclonedx/cdxgen": "^12.3.2",
+    "typescript": "^6.0.3",
     "vue": "^3.5.33"
   },
   "devDependencies": {
@@ -92,6 +93,7 @@
     "@cucumber/messages": "^32.3.1",
     "@iconify-json/lucide": "^1.2.105",
     "@playwright/test": "^1.59.1",
+    "@types/d3": "^7.4.3",
     "@types/node": "^25.6.0",
     "@types/semver": "^7.7.1",
     "@types/swagger-jsdoc": "^6.0.4",

--- a/schema/migrations/common/20260505_100000_component_purl_as_merge_key.down.cypher
+++ b/schema/migrations/common/20260505_100000_component_purl_as_merge_key.down.cypher
@@ -1,0 +1,10 @@
+// Rollback: Restore name+version+packageManager as the Component MERGE key
+//
+// Re-creates the composite uniqueness constraint dropped by the up migration.
+// Note: if duplicate {name, version, packageManager} nodes were created after
+// the up migration ran, this rollback will fail until those duplicates are
+// resolved manually.
+
+CREATE CONSTRAINT component_name_version_pm_unique IF NOT EXISTS
+FOR (c:Component)
+REQUIRE (c.name, c.version, c.packageManager) IS UNIQUE;

--- a/schema/migrations/common/20260505_100000_component_purl_as_merge_key.up.cypher
+++ b/schema/migrations/common/20260505_100000_component_purl_as_merge_key.up.cypher
@@ -1,0 +1,23 @@
+// Migration: Use purl as the primary MERGE key for Component nodes
+//
+// Previously, Component nodes were merged on {name, version, packageManager}.
+// This key is not unique for scoped npm packages: CycloneDX strips the @scope/
+// prefix from the name field, so @types/linkify-it@5.0.0 and linkify-it@5.0.0
+// both produce name='linkify-it'. They collided into a single node, corrupting
+// bomRef and breaking DEPENDS_ON edge resolution for the displaced package.
+//
+// The fix: purl is the canonical unique identifier. The component_purl_unique
+// constraint already exists; this migration drops the name+version+pm constraint
+// and backfills purl on any legacy nodes that lack it.
+
+// Step 1: Backfill purl on legacy Component nodes that were created before purl
+//         was stored. Uses name@version as a stable fallback key so the
+//         component_purl_unique constraint can be satisfied.
+MATCH (c:Component)
+WHERE c.purl IS NULL
+SET c.purl = c.name + '@' + COALESCE(c.version, 'unknown');
+
+// Step 2: Drop the name+version+packageManager uniqueness constraint. It is
+//         superseded by component_purl_unique and causes false collisions for
+//         scoped npm packages.
+DROP CONSTRAINT component_name_version_pm_unique IF EXISTS;

--- a/server/api/systems/[name]/graph.get.ts
+++ b/server/api/systems/[name]/graph.get.ts
@@ -1,0 +1,143 @@
+import { SystemRepository } from '../../../repositories/system.repository'
+
+interface GraphNode {
+  id: string
+  label: string
+  type: 'system' | 'group' | 'component' | 'technology'
+  packageManager?: string | null
+  count?: number
+  // Component detail fields (type === 'component')
+  version?: string | null
+  componentType?: string | null
+  scope?: string | null
+  purl?: string | null
+  cpe?: string | null
+  group?: string | null
+  description?: string | null
+  licenses?: Array<{ id?: string; name?: string; allowed?: boolean }>
+  technologyName?: string | null
+  /** True when this component is a direct dependency of the system */
+  direct?: boolean
+  /** IDs of component nodes this component directly depends on */
+  dependsOn?: string[]
+}
+
+interface GraphEdge {
+  source: string
+  target: string
+}
+
+/**
+ * @openapi
+ * /systems/{name}/graph:
+ *   get:
+ *     tags:
+ *       - Systems
+ *     summary: Get dependency graph data for a system
+ *     description: |
+ *       Returns all nodes and edges for the system dependency graph.
+ *       Nodes include the system, packageManager group nodes, individual
+ *       component nodes, and technology nodes. Expand/collapse state is
+ *       managed client-side.
+ *     parameters:
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Graph data returned
+ *       404:
+ *         description: System not found
+ */
+export default defineEventHandler(async (event) => {
+  const rawName = getRouterParam(event, 'name')
+
+  if (!rawName) {
+    throw createError({ statusCode: 400, message: 'System name is required' })
+  }
+
+  const name = decodeURIComponent(rawName)
+  const repo = new SystemRepository()
+  const rows = await repo.getGraph(name)
+
+  if (rows === null) {
+    throw createError({ statusCode: 404, message: `System '${name}' not found` })
+  }
+
+  const systemId = `system:${name}`
+  const nodes: GraphNode[] = [{ id: systemId, label: name, type: 'system' }]
+  const edges: GraphEdge[] = []
+
+  // Single pass: count per packageManager and collect known purls simultaneously
+  const groupsSeen = new Map<string, number>() // packageManager → count
+  const techsSeen = new Set<string>()
+  const knownPurls = new Set<string>()
+
+  for (const row of rows) {
+    if (!row.name) continue
+    groupsSeen.set(row.packageManager ?? 'unknown', (groupsSeen.get(row.packageManager ?? 'unknown') ?? 0) + 1)
+    if (row.purl) knownPurls.add(row.purl)
+  }
+
+  // Add group nodes and system→group edges
+  for (const [pm, count] of groupsSeen) {
+    const groupId = `group:${pm}`
+    nodes.push({ id: groupId, label: `${pm} (${count})`, type: 'group', packageManager: pm, count })
+    edges.push({ source: systemId, target: groupId })
+  }
+
+  // Add component nodes, technology nodes, and all edges
+  for (const row of rows) {
+    if (!row.name) continue
+
+    const pm = row.packageManager ?? 'unknown'
+    const compId = `comp:${row.purl ?? `${row.name}@${row.version ?? ''}`}`
+    const groupId = `group:${pm}`
+
+    // Resolve dependsOnPurls to node IDs; drop purls not present in this graph
+    const dependsOn = row.dependsOnPurls
+      .filter(p => knownPurls.has(p))
+      .map(p => `comp:${p}`)
+
+    nodes.push({
+      id: compId,
+      label: row.name,
+      type: 'component',
+      packageManager: pm,
+      version: row.version,
+      componentType: row.type,
+      scope: row.scope,
+      purl: row.purl,
+      cpe: row.cpe,
+      group: row.group,
+      description: row.description,
+      licenses: row.licenses,
+      technologyName: row.technologyName,
+      direct: row.direct,
+      dependsOn,
+    })
+
+    edges.push({ source: groupId, target: compId })
+
+    // comp→comp edges for dependency drill-down
+    for (const depId of dependsOn) {
+      edges.push({ source: compId, target: depId })
+    }
+
+    if (row.technologyName) {
+      const techId = `tech:${row.technologyName}`
+      if (!techsSeen.has(techId)) {
+        techsSeen.add(techId)
+        nodes.push({ id: techId, label: row.technologyName, type: 'technology' })
+      }
+      edges.push({ source: compId, target: techId })
+    }
+  }
+
+  return {
+    success: true,
+    data: { nodes, edges }
+  }
+})

--- a/server/database/queries/components/find-all.cypher
+++ b/server/database/queries/components/find-all.cypher
@@ -1,11 +1,12 @@
-// Phase 1: filter on component properties, then join and apply join filters
+// Phase 1: filter on component properties, then paginate.
+// All filters are applied via {{COMPONENT_WHERE}} before any OPTIONAL MATCH so that
+// WHERE clauses are never placed after OPTIONAL MATCH (which in Cypher only affects
+// the optional pattern, not the row).
 MATCH (c:Component)
 {{COMPONENT_WHERE}}
 OPTIONAL MATCH (c)-[:IS_VERSION_OF]->(tech:Technology)
-{{LICENSE_MATCH}}
-{{JOIN_WHERE}}
 {{PRE_AGGREGATION}}
-WITH collect({c: c, tech: tech{{PRE_AGG_COLLECT}}}) as allRows, count(c) as total
+WITH collect({c: c, tech: tech{{PRE_AGG_COLLECT}}}) as allRows, count(DISTINCT c) as total
 UNWIND allRows as row
 WITH row.c as c, row.tech as tech, total{{PRE_AGG_UNWIND}}
 ORDER BY {{PRE_ORDER_BY}}

--- a/server/database/queries/sboms/persist-components-core.cypher
+++ b/server/database/queries/sboms/persist-components-core.cypher
@@ -1,0 +1,52 @@
+// Phase 1: MERGE Component nodes and USES relationships, set scalar properties.
+// Deliberately excludes hashes, licenses, and external references — those are
+// handled separately in persist-components-relations.cypher so each transaction
+// stays small enough to fit within Neo4j's transaction memory limit.
+//
+// MERGE key: purl is the canonical unique identifier for a component. For
+// components without a purl, falls back to name@version to avoid null-key
+// collisions (null != null in Neo4j MERGE).
+//
+// ON CREATE / ON MATCH set a transient _new flag used only for counting;
+// no pre-MERGE OPTIONAL MATCH is needed to detect existence.
+MATCH (s:System {name: $systemName})
+UNWIND $components AS comp
+WITH s, comp,
+     COALESCE(comp.purl, comp.name + '@' + COALESCE(comp.version, 'unknown')) AS componentPurl
+
+MERGE (c:Component {purl: componentPurl})
+ON CREATE SET
+  c.name = comp.name,
+  c.version = COALESCE(comp.version, 'unknown'),
+  c.packageManager = COALESCE(comp.packageManager, 'unknown'),
+  c.createdAt = $timestamp,
+  c._new = true
+ON MATCH SET
+  c.updatedAt = $timestamp,
+  c._new = false
+
+WITH s, c, comp, c._new AS isNew
+REMOVE c._new
+
+FOREACH (_ IN CASE WHEN comp.cpe IS NOT NULL THEN [1] ELSE [] END | SET c.cpe = comp.cpe)
+FOREACH (_ IN CASE WHEN comp.bomRef IS NOT NULL THEN [1] ELSE [] END | SET c.bomRef = comp.bomRef)
+FOREACH (_ IN CASE WHEN comp.type IS NOT NULL THEN [1] ELSE [] END | SET c.type = comp.type)
+FOREACH (_ IN CASE WHEN comp.group IS NOT NULL THEN [1] ELSE [] END | SET c.group = comp.group)
+FOREACH (_ IN CASE WHEN comp.scope IS NOT NULL THEN [1] ELSE [] END | SET c.scope = comp.scope)
+FOREACH (_ IN CASE WHEN comp.copyright IS NOT NULL THEN [1] ELSE [] END | SET c.copyright = comp.copyright)
+FOREACH (_ IN CASE WHEN comp.supplier IS NOT NULL THEN [1] ELSE [] END | SET c.supplier = comp.supplier)
+FOREACH (_ IN CASE WHEN comp.author IS NOT NULL THEN [1] ELSE [] END | SET c.author = comp.author)
+FOREACH (_ IN CASE WHEN comp.publisher IS NOT NULL THEN [1] ELSE [] END | SET c.publisher = comp.publisher)
+FOREACH (_ IN CASE WHEN comp.homepage IS NOT NULL THEN [1] ELSE [] END | SET c.homepage = comp.homepage)
+FOREACH (_ IN CASE WHEN comp.description IS NOT NULL THEN [1] ELSE [] END | SET c.description = comp.description)
+
+MERGE (s)-[r:USES]->(c)
+ON CREATE SET r.addedAt = $timestamp, r._new = true
+ON MATCH SET r.lastSeenAt = $timestamp, r._new = false
+
+WITH isNew, r, r._new AS relIsNew
+REMOVE r._new
+
+RETURN sum(CASE WHEN isNew THEN 1 ELSE 0 END) AS componentsAdded,
+       sum(CASE WHEN isNew THEN 0 ELSE 1 END) AS componentsUpdated,
+       sum(CASE WHEN relIsNew THEN 1 ELSE 0 END) AS relationshipsCreated

--- a/server/database/queries/sboms/persist-components-relations.cypher
+++ b/server/database/queries/sboms/persist-components-relations.cypher
@@ -1,0 +1,46 @@
+// Phase 2: Replace hashes, licenses, and external references for a batch of
+// components. Runs after persist-components-core.cypher with a smaller batch
+// size (RELATIONS_BATCH_SIZE) to keep each transaction within memory limits.
+//
+// Hash and ExternalReference nodes are shared across components (MERGEd on
+// their content). Only the relationships are deleted and re-created — the
+// nodes themselves are left intact to avoid corrupting other components.
+UNWIND $components AS comp
+MATCH (c:Component {purl: COALESCE(comp.purl, comp.name + '@' + COALESCE(comp.version, 'unknown'))})
+
+// Replace hashes — delete only the relationships, not the shared Hash nodes
+OPTIONAL MATCH (c)-[oldHashRel:HAS_HASH]->(:Hash)
+DELETE oldHashRel
+
+WITH c, comp
+FOREACH (hash IN comp.hashes |
+  MERGE (h:Hash {algorithm: hash.algorithm, value: hash.value})
+  MERGE (c)-[:HAS_HASH]->(h)
+)
+
+// Replace licenses — delete only the relationships, not the shared License nodes
+WITH c, comp
+OPTIONAL MATCH (c)-[oldLicRel:HAS_LICENSE]->(:License)
+DELETE oldLicRel
+
+WITH c, comp
+FOREACH (lic IN comp.licenses |
+  MERGE (l:License {id: COALESCE(lic.id, lic.name)})
+  ON CREATE SET l.name = lic.name, l.url = lic.url, l.text = lic.text, l.expression = lic.expression
+  ON MATCH SET l.name = COALESCE(lic.name, l.name), l.url = COALESCE(lic.url, l.url)
+  FOREACH (_ IN CASE WHEN lic.allowed IS NOT NULL THEN [1] ELSE [] END | SET l.allowed = lic.allowed)
+  MERGE (c)-[:HAS_LICENSE]->(l)
+)
+
+// Replace external references — delete only the relationships, not the shared ExternalReference nodes
+WITH c, comp
+OPTIONAL MATCH (c)-[oldRefRel:HAS_EXTERNAL_REF]->(:ExternalReference)
+DELETE oldRefRel
+
+WITH c, comp
+FOREACH (ref IN comp.externalReferences |
+  MERGE (er:ExternalReference {type: ref.type, url: ref.url})
+  MERGE (c)-[:HAS_EXTERNAL_REF]->(er)
+)
+
+RETURN count(c) AS componentsProcessed

--- a/server/database/queries/sboms/persist-dependencies.cypher
+++ b/server/database/queries/sboms/persist-dependencies.cypher
@@ -1,0 +1,10 @@
+// Create DEPENDS_ON edges between Component nodes based on SBOM dependency data.
+// Components are matched by bomRef. Unresolvable refs are silently skipped.
+UNWIND $dependencies AS dep
+MATCH (src:Component {bomRef: dep.ref})
+UNWIND dep.dependsOn AS targetRef
+MATCH (tgt:Component {bomRef: targetRef})
+MERGE (src)-[r:DEPENDS_ON]->(tgt)
+ON CREATE SET r.addedAt = $timestamp
+ON MATCH SET r.lastSeenAt = $timestamp
+RETURN count(r) AS edgesCreated

--- a/server/database/queries/sboms/persist-direct-deps.cypher
+++ b/server/database/queries/sboms/persist-direct-deps.cypher
@@ -1,0 +1,12 @@
+// Create (System)-[:DIRECT_DEP]->(Component) edges for each component
+// that the root component directly depends on.
+// $rootBomRef: bomRef of the root component (metadata.component)
+// $systemName: name of the system
+// $timestamp: ISO timestamp
+MATCH (sys:System {name: $systemName})
+UNWIND $directBomRefs AS targetRef
+MATCH (tgt:Component {bomRef: targetRef})
+MERGE (sys)-[r:DIRECT_DEP]->(tgt)
+ON CREATE SET r.addedAt = $timestamp
+ON MATCH SET r.lastSeenAt = $timestamp
+RETURN count(r) AS edgesCreated

--- a/server/database/queries/systems/delete.cypher
+++ b/server/database/queries/systems/delete.cypher
@@ -12,4 +12,21 @@ CREATE (a:AuditLog {
   userId: $userId,
   realUserId: $realUserId
 })
+
+// Collect components used exclusively by this system (no other USES relationship).
+// These become orphans once the system is removed and must be cleaned up.
+// OPTIONAL MATCH ensures the pipeline continues even when the system has no components.
+WITH s
+OPTIONAL MATCH (s)-[:USES]->(c:Component)
+WHERE NOT EXISTS { MATCH (other:System)-[:USES]->(c) WHERE other <> s }
+WITH s, collect(c) AS orphans
+
+// Delete Hash and ExternalReference nodes owned by orphaned components.
+// These node types have no meaning outside their parent component.
+FOREACH (c IN orphans |
+  DETACH DELETE c
+)
+
+// Remove the system and all its remaining relationships
+// (USES edges to shared components, DIRECT_DEP edges, HAS_SOURCE_IN, etc.)
 DETACH DELETE s

--- a/server/database/queries/systems/graph.cypher
+++ b/server/database/queries/systems/graph.cypher
@@ -1,0 +1,35 @@
+// Always returns at least one row when the system exists (c may be null when
+// there are no components). Returns zero rows when the system does not exist,
+// allowing the caller to distinguish not-found from empty without a separate
+// exists() query.
+MATCH (sys:System {name: $name})
+OPTIONAL MATCH (sys)-[:USES]->(c:Component)
+OPTIONAL MATCH (c)-[:IS_VERSION_OF]->(tech:Technology)
+OPTIONAL MATCH (c)-[:HAS_LICENSE]->(l:License)
+WITH sys, c, tech,
+     collect(DISTINCT {id: l.id, name: l.name, allowed: l.allowed}) AS licenses
+// direct=true when the system has a DIRECT_DEP edge to this component
+// (set at ingest time from the root component's dependsOn list)
+WITH sys, c, tech, licenses,
+     EXISTS { (sys)-[:DIRECT_DEP]->(c) } AS direct
+// Collect purls of c's direct dependencies that are also used by this system.
+// Filter null purls at match time to avoid collecting them into the list.
+OPTIONAL MATCH (c)-[:DEPENDS_ON]->(dep:Component)<-[:USES]-(sys)
+WHERE dep.purl IS NOT NULL
+WITH sys, c, tech, licenses, direct,
+     collect(DISTINCT dep.purl) AS dependsOnPurls
+RETURN sys.name AS systemName,
+       c.name AS name,
+       c.version AS version,
+       c.packageManager AS packageManager,
+       c.purl AS purl,
+       c.cpe AS cpe,
+       c.type AS type,
+       c.group AS `group`,
+       c.scope AS scope,
+       c.description AS description,
+       [lic IN licenses WHERE lic.id IS NOT NULL OR lic.name IS NOT NULL | lic] AS licenses,
+       tech.name AS technologyName,
+       direct,
+       dependsOnPurls
+ORDER BY c.packageManager, c.name, c.version

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -39,19 +39,16 @@ export class ComponentRepository extends BaseRepository {
   /**
    * Build WHERE conditions and params from filters.
    *
-   * Conditions are split into two groups:
-   * - componentConditions: reference only `c` properties, safe to place
-   *   before OPTIONAL MATCHes (avoids scoping issues in Cypher)
-   * - joinConditions: reference variables from OPTIONAL MATCH (tech, l),
-   *   must be placed after those matches
+   * All conditions reference only `c` and are applied before any OPTIONAL MATCH.
+   * Join-based filters (technology, license, hasLicense) use EXISTS subqueries so
+   * that a WHERE clause after an OPTIONAL MATCH is never needed — in Cypher, WHERE
+   * after OPTIONAL MATCH applies only to the optional pattern and does not filter rows.
    */
   private buildFilterConditions(filters: ComponentFilters): {
     componentConditions: string[]
-    joinConditions: string[]
     params: Record<string, unknown>
   } {
     const componentConditions: string[] = []
-    const joinConditions: string[] = []
     const params: Record<string, unknown> = {}
 
     if (filters.search) {
@@ -75,25 +72,22 @@ export class ComponentRepository extends BaseRepository {
     }
 
     if (filters.technology) {
-      joinConditions.push('tech.name = $technology')
+      componentConditions.push('EXISTS { MATCH (c)-[:IS_VERSION_OF]->(:Technology {name: $technology}) }')
       params.technology = filters.technology
     }
 
     if (filters.license) {
-      joinConditions.push('l.id = $license')
+      componentConditions.push('EXISTS { MATCH (c)-[:HAS_LICENSE]->(:License {id: $license}) }')
       params.license = filters.license
-      // Filtering by a specific license implies hasLicense=true, so
-      // ignore hasLicense to avoid contradictory conditions (e.g.,
-      // license=MIT AND l IS NULL can never match).
     } else if (filters.hasLicense !== undefined) {
       if (filters.hasLicense) {
-        joinConditions.push('l IS NOT NULL')
+        componentConditions.push('EXISTS { (c)-[:HAS_LICENSE]->(:License) }')
       } else {
-        joinConditions.push('l IS NULL')
+        componentConditions.push('NOT EXISTS { (c)-[:HAS_LICENSE]->(:License) }')
       }
     }
 
-    return { componentConditions, joinConditions, params }
+    return { componentConditions, params }
   }
 
   /**
@@ -104,16 +98,6 @@ export class ComponentRepository extends BaseRepository {
    * - OPTIONAL MATCH when filtering by license presence (hasLicense)
    * - Empty when no license filtering is needed (avoids row multiplication)
    */
-  private buildLicenseMatch(filters: ComponentFilters): string {
-    if (filters.license) {
-      return 'MATCH (c)-[:HAS_LICENSE]->(l:License)'
-    }
-    if (filters.hasLicense !== undefined) {
-      return 'OPTIONAL MATCH (c)-[:HAS_LICENSE]->(l:License)'
-    }
-    return ''
-  }
-
   /**
    * Inject dynamic placeholders into a loaded query template.
    */
@@ -137,14 +121,10 @@ export class ComponentRepository extends BaseRepository {
    */
   async findAll(filters: ComponentFilters = {}): Promise<{ data: Component[]; total: number }> {
     const baseQuery = await loadQuery('components/find-all.cypher')
-    const { componentConditions, joinConditions, params } = this.buildFilterConditions(filters)
+    const { componentConditions, params } = this.buildFilterConditions(filters)
 
     const componentWhere = componentConditions.length > 0
       ? `WHERE ${componentConditions.join(' AND ')}`
-      : ''
-
-    const joinWhere = joinConditions.length > 0
-      ? `WHERE ${joinConditions.join(' AND ')}`
       : ''
 
     let pagination = ''
@@ -176,8 +156,6 @@ export class ComponentRepository extends BaseRepository {
 
     const cypher = this.injectPlaceholders(baseQuery, {
       '{{COMPONENT_WHERE}}': componentWhere,
-      '{{LICENSE_MATCH}}': this.buildLicenseMatch(filters),
-      '{{JOIN_WHERE}}': joinWhere,
       '{{PRE_AGGREGATION}}': preAggregation,
       '{{PRE_AGG_COLLECT}}': preAggCollect,
       '{{PRE_AGG_UNWIND}}': preAggUnwind,

--- a/server/repositories/sbom.repository.ts
+++ b/server/repositories/sbom.repository.ts
@@ -1,5 +1,5 @@
 import { BaseRepository } from './base.repository'
-import type { PersistSBOMParams, PersistSBOMResult } from '../types/sbom'
+import type { PersistSBOMParams, PersistSBOMResult, ComponentDependency } from '../types/sbom'
 
 /**
  * Repository for SBOM-related data access
@@ -14,19 +14,18 @@ export class SBOMRepository extends BaseRepository {
    * @param params - SBOM persistence parameters
    * @returns Persistence result with counts
    */
-  // Number of components processed per transaction. Each component carries its
-  // own hashes/licenses/refs so Neo4j never holds the full batch lists in scope
-  // per row. Reduce further if individual components are unusually large.
+  // Batch size for phase 1 (scalar properties only — cheap)
   private static readonly BATCH_SIZE = 50
+  // Batch size for phase 2 (hashes/licenses/refs — expensive due to delete+recreate)
+  private static readonly RELATIONS_BATCH_SIZE = 10
 
   async persistSBOM(params: PersistSBOMParams): Promise<PersistSBOMResult> {
-    const query = await loadQuery('sboms/persist-components-flat.cypher')
+    const coreQuery = await loadQuery('sboms/persist-components-core.cypher')
+    const relationsQuery = await loadQuery('sboms/persist-components-relations.cypher')
     const timestamp = params.timestamp.toISOString()
 
-    // Embed hashes/licenses/refs inside each component so the Cypher query can
-    // access comp.hashes directly per row instead of filtering a global list.
-    // This avoids the O(n²) pattern where $hashes was scanned for every UNWIND row.
-    const allComponents = params.components.map((comp) => ({
+    // Scalar fields only — sent in phase 1 (large batches, cheap)
+    const coreComponents = params.components.map((comp) => ({
       name: comp.name,
       version: comp.version,
       packageManager: comp.packageManager,
@@ -42,25 +41,30 @@ export class SBOMRepository extends BaseRepository {
       publisher: comp.publisher,
       homepage: comp.homepage,
       description: comp.description,
+    }))
+
+    // Relation fields — sent in phase 2 (small batches, expensive)
+    const relComponents = params.components.map((comp) => ({
+      purl: comp.purl,
+      name: comp.name,
+      version: comp.version,
       hashes: comp.hashes.map(h => ({ algorithm: h.algorithm, value: h.value })),
       licenses: comp.licenses.map(l => ({ id: l.id, name: l.name, url: l.url, text: l.text, expression: l.expression })),
-      externalReferences: comp.externalReferences.map(r => ({ type: r.type, url: r.url }))
+      externalReferences: comp.externalReferences.map(r => ({ type: r.type, url: r.url })),
     }))
 
     let componentsAdded = 0
     let componentsUpdated = 0
     let relationshipsCreated = 0
 
-    // Process in batches — each batch is its own transaction
-    for (let start = 0; start < allComponents.length; start += SBOMRepository.BATCH_SIZE) {
-      const batchComponents = allComponents.slice(start, start + SBOMRepository.BATCH_SIZE)
-
-      const { records } = await this.executeQueryWithSession(query, {
+    // Phase 1: MERGE components and USES edges — batch of 50
+    for (let i = 0; i < coreComponents.length; i += SBOMRepository.BATCH_SIZE) {
+      const batch = coreComponents.slice(i, i + SBOMRepository.BATCH_SIZE)
+      const { records } = await this.executeQueryWithSession(coreQuery, {
         systemName: params.systemName,
-        components: batchComponents,
-        timestamp
+        components: batch,
+        timestamp,
       })
-
       if (records.length > 0) {
         componentsAdded += records[0]!.get('componentsAdded').toNumber()
         componentsUpdated += records[0]!.get('componentsUpdated').toNumber()
@@ -68,7 +72,54 @@ export class SBOMRepository extends BaseRepository {
       }
     }
 
+    // Phase 2: Replace hashes, licenses, external refs — batch of 10
+    for (let i = 0; i < relComponents.length; i += SBOMRepository.RELATIONS_BATCH_SIZE) {
+      const batch = relComponents.slice(i, i + SBOMRepository.RELATIONS_BATCH_SIZE)
+      await this.executeQueryWithSession(relationsQuery, {
+        components: batch,
+        timestamp,
+      })
+    }
+
+    // Persist DEPENDS_ON edges between components
+    if (params.dependencies.length > 0) {
+      await this.persistDependencies(params.dependencies, params.timestamp)
+    }
+
+    // Persist (System)-[:DIRECT_DEP]->(Component) edges
+    if (params.directDeps.length > 0) {
+      await this.persistDirectDeps(params.systemName, params.directDeps, params.timestamp)
+    }
+
     return { componentsAdded, componentsUpdated, relationshipsCreated }
+  }
+
+  /**
+   * Create DEPENDS_ON edges between Component nodes.
+   *
+   * Matches components by bomRef. Refs that don't resolve to a known
+   * Component node are silently skipped by the Cypher query.
+   */
+  private async persistDirectDeps(systemName: string, directBomRefs: string[], timestamp: Date): Promise<void> {
+    if (directBomRefs.length === 0) return
+    const query = await loadQuery('sboms/persist-direct-deps.cypher')
+    const ts = timestamp.toISOString()
+    for (let i = 0; i < directBomRefs.length; i += SBOMRepository.BATCH_SIZE) {
+      const batch = directBomRefs.slice(i, i + SBOMRepository.BATCH_SIZE)
+      await this.executeQuery(query, { systemName, directBomRefs: batch, timestamp: ts })
+    }
+  }
+
+  private async persistDependencies(dependencies: ComponentDependency[], timestamp: Date): Promise<void> {
+    if (dependencies.length === 0) return
+    const query = await loadQuery('sboms/persist-dependencies.cypher')
+    const filtered = dependencies.filter(d => d.dependsOn.length > 0)
+    if (filtered.length === 0) return
+    const ts = timestamp.toISOString()
+    for (let i = 0; i < filtered.length; i += SBOMRepository.BATCH_SIZE) {
+      const batch = filtered.slice(i, i + SBOMRepository.BATCH_SIZE)
+      await this.executeQuery(query, { dependencies: batch, timestamp: ts })
+    }
   }
 
   async createAuditLog(params: {

--- a/server/repositories/system.repository.ts
+++ b/server/repositories/system.repository.ts
@@ -26,6 +26,25 @@ export interface System {
   repositoryCount: number
 }
 
+export interface GraphComponentRow {
+  systemName: string
+  name: string | null
+  version: string | null
+  packageManager: string | null
+  purl: string | null
+  cpe: string | null
+  type: string | null
+  group: string | null
+  scope: string | null
+  description: string | null
+  licenses: Array<{ id?: string; name?: string; allowed?: boolean }>
+  technologyName: string | null
+  /** True when this component is a direct dependency (has a DEPENDS_ON edge from another system component) */
+  direct: boolean
+  /** PURLs of components this component directly depends on (within the same system) */
+  dependsOnPurls: string[]
+}
+
 export interface RepositoryInput {
   url: string
   name: string
@@ -179,6 +198,43 @@ export class SystemRepository extends BaseRepository {
       lastSbomScanAt: record.get('lastSbomScanAt')?.toString() || null,
       systemCount: 1
     }
+  }
+
+  /**
+   * Get graph data for a system: all components and their technology links.
+   *
+   * Returns null when the system does not exist.
+   * Returns an empty array when the system exists but has no components.
+   *
+   * @param name - System name
+   * @returns Array of component rows with technology info, or null if system not found
+   */
+  async getGraph(name: string): Promise<GraphComponentRow[] | null> {
+    const query = await loadQuery('systems/graph.cypher')
+    const { records } = await this.executeQuery(query, { name })
+
+    // Zero rows → system not found
+    if (records.length === 0) return null
+
+    // One row with c.name = null → system exists but has no components
+    if (records.length === 1 && records[0]!.get('name') === null) return []
+
+    return records.map(record => ({
+      systemName: record.get('systemName') as string,
+      name: record.get('name') as string | null,
+      version: record.get('version') as string | null,
+      packageManager: record.get('packageManager') as string | null,
+      purl: record.get('purl') as string | null,
+      cpe: record.get('cpe') as string | null,
+      type: record.get('type') as string | null,
+      group: record.get('group') as string | null,
+      scope: record.get('scope') as string | null,
+      description: record.get('description') as string | null,
+      licenses: (record.get('licenses') as Array<{ id?: string; name?: string; allowed?: boolean }>) ?? [],
+      technologyName: record.get('technologyName') as string | null,
+      direct: (record.get('direct') as boolean) ?? false,
+      dependsOnPurls: (record.get('dependsOnPurls') as string[]) ?? [],
+    }))
   }
 
   /**

--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -7,10 +7,22 @@ import type {
   ProcessSBOMInput,
   ProcessSBOMResult,
   ExtractedComponent,
+  ComponentDependency,
   ComponentHash,
   ComponentLicense,
   ExternalReference
 } from '../types/sbom'
+
+// SPDX relationship types that represent a dependency edge.
+// Defined at module level to avoid re-allocation on every call.
+const SPDX_DEPENDENCY_TYPES = new Set([
+  'DEPENDS_ON',
+  'DEV_DEPENDENCY_OF',
+  'OPTIONAL_DEPENDENCY_OF',
+  'PROVIDED_DEPENDENCY_OF',
+  'RUNTIME_DEPENDENCY_OF',
+  'TEST_DEPENDENCY_OF',
+])
 
 /**
  * Service for SBOM processing and persistence
@@ -73,14 +85,23 @@ export class SBOMService {
       throw error
     }
     
-    // 4. Extract components from SBOM
-    const components = this.extractComponents(input.sbom as Record<string, unknown>, input.format)
-    
+    // 4. Extract components and dependency relationships from SBOM
+    const sbomData = input.sbom as Record<string, unknown>
+    const components = this.extractComponents(sbomData, input.format)
+    const dependencies = this.extractDependencies(sbomData, input.format)
+    const { bomRef: rootBomRef, name: rootName } = this.extractRootBomRef(sbomData, input.format)
+    // Resolve direct deps here so the repository doesn't need to re-scan dependencies.
+    // Uses a fallback for SBOMs where the root bom-ref type differs between
+    // metadata.component and the dependencies[] entry (e.g. cdxgen without node_modules).
+    const directDeps = this.resolveDirectDeps(rootBomRef, rootName, dependencies)
+
     // 5. Persist to database
     const result = await this.sbomRepo.persistSBOM({
       systemName: system.name,
       repositoryUrl: normalizedUrl,
       components,
+      dependencies,
+      directDeps,
       format: input.format,
       timestamp: new Date()
     })
@@ -124,6 +145,119 @@ export class SBOMService {
     } else {
       return this.extractSPDXComponents(sbom)
     }
+  }
+
+  /**
+   * Extract the bomRef and name of the root component (the scanned system itself).
+   * CycloneDX: metadata.component['bom-ref'] and metadata.component.name
+   * SPDX: the SPDXID of the document element (SPDXRef-DOCUMENT); name is null
+   */
+  private extractRootBomRef(sbom: Record<string, unknown>, format: 'cyclonedx' | 'spdx'): { bomRef: string | null; name: string | null } {
+    if (format === 'cyclonedx') {
+      const metadata = sbom.metadata as Record<string, unknown> | undefined
+      const root = metadata?.component as Record<string, unknown> | undefined
+      return {
+        bomRef: (root?.['bom-ref'] as string)?.trim() || null,
+        name: (root?.name as string)?.trim() || null,
+      }
+    } else {
+      // SPDX: the document itself is the root; its SPDXID is typically SPDXRef-DOCUMENT
+      return {
+        bomRef: (sbom.SPDXID as string)?.trim() || null,
+        name: null,
+      }
+    }
+  }
+
+  /**
+   * Resolve the direct dependency bomRefs for the root component.
+   *
+   * cdxgen sometimes uses different purl types for the root component in
+   * `metadata.component` vs `dependencies[]`. For example, when run without
+   * `node_modules`, the root bom-ref may be `pkg:application/name@ver` while
+   * the dependencies entry uses `pkg:npm/name@ver`. The exact lookup finds the
+   * `application`-typed entry which has an empty `dependsOn` list.
+   *
+   * Strategy:
+   * 1. Exact match on `rootBomRef` — use it if `dependsOn` is non-empty.
+   * 2. Fallback: find the dependency entry whose purl name segment matches
+   *    `rootName` and has the most `dependsOn` entries.
+   */
+  private resolveDirectDeps(
+    rootBomRef: string | null,
+    rootName: string | null,
+    dependencies: ComponentDependency[]
+  ): string[] {
+    if (rootBomRef) {
+      const exact = dependencies.find(d => d.ref === rootBomRef)
+      if (exact && exact.dependsOn.length > 0) return exact.dependsOn
+    }
+
+    if (!rootName) return []
+
+    // Extract the name segment from a purl: pkg:<type>/<name>@<version> → <name>
+    const nameFromRef = (ref: string): string | null => {
+      const m = ref.match(/^pkg:[^/]+\/([^@]+)@/)
+      return m?.[1] ?? null
+    }
+
+    const candidates = dependencies
+      .filter(d => nameFromRef(d.ref) === rootName && d.dependsOn.length > 0)
+      .sort((a, b) => b.dependsOn.length - a.dependsOn.length)
+
+    return candidates[0]?.dependsOn ?? []
+  }
+
+  /**
+   * Extract component dependency relationships from a CycloneDX or SPDX SBOM.
+   *
+   * CycloneDX: reads the top-level `dependencies` array.
+   * SPDX: reads the top-level `relationships` array, filtered to dependency types.
+   *
+   * Returns an empty array if the SBOM has no dependency section.
+   */
+  private extractDependencies(sbom: Record<string, unknown>, format: 'cyclonedx' | 'spdx'): ComponentDependency[] {
+    if (format === 'cyclonedx') {
+      return this.extractCycloneDXDependencies(sbom)
+    } else {
+      return this.extractSPDXDependencies(sbom)
+    }
+  }
+
+  private extractCycloneDXDependencies(sbom: Record<string, unknown>): ComponentDependency[] {
+    const depsArray = sbom.dependencies as unknown[] | undefined
+    if (!Array.isArray(depsArray)) return []
+
+    return (depsArray as Record<string, unknown>[]).flatMap(dep => {
+      const ref = (dep.ref as string)?.trim()
+      if (!ref) return []
+      const dependsOn = dep.dependsOn as unknown[] | undefined
+      return [{
+        ref,
+        dependsOn: Array.isArray(dependsOn)
+          ? (dependsOn as string[]).map(r => r.trim()).filter(Boolean)
+          : [],
+      }]
+    })
+  }
+
+  private extractSPDXDependencies(sbom: Record<string, unknown>): ComponentDependency[] {
+    const relationships = sbom.relationships as unknown[] | undefined
+    if (!Array.isArray(relationships)) return []
+
+    // Group by spdxElementId → list of relatedSpdxElement
+    const map = new Map<string, string[]>()
+    for (const rel of relationships) {
+      const r = rel as Record<string, unknown>
+      if (!SPDX_DEPENDENCY_TYPES.has(r.relationshipType as string)) continue
+      const src = (r.spdxElementId as string)?.trim()
+      const tgt = (r.relatedSpdxElement as string)?.trim()
+      if (!src || !tgt) continue
+      if (!map.has(src)) map.set(src, [])
+      map.get(src)!.push(tgt)
+    }
+
+    return Array.from(map.entries()).map(([ref, dependsOn]) => ({ ref, dependsOn }))
   }
 
   /**
@@ -187,11 +321,12 @@ export class SBOMService {
    */
   private mapCycloneDXComponent(comp: Record<string, unknown>): ExtractedComponent {
     const supplier = comp.supplier as Record<string, unknown> | undefined
+    const purl = this.normalizePurl((comp.purl as string)?.trim() || null)
     return {
       name: comp.name as string,
       version: (comp.version as string)?.trim() || null,
-      packageManager: this.extractPackageManager(comp.purl as string | null),
-      purl: (comp.purl as string)?.trim() || null,
+      packageManager: this.extractPackageManager(purl),
+      purl,
       cpe: (comp.cpe as string)?.trim() || null,
       bomRef: (comp['bom-ref'] as string)?.trim() || null,
       type: (comp.type as string)?.trim() || null,
@@ -213,7 +348,7 @@ export class SBOMService {
    * Map SPDX package to ExtractedComponent
    */
   private mapSPDXPackage(pkg: Record<string, unknown>): ExtractedComponent {
-    const purl = this.extractPurlFromExternalRefs((pkg.externalRefs as unknown[]) || [])
+    const purl = this.normalizePurl(this.extractPurlFromExternalRefs((pkg.externalRefs as unknown[]) || []))
     
     return {
       name: pkg.name as string,
@@ -235,6 +370,17 @@ export class SBOMService {
       description: (pkg.description as string)?.trim() || null,
       externalReferences: this.extractSPDXReferences((pkg.externalRefs as unknown[]) || [])
     }
+  }
+
+  /**
+   * Normalize a purl by decoding percent-encoded characters that the purl spec
+   * does not require to be encoded. cdxgen encodes '@' as '%40' in the namespace
+   * portion of npm purls (e.g. pkg:npm/%40scope/name), which diverges from the
+   * spec and causes purl != bom-ref mismatches for scoped packages.
+   */
+  private normalizePurl(purl: string | null): string | null {
+    if (!purl) return null
+    return purl.replace(/%40/gi, '@')
   }
 
   /**

--- a/server/types/sbom.ts
+++ b/server/types/sbom.ts
@@ -59,10 +59,20 @@ export interface ExternalReference {
   url: string
 }
 
+export interface ComponentDependency {
+  /** bom-ref of the component that has dependencies */
+  ref: string
+  /** bom-refs of its direct dependencies */
+  dependsOn: string[]
+}
+
 export interface PersistSBOMParams {
   systemName: string
   repositoryUrl: string
   components: ExtractedComponent[]
+  dependencies: ComponentDependency[]
+  /** bomRefs of components that are direct dependencies of the system root */
+  directDeps: string[]
   format: 'cyclonedx' | 'spdx'
   timestamp: Date
 }

--- a/test/server/repositories/sbom.repository.spec.ts
+++ b/test/server/repositories/sbom.repository.spec.ts
@@ -34,6 +34,8 @@ describe('SBOMRepository', () => {
         repositoryUrl: `https://github.com/${PREFIX}org/repo`,
         format: 'cyclonedx',
         timestamp: new Date(),
+        dependencies: [],
+        directDeps: [],
         components: [
           {
             name: `${PREFIX}lodash`, version: '4.17.21',
@@ -63,6 +65,165 @@ describe('SBOMRepository', () => {
       `, { sys: `${PREFIX}my-system`, prefix: PREFIX })
 
       expect(check.records[0].get('count').toNumber()).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  describe('DIRECT_DEP edges via persistSBOM()', () => {
+    it('should create DIRECT_DEP edges for components listed in directDeps', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await seed(ctx.driver, `
+        CREATE (:System { name: $sys })
+        CREATE (:Repository { url: $url, name: $repoName })
+      `, {
+        sys: `${PREFIX}direct-system`,
+        url: `https://github.com/${PREFIX}org/direct-repo`,
+        repoName: `${PREFIX}direct-repo`,
+      })
+
+      const refA = `pkg:npm/${PREFIX}direct-comp-a@1.0.0`
+      const refB = `pkg:npm/${PREFIX}direct-comp-b@1.0.0`
+
+      await repo.persistSBOM({
+        systemName: `${PREFIX}direct-system`,
+        repositoryUrl: `https://github.com/${PREFIX}org/direct-repo`,
+        format: 'cyclonedx',
+        timestamp: new Date(),
+        dependencies: [
+          { ref: refA, dependsOn: [refB] },
+          { ref: refB, dependsOn: [] },
+        ],
+        directDeps: [refA, refB],
+        components: [
+          {
+            name: `${PREFIX}direct-comp-a`, version: '1.0.0',
+            purl: refA, packageManager: 'npm', bomRef: refA,
+            cpe: null, type: 'library', group: null, scope: null,
+            hashes: [], licenses: [], copyright: null, supplier: null,
+            author: null, publisher: null, homepage: null, description: null,
+            externalReferences: [],
+          },
+          {
+            name: `${PREFIX}direct-comp-b`, version: '1.0.0',
+            purl: refB, packageManager: 'npm', bomRef: refB,
+            cpe: null, type: 'library', group: null, scope: null,
+            hashes: [], licenses: [], copyright: null, supplier: null,
+            author: null, publisher: null, homepage: null, description: null,
+            externalReferences: [],
+          },
+        ],
+      })
+
+      const check = await session.run(`
+        MATCH (s:System { name: $sys })-[r:DIRECT_DEP]->(c:Component)
+        WHERE c.purl STARTS WITH $prefix
+        RETURN count(r) AS count
+      `, { sys: `${PREFIX}direct-system`, prefix: `pkg:npm/${PREFIX}` })
+
+      expect(check.records[0].get('count').toNumber()).toBe(2)
+    })
+  })
+
+  describe('DEPENDS_ON edges via persistSBOM()', () => {
+    it('should create DEPENDS_ON edges between components', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await seed(ctx.driver, `
+        CREATE (:System { name: $sys })
+        CREATE (:Repository { url: $url, name: $repoName })
+      `, {
+        sys: `${PREFIX}dep-system`,
+        url: `https://github.com/${PREFIX}org/dep-repo`,
+        repoName: `${PREFIX}dep-repo`,
+      })
+
+      const purlA = `pkg:npm/${PREFIX}comp-a@1.0.0`
+      const purlB = `pkg:npm/${PREFIX}comp-b@1.0.0`
+
+      await repo.persistSBOM({
+        systemName: `${PREFIX}dep-system`,
+        repositoryUrl: `https://github.com/${PREFIX}org/dep-repo`,
+        format: 'cyclonedx',
+        timestamp: new Date(),
+        dependencies: [{ ref: purlA, dependsOn: [purlB] }],
+        directDeps: [],
+        components: [
+          {
+            name: `${PREFIX}comp-a`, version: '1.0.0',
+            purl: purlA, packageManager: 'npm', bomRef: purlA,
+            cpe: null, type: 'library', group: null, scope: null,
+            hashes: [], licenses: [], copyright: null, supplier: null,
+            author: null, publisher: null, homepage: null, description: null,
+            externalReferences: [],
+          },
+          {
+            name: `${PREFIX}comp-b`, version: '1.0.0',
+            purl: purlB, packageManager: 'npm', bomRef: purlB,
+            cpe: null, type: 'library', group: null, scope: null,
+            hashes: [], licenses: [], copyright: null, supplier: null,
+            author: null, publisher: null, homepage: null, description: null,
+            externalReferences: [],
+          },
+        ],
+      })
+
+      const check = await session.run(`
+        MATCH (a:Component { purl: $purlA })-[r:DEPENDS_ON]->(b:Component { purl: $purlB })
+        RETURN count(r) AS count
+      `, { purlA, purlB })
+
+      expect(check.records[0].get('count').toNumber()).toBe(1)
+    })
+
+    it('should silently skip unresolvable bomRefs in dependencies', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await seed(ctx.driver, `
+        CREATE (:System { name: $sys })
+        CREATE (:Repository { url: $url, name: $repoName })
+      `, {
+        sys: `${PREFIX}skip-system`,
+        url: `https://github.com/${PREFIX}org/skip-repo`,
+        repoName: `${PREFIX}skip-repo`,
+      })
+
+      // dependencies reference bomRefs that don't exist — should not throw
+      await expect(
+        repo.persistSBOM({
+          systemName: `${PREFIX}skip-system`,
+          repositoryUrl: `https://github.com/${PREFIX}org/skip-repo`,
+          format: 'cyclonedx',
+          timestamp: new Date(),
+          dependencies: [{ ref: `${PREFIX}nonexistent`, dependsOn: [`${PREFIX}also-nonexistent`] }],
+          directDeps: [],
+          components: [],
+        })
+      ).resolves.not.toThrow()
+    })
+
+    it('should do nothing when dependencies array is empty', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await seed(ctx.driver, `
+        CREATE (:System { name: $sys })
+        CREATE (:Repository { url: $url, name: $repoName })
+      `, {
+        sys: `${PREFIX}empty-dep-system`,
+        url: `https://github.com/${PREFIX}org/empty-dep-repo`,
+        repoName: `${PREFIX}empty-dep-repo`,
+      })
+
+      await expect(
+        repo.persistSBOM({
+          systemName: `${PREFIX}empty-dep-system`,
+          repositoryUrl: `https://github.com/${PREFIX}org/empty-dep-repo`,
+          format: 'cyclonedx',
+          timestamp: new Date(),
+          dependencies: [],
+          directDeps: [],
+          components: [],
+        })
+      ).resolves.not.toThrow()
     })
   })
 

--- a/test/server/repositories/system.repository.spec.ts
+++ b/test/server/repositories/system.repository.spec.ts
@@ -148,25 +148,45 @@ describe('SystemRepository', () => {
       expect(await repo.exists(`${PREFIX}to-delete`)).toBe(false)
     })
 
-    it('should remove relationships but keep related nodes', async () => {
+    it('should delete components that are only used by the deleted system', async () => {
       if (!ctx.neo4jAvailable) return
       await seed(ctx.driver, `
         CREATE (s:System { name: $sys, domain: 'Test' })
-        CREATE (c:Component { name: $comp, version: '1.0.0' })
+        CREATE (c:Component { name: $comp, version: '1.0.0', purl: $purl })
         CREATE (s)-[:USES]->(c)
-      `, { sys: `${PREFIX}sys-rels`, comp: `${PREFIX}comp` })
+      `, { sys: `${PREFIX}sys-rels`, comp: `${PREFIX}comp`, purl: `pkg:npm/${PREFIX}comp@1.0.0` })
 
       await repo.delete(`${PREFIX}sys-rels`, 'test-user', {})
 
-      const result = await session.run(`
-        MATCH (c:Component { name: $comp })
-        OPTIONAL MATCH (c)<-[r:USES]-()
-        RETURN c, r
-      `, { comp: `${PREFIX}comp` })
+      const result = await session.run(
+        `MATCH (c:Component { name: $comp }) RETURN c`,
+        { comp: `${PREFIX}comp` }
+      )
+      expect(result.records.length).toBe(0)
+    })
 
+    it('should keep components that are still used by another system', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (s1:System { name: $sys1, domain: 'Test' })
+        CREATE (s2:System { name: $sys2, domain: 'Test' })
+        CREATE (c:Component { name: $comp, version: '1.0.0', purl: $purl })
+        CREATE (s1)-[:USES]->(c)
+        CREATE (s2)-[:USES]->(c)
+      `, {
+        sys1: `${PREFIX}sys-shared-1`,
+        sys2: `${PREFIX}sys-shared-2`,
+        comp: `${PREFIX}shared-comp`,
+        purl: `pkg:npm/${PREFIX}shared-comp@1.0.0`
+      })
+
+      await repo.delete(`${PREFIX}sys-shared-1`, 'test-user', {})
+
+      const result = await session.run(
+        `MATCH (c:Component { name: $comp }) RETURN c`,
+        { comp: `${PREFIX}shared-comp` }
+      )
       expect(result.records.length).toBe(1)
-      expect(result.records[0].get('c')).not.toBeNull()
-      expect(result.records[0].get('r')).toBeNull()
     })
   })
 

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -209,6 +209,36 @@ describe('SBOMService', () => {
       expect(persistCall.components[0].purl).toBe('pkg:npm/lodash@4.17.21')
     })
 
+    it('should decode percent-encoded @ in purl for scoped npm packages', async () => {
+      const sbomWithScopedPackage = {
+        ...validCycloneDxSbom,
+        components: [
+          {
+            type: 'library',
+            name: 'ui',
+            version: '4.3.0',
+            // cdxgen encodes @ as %40 in the namespace — must be normalized
+            purl: 'pkg:npm/%40nuxt/ui@4.3.0',
+            'bom-ref': 'pkg:npm/@nuxt/ui@4.3.0',
+          }
+        ]
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1, componentsUpdated: 0, relationshipsCreated: 1
+      })
+
+      await service.processSBOM({
+        sbom: sbomWithScopedPackage,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.components[0].purl).toBe('pkg:npm/@nuxt/ui@4.3.0')
+    })
+
     it('should extract package manager from purl', async () => {
       vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
         componentsAdded: 1,
@@ -292,6 +322,200 @@ describe('SBOMService', () => {
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
       expect(persistCall.components[0].licenses).toHaveLength(1)
       expect(persistCall.components[0].licenses[0].id).toBe('MIT')
+    })
+
+    it('should extract CycloneDX dependencies and directDeps and pass them to persistSBOM', async () => {
+      const sbomWithDeps = {
+        ...validCycloneDxSbom,
+        metadata: {
+          component: {
+            type: 'application',
+            name: 'test-app',
+            version: '1.0.0',
+            'bom-ref': 'pkg:npm/test-app@1.0.0',
+          }
+        },
+        dependencies: [
+          { ref: 'pkg:npm/test-app@1.0.0', dependsOn: ['pkg:npm/lodash@4.17.21'] },
+          { ref: 'pkg:npm/lodash@4.17.21', dependsOn: [] },
+        ]
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1, componentsUpdated: 0, relationshipsCreated: 1
+      })
+
+      await service.processSBOM({
+        sbom: sbomWithDeps,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.dependencies).toContainEqual({
+        ref: 'pkg:npm/test-app@1.0.0',
+        dependsOn: ['pkg:npm/lodash@4.17.21'],
+      })
+      // directDeps is resolved from the root's dependsOn list in the service layer
+      expect(persistCall.directDeps).toEqual(['pkg:npm/lodash@4.17.21'])
+    })
+
+    it('should extract SPDX dependency relationships and pass them to persistSBOM', async () => {
+      const sbomWithRels = {
+        ...validSpdxSbom,
+        relationships: [
+          {
+            spdxElementId: 'SPDXRef-DOCUMENT',
+            relationshipType: 'DEPENDS_ON',
+            relatedSpdxElement: 'SPDXRef-Package-lodash',
+          },
+          {
+            spdxElementId: 'SPDXRef-Package-lodash',
+            relationshipType: 'DESCRIBES',
+            relatedSpdxElement: 'SPDXRef-DOCUMENT',
+          },
+        ]
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1, componentsUpdated: 0, relationshipsCreated: 1
+      })
+
+      await service.processSBOM({
+        sbom: sbomWithRels,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'spdx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      // Only DEPENDS_ON type should be included, not DESCRIBES
+      expect(persistCall.dependencies).toContainEqual({
+        ref: 'SPDXRef-DOCUMENT',
+        dependsOn: ['SPDXRef-Package-lodash'],
+      })
+      expect(persistCall.dependencies).not.toContainEqual(
+        expect.objectContaining({ ref: 'SPDXRef-Package-lodash' })
+      )
+    })
+
+    it('should pass empty dependencies when SBOM has no dependency section', async () => {
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1, componentsUpdated: 0, relationshipsCreated: 1
+      })
+
+      await service.processSBOM({
+        sbom: validCycloneDxSbom,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.dependencies).toEqual([])
+    })
+
+    it('should resolve directDeps via fallback when root bom-ref type differs from dependencies entry', async () => {
+      // Simulates cdxgen output when run without node_modules:
+      // metadata.component uses type=application, but dependencies[] uses type=npm.
+      const sbomWithTypeMismatch = {
+        ...validCycloneDxSbom,
+        metadata: {
+          component: {
+            type: 'application',
+            name: 'my-app',
+            version: '1.0.0',
+            'bom-ref': 'pkg:application/my-app@1.0.0',
+          }
+        },
+        dependencies: [
+          // The application-typed entry has no dependsOn (cdxgen quirk)
+          { ref: 'pkg:application/my-app@1.0.0', dependsOn: [] },
+          // The npm-typed entry has the real direct deps
+          { ref: 'pkg:npm/my-app@1.0.0', dependsOn: ['pkg:npm/lodash@4.17.21', 'pkg:npm/express@4.18.2'] },
+          { ref: 'pkg:npm/lodash@4.17.21', dependsOn: [] },
+          { ref: 'pkg:npm/express@4.18.2', dependsOn: [] },
+        ]
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 2, componentsUpdated: 0, relationshipsCreated: 2
+      })
+
+      await service.processSBOM({
+        sbom: sbomWithTypeMismatch,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.directDeps).toEqual(['pkg:npm/lodash@4.17.21', 'pkg:npm/express@4.18.2'])
+    })
+
+    it('should use exact match directDeps when root bom-ref matches a non-empty dependsOn entry', async () => {
+      const sbomWithExactMatch = {
+        ...validCycloneDxSbom,
+        metadata: {
+          component: {
+            type: 'application',
+            name: 'my-app',
+            version: '1.0.0',
+            'bom-ref': 'pkg:npm/my-app@1.0.0',
+          }
+        },
+        dependencies: [
+          { ref: 'pkg:npm/my-app@1.0.0', dependsOn: ['pkg:npm/lodash@4.17.21'] },
+          { ref: 'pkg:npm/lodash@4.17.21', dependsOn: [] },
+        ]
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1, componentsUpdated: 0, relationshipsCreated: 1
+      })
+
+      await service.processSBOM({
+        sbom: sbomWithExactMatch,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.directDeps).toEqual(['pkg:npm/lodash@4.17.21'])
+    })
+
+    it('should return empty directDeps when no dependency entry matches the root name', async () => {
+      const sbomNoMatch = {
+        ...validCycloneDxSbom,
+        metadata: {
+          component: {
+            type: 'application',
+            name: 'my-app',
+            version: '1.0.0',
+            'bom-ref': 'pkg:application/my-app@1.0.0',
+          }
+        },
+        // No entry for my-app in dependencies at all
+        dependencies: [
+          { ref: 'pkg:npm/lodash@4.17.21', dependsOn: [] },
+        ]
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1, componentsUpdated: 0, relationshipsCreated: 1
+      })
+
+      await service.processSBOM({
+        sbom: sbomNoMatch,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.directDeps).toEqual([])
     })
 
     it('should handle nested CycloneDX components', async () => {


### PR DESCRIPTION
## Description

Three areas of work: an interactive dependency graph for systems, fixes to the SBOM ingestion pipeline identified during code review, and fixes to broken component filtering.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Schema update (changes to database schemas)

## Related Issues

Relates to #

## Changes Made

**Dependency graph**
- Add `SystemDependencyGraph.vue` — D3 force-directed graph showing direct and transitive npm dependencies per system
- Click a group node to expand its direct dependencies; click a component to drill into its own dependency tree (cycle-safe, unlimited depth)
- New `/api/systems/[name]/graph` endpoint and `systems/graph.cypher` query
- New `DEPENDS_ON` and `DIRECT_DEP` edge types in Neo4j
- Schema migration `20260505_100000_component_purl_as_merge_key`: use `purl` as the MERGE key for `Component` nodes (fixes scoped npm package collisions)

**SBOM ingestion pipeline**
- Split component persistence into two phases (core scalars + relations) to keep transactions within Neo4j memory limits
- Fix `directDeps` resolution: cdxgen uses `pkg:application/` type for `metadata.component` but `pkg:npm/` in `dependencies[]`; add name-based fallback in `resolveDirectDeps` so direct dependencies are found correctly when ingesting via GitHub import
- Fix `DETACH DELETE` on shared `Hash` and `ExternalReference` nodes: delete only the relationship, not the shared node
- Remove redundant pre-MERGE `OPTIONAL MATCH` checks in `persist-components-core`; use `ON CREATE`/`ON MATCH` flags instead
- Eliminate extra `exists()` round-trip in `getGraph`; distinguish not-found from empty via row count
- Add `comp→comp` edges to graph API response so drill-down children are connected in the D3 simulation
- Move `directDeps` resolution to the service layer; `persistDirectDeps` and `persistDependencies` are now private

**Component filtering**
- Fix broken `technology`, `hasLicense=true`, and `hasLicense=false` filters: `WHERE` after `OPTIONAL MATCH` in Cypher does not filter rows; replaced with `EXISTS {}` subqueries applied before any `OPTIONAL MATCH`
- Fix count inflation: use `count(DISTINCT c)` instead of `count(c)`
- Fix `useFetch` reactivity on all table pages: pass individual refs as query values so Nuxt tracks each as a reactive dependency; a computed object was unwrapped by `reactive()` at setup time and never re-evaluated
- Fix `ComponentNameCell`: `displayName` was captured as a static string in `setup()`; moved to the render function so it updates when rows are reused with different data

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have updated documentation if needed
