### PR TITLE
feat: replace console.log/error with pino structured logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,8 @@ AUTH_TRUST_HOST=true
 SUPERUSER_EMAILS=admin@company.com,lead@company.com
 
 SEED_API_TOKEN=
+
+# Logging
+# Controls server-side log verbosity. Valid values: trace, debug, info, warn, error, fatal
+# Set to "debug" for incident investigation without a redeploy.
+LOG_LEVEL=info

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "next-auth": "4.22.5",
         "nuxt": "4.4.4",
         "nuxt-neo4j": "^0.0.4",
+        "pino": "^10.3.1",
         "semver": "^7.7.4",
         "spdx-expression-parse": "^4.0.0",
         "spdx-license-list": "^6.11.0",
@@ -5001,6 +5002,12 @@
       "version": "7.1.1",
       "license": "MIT"
     },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "license": "MIT",
@@ -8331,6 +8338,15 @@
     "node_modules/async-sema": {
       "version": "3.1.1",
       "license": "MIT"
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -15589,6 +15605,15 @@
         "url": "https://github.com/sindresorhus/on-change?sponsor=1"
       }
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -16094,6 +16119,43 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
     },
     "node_modules/pkg-types": {
       "version": "2.3.1",
@@ -16678,6 +16740,22 @@
       "version": "2.0.1",
       "license": "MIT"
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "dev": true,
@@ -16913,6 +16991,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/quick-lru": {
       "version": "5.1.1",
       "license": "MIT",
@@ -17098,6 +17182,15 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/redis-errors": {
@@ -17496,6 +17589,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
@@ -17855,6 +17957,15 @@
         "url": "https://github.com/sponsors/cyyynthia"
       }
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "license": "BSD-3-Clause",
@@ -17926,6 +18037,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/srvx": {
@@ -18411,6 +18531,18 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tiny-case": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "next-auth": "4.22.5",
     "nuxt": "4.4.4",
     "nuxt-neo4j": "^0.0.4",
+    "pino": "^10.3.1",
     "semver": "^7.7.4",
     "spdx-expression-parse": "^4.0.0",
     "spdx-license-list": "^6.11.0",

--- a/server/api/admin/import/github.post.ts
+++ b/server/api/admin/import/github.post.ts
@@ -101,7 +101,7 @@ export default defineEventHandler(async (event) => {
     const stack = error instanceof Error ? error.stack : undefined
 
     // Log the full error so it appears in production server logs
-    console.error('[github-import] Import failed:', message, stack)
+    event.context.logger.error({ err: error, stack }, 'GitHub import failed')
 
     // GitHub API errors — surface as 422 so the client gets a useful message
     if (

--- a/server/api/audit-logs.get.ts
+++ b/server/api/audit-logs.get.ts
@@ -105,7 +105,7 @@ export default defineEventHandler(async (event) => {
       filters: result.filters
     }
   } catch (error) {
-    console.error('Audit log fetch error:', error)
+    event.context.logger.error({ err: error }, 'Audit log fetch error')
     setResponseStatus(event, 500)
     return {
       success: false,

--- a/server/api/auth/[...].ts
+++ b/server/api/auth/[...].ts
@@ -38,6 +38,7 @@
 import { NuxtAuthHandler } from '#auth'
 import GithubProvider from 'next-auth/providers/github'
 import { userService } from '../../services/singletons'
+import { logger } from '../../utils/logger'
 
 export default NuxtAuthHandler({
   secret: process.env.AUTH_SECRET || 'replace-me-in-production',
@@ -82,7 +83,7 @@ export default NuxtAuthHandler({
             token.teams = authData.teams
           }
         } catch (error) {
-          console.error('Error fetching user data from Neo4j:', error)
+          logger.error({ err: error }, 'Error fetching user data from Neo4j')
         }
       }
 
@@ -123,7 +124,7 @@ export default NuxtAuthHandler({
             role
           })
         } catch (error) {
-          console.error('Error creating/updating user in Neo4j:', error)
+          logger.error({ err: error }, 'Error creating/updating user in Neo4j')
           // Don't block sign in if database update fails
         }
       }

--- a/server/api/sboms.post.ts
+++ b/server/api/sboms.post.ts
@@ -311,7 +311,7 @@ export default defineEventHandler(async (event): Promise<SbomResponse> => {
     }
 
     // Internal error during processing
-    console.error('SBOM processing error:', error)
+    event.context.logger.error({ err: error }, 'SBOM processing error')
     setResponseStatus(event, 500)
     return {
       success: false,

--- a/server/api/users/index.get.ts
+++ b/server/api/users/index.get.ts
@@ -75,7 +75,7 @@ export default defineEventHandler(async (event) => {
       total
     }
   } catch (error) {
-    console.error('Error fetching users:', error)
+    event.context.logger.error({ err: error }, 'Error fetching users')
     throw createError({
       statusCode: 500,
       statusMessage: 'Failed to fetch users'

--- a/server/api/version-constraints.post.ts
+++ b/server/api/version-constraints.post.ts
@@ -83,7 +83,7 @@ export default defineEventHandler(async (event) => {
       }
     }
 
-    console.error('Version constraint creation error:', error)
+    event.context.logger.error({ err: error }, 'Version constraint creation error')
     setResponseStatus(event, 500)
     return { success: false, error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' }
   }

--- a/server/middleware/logger.ts
+++ b/server/middleware/logger.ts
@@ -1,0 +1,20 @@
+import { logger } from '../utils/logger'
+import { randomUUID } from 'crypto'
+
+/**
+ * Attaches a per-request child logger to `event.context.logger`.
+ *
+ * The child logger inherits all base logger settings and automatically
+ * includes `requestId`, `method`, and `url` on every log line emitted
+ * by downstream handlers and services. `requestId` is taken from the
+ * incoming `x-request-id` header when present (e.g. set by a reverse
+ * proxy), otherwise a new UUID is generated.
+ */
+export default defineEventHandler((event) => {
+  const requestId = getRequestHeader(event, 'x-request-id') ?? randomUUID()
+  event.context.logger = logger.child({
+    requestId,
+    method: event.node.req.method,
+    url: event.node.req.url,
+  })
+})

--- a/server/plugins/neo4j.ts
+++ b/server/plugins/neo4j.ts
@@ -1,3 +1,5 @@
+import { logger } from '../utils/logger'
+
 /**
  * Neo4j server plugin
  * Initializes and verifies Neo4j connection at startup
@@ -8,15 +10,15 @@ export default defineNitroPlugin((nitroApp) => {
   // Verify connection at startup
   driver.verifyAuthentication()
     .then(() => {
-      console.log('✅ Neo4j connected successfully')
+      logger.info('Neo4j connected successfully')
     })
     .catch((err) => {
-      console.error('❌ Neo4j connection failed:', err)
+      logger.error({ err }, 'Neo4j connection failed')
     })
   
   // Cleanup on shutdown
   nitroApp.hooks.hook('close', async () => {
-    console.log('🔌 Closing Neo4j connection...')
+    logger.info('Closing Neo4j connection')
     await driver.close()
   })
 })

--- a/server/plugins/sbom-validator.ts
+++ b/server/plugins/sbom-validator.ts
@@ -1,4 +1,5 @@
 import { initializeSbomValidator } from '../utils/sbom-validator'
+import { logger } from '../utils/logger'
 
 /**
  * Initialize SBOM validators at application startup
@@ -9,9 +10,9 @@ import { initializeSbomValidator } from '../utils/sbom-validator'
 export default defineNitroPlugin(async () => {
   try {
     await initializeSbomValidator()
-    console.log('✅ SBOM validator plugin initialized')
+    logger.info('SBOM validator plugin initialized')
   } catch (error) {
-    console.error('❌ Failed to initialize SBOM validator plugin:', error)
+    logger.error({ err: error }, 'Failed to initialize SBOM validator plugin')
     // Don't throw - allow app to start, but validation will fail
   }
 })

--- a/server/services/github-import.service.ts
+++ b/server/services/github-import.service.ts
@@ -2,6 +2,7 @@ import { mkdirSync, writeFileSync, rmSync, existsSync } from 'fs'
 import { join, dirname } from 'path'
 import { randomBytes } from 'crypto'
 import { createBom } from '@cyclonedx/cdxgen'
+import { logger } from '../utils/logger'
 import {
   parseGitHubRepo,
   fetchRepoMetadata,
@@ -157,7 +158,7 @@ export class GitHubImportService {
         writeFileSync(filePath, file.content, 'utf-8')
       }
 
-      console.log(`[github-import] Running cdxgen in ${tempDir} for project "${projectName}" with ${manifests.length} manifest(s)`)
+      logger.info({ projectName, manifestCount: manifests.length }, 'Running cdxgen for GitHub import')
 
       // Run cdxgen
       const bom = await createBom(tempDir, {
@@ -168,7 +169,7 @@ export class GitHubImportService {
       })
 
       if (!bom) {
-        console.warn(`[github-import] cdxgen returned no BOM for "${projectName}"`)
+        logger.warn({ projectName }, 'cdxgen returned no BOM')
         return null
       }
 
@@ -180,7 +181,7 @@ export class GitHubImportService {
 
       return bom as object
     } catch (err) {
-      console.error(`[github-import] cdxgen threw for "${projectName}":`, err instanceof Error ? err.message : err)
+      logger.error({ err, projectName }, 'cdxgen threw during GitHub import')
       throw err
     } finally {
       // Always clean up

--- a/server/types/h3.d.ts
+++ b/server/types/h3.d.ts
@@ -1,0 +1,8 @@
+import type { Logger } from 'pino'
+
+declare module 'h3' {
+  interface H3EventContext {
+    /** Per-request pino child logger. Carries requestId, method, and url. */
+    logger: Logger
+  }
+}

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -3,6 +3,7 @@ import type { H3Event } from 'h3'
 import { tokenService, userService } from '../services/singletons'
 import { UserRepository } from '../repositories/user.repository'
 import { TeamRepository } from '../repositories/team.repository'
+import { logger } from './logger'
 
 const IMPERSONATE_COOKIE = 'polaris-impersonate'
 
@@ -28,7 +29,7 @@ async function getRealUser(event: H3Event) {
         }
       }
     } catch (error) {
-      console.error('Token resolution failed:', error)
+      logger.error({ err: error }, 'Token resolution failed')
     }
   }
   
@@ -62,7 +63,7 @@ export async function getCurrentUser(event: H3Event) {
       }
     }
   } catch (error) {
-    console.error('Impersonation lookup failed:', error)
+    logger.error({ err: error }, 'Impersonation lookup failed')
   }
 
   // Target user not found — fall back to real user

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -3,6 +3,7 @@
  *
  * Used by the GitHub import feature to create systems without cloning repos.
  */
+import { logger } from './logger'
 
 export interface GitHubRepoMetadata {
   name: string
@@ -161,7 +162,7 @@ export async function fetchFileTree(owner: string, repo: string, branch: string)
   if (data.truncated) {
     // Repository has more than 100,000 tree entries; the tree is partial.
     // Log a warning but continue — manifests near the root will still be found.
-    console.warn(`[github] Tree response truncated for ${owner}/${repo}@${branch} — large repo, some manifests may be missed`)
+    logger.warn({ owner, repo, branch }, 'GitHub tree response truncated — large repo, some manifests may be missed')
   }
 
   return data.tree

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -1,0 +1,23 @@
+import pino from 'pino'
+
+/**
+ * Base structured logger for server-side code.
+ *
+ * Level is controlled at runtime via the LOG_LEVEL environment variable
+ * (default: "info"). Set LOG_LEVEL=debug for verbose output during incident
+ * investigation without a redeploy.
+ *
+ * Output is newline-delimited JSON on stdout, compatible with Docker log
+ * drivers and Dozzle. The `formatters.level` option emits string level names
+ * ("info", "warn", "error") instead of numeric codes so Dozzle can apply
+ * level-based colour coding and filtering.
+ *
+ * In test environments (NODE_ENV=test) logging is silenced to keep test
+ * output clean.
+ */
+export const logger = pino({
+  level: process.env.NODE_ENV === 'test' ? 'silent' : (process.env.LOG_LEVEL ?? 'info'),
+  formatters: {
+    level: (label) => ({ level: label }),
+  },
+})

--- a/server/utils/sbom-validator.ts
+++ b/server/utils/sbom-validator.ts
@@ -2,6 +2,7 @@ import Ajv from 'ajv'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import type { ErrorObject } from 'ajv'
+import { logger } from './logger'
 
 /**
  * SBOM format types
@@ -82,9 +83,9 @@ export class SbomValidator {
       
       this.initialized = true
       
-      console.log('✅ SBOM validators initialized successfully')
+      logger.info('SBOM validators initialized successfully')
     } catch (error) {
-      console.error('❌ Failed to initialize SBOM validators:', error)
+      logger.error({ err: error }, 'Failed to initialize SBOM validators')
       throw new Error(`Failed to initialize SBOM validators: ${error instanceof Error ? error.message : 'Unknown error'}`)
     }
   }

--- a/test/fixtures/h3-event.ts
+++ b/test/fixtures/h3-event.ts
@@ -1,7 +1,11 @@
 import { createEvent } from 'h3'
 import { IncomingMessage, ServerResponse } from 'http'
+import pino from 'pino'
 
 const PARSED_BODY_SYMBOL = Symbol.for('h3ParsedBody')
+
+/** Silent pino logger used in tests so handler code can call event.context.logger without errors. */
+const testLogger = pino({ level: 'silent' })
 
 export interface MockEventOptions {
   method?: string
@@ -32,6 +36,8 @@ export function mockEvent(options: MockEventOptions = {}) {
 
   const res = new ServerResponse(req)
   const event = createEvent(req, res)
+
+  event.context.logger = testLogger
 
   if (Object.keys(params).length > 0) {
     event.context.params = params


### PR DESCRIPTION
## Description

Replaces all `console.log` / `console.error` / `console.warn` calls in server runtime code with [pino](https://getpino.io/), emitting newline-delimited JSON to stdout. Each HTTP request gets a child logger carrying `requestId`, `method`, and `url` on every log line, making logs parseable and correlatable in Dozzle without any infrastructure changes.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Closes #479

## Changes Made

- Add `server/utils/logger.ts`: base pino logger; level controlled by `LOG_LEVEL` env var (default `info`), silenced in `NODE_ENV=test`
- Add `server/middleware/logger.ts`: Nitro middleware that attaches a per-request child logger to `event.context.logger` with `requestId`, `method`, and `url` fields
- Add `server/types/h3.d.ts`: TypeScript declaration extending `H3EventContext` with the `logger` property
- Replace `console.*` in 11 runtime server files — API handlers use `event.context.logger`, startup plugins and utility modules use the base logger (no request context available at that point)
- Update `test/fixtures/h3-event.ts`: inject a silent pino logger into `event.context` so handler tests that reach error paths don't throw on missing logger
- Add `LOG_LEVEL=info` to `.env.example`

**Notes:**
- `@types/pino` was not installed — pino ships its own types since v7
- Error objects are passed as `{ err }` (pino's standard serializer key) so stack traces are captured as structured fields
- `server/scripts/generate-openapi.ts` is a build-time CLI script and was intentionally left unchanged

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed