### PR TITLE
fix: case-insensitive Bearer token parsing, reject empty tokens

### DIFF
--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -14,7 +14,7 @@ async function getRealUser(event: H3Event) {
   // Check for Bearer token first
   const authHeader = getHeader(event, 'authorization')
   
-  const match = authHeader?.match(/^Bearer\s+(\S+)$/i)
+  const match = authHeader?.match(/^Bearer\s+(\S+)\s*$/i)
   if (match) {
     const token = match[1]
     

--- a/server/utils/auth.ts
+++ b/server/utils/auth.ts
@@ -14,8 +14,9 @@ async function getRealUser(event: H3Event) {
   // Check for Bearer token first
   const authHeader = getHeader(event, 'authorization')
   
-  if (authHeader && authHeader.startsWith('Bearer ')) {
-    const token = authHeader.substring(7)
+  const match = authHeader?.match(/^Bearer\s+(\S+)$/i)
+  if (match) {
+    const token = match[1]
     
     try {
       const resolved = await tokenService.resolveToken(token)

--- a/test/server/utils/auth.spec.ts
+++ b/test/server/utils/auth.spec.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import { getRealUser } from '../../../server/utils/auth'
+import { tokenService } from '../../../server/services/singletons'
+import { getServerSession } from '#auth'
+
+// Mock the singletons so resolveToken is fully controlled
+vi.mock('../../../server/services/singletons', () => ({
+  tokenService: { resolveToken: vi.fn() },
+  userService: { getAuthData: vi.fn() },
+}))
+
+// Mock #auth so getServerSession is controllable
+vi.mock('#auth', () => ({
+  getServerSession: vi.fn().mockResolvedValue(null),
+}))
+
+const resolvedUser = {
+  user: {
+    id: 'user-1',
+    email: 'user@example.com',
+    role: 'user' as const,
+    teams: [],
+  },
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.mocked(getServerSession).mockResolvedValue(null)
+})
+
+describe('getRealUser — Bearer token extraction', () => {
+  describe('case-insensitive scheme matching (RFC 7235)', () => {
+    it('accepts canonical "Bearer" casing', async () => {
+      vi.mocked(tokenService.resolveToken).mockResolvedValue(resolvedUser)
+      const event = mockEvent({ headers: { authorization: 'Bearer abc123' } })
+
+      const user = await getRealUser(event)
+
+      expect(tokenService.resolveToken).toHaveBeenCalledWith('abc123')
+      expect(user?.id).toBe('user-1')
+    })
+
+    it('accepts lowercase "bearer"', async () => {
+      vi.mocked(tokenService.resolveToken).mockResolvedValue(resolvedUser)
+      const event = mockEvent({ headers: { authorization: 'bearer abc123' } })
+
+      const user = await getRealUser(event)
+
+      expect(tokenService.resolveToken).toHaveBeenCalledWith('abc123')
+      expect(user?.id).toBe('user-1')
+    })
+
+    it('accepts uppercase "BEARER"', async () => {
+      vi.mocked(tokenService.resolveToken).mockResolvedValue(resolvedUser)
+      const event = mockEvent({ headers: { authorization: 'BEARER abc123' } })
+
+      const user = await getRealUser(event)
+
+      expect(tokenService.resolveToken).toHaveBeenCalledWith('abc123')
+      expect(user?.id).toBe('user-1')
+    })
+
+    it('accepts mixed casing "bEaReR"', async () => {
+      vi.mocked(tokenService.resolveToken).mockResolvedValue(resolvedUser)
+      const event = mockEvent({ headers: { authorization: 'bEaReR abc123' } })
+
+      await getRealUser(event)
+
+      expect(tokenService.resolveToken).toHaveBeenCalledWith('abc123')
+    })
+  })
+
+  describe('empty and whitespace-only tokens', () => {
+    it('does not call resolveToken when token is absent ("Bearer " with trailing space)', async () => {
+      const event = mockEvent({ headers: { authorization: 'Bearer ' } })
+
+      await getRealUser(event)
+
+      expect(tokenService.resolveToken).not.toHaveBeenCalled()
+    })
+
+    it('does not call resolveToken when token is only whitespace', async () => {
+      const event = mockEvent({ headers: { authorization: 'Bearer    ' } })
+
+      await getRealUser(event)
+
+      expect(tokenService.resolveToken).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fallback behaviour', () => {
+    it('falls back to session when no Authorization header is present', async () => {
+      const sessionUser = { id: 'session-user', email: 'session@example.com', role: 'user' as const, teams: [] }
+      vi.mocked(getServerSession).mockResolvedValue({ user: sessionUser, expires: '' })
+      const event = mockEvent()
+
+      const user = await getRealUser(event)
+
+      expect(tokenService.resolveToken).not.toHaveBeenCalled()
+      expect(user?.id).toBe('session-user')
+    })
+
+    it('falls back to session when token resolves to null (unknown token)', async () => {
+      vi.mocked(tokenService.resolveToken).mockResolvedValue(null)
+      const sessionUser = { id: 'session-user', email: 'session@example.com', role: 'user' as const, teams: [] }
+      vi.mocked(getServerSession).mockResolvedValue({ user: sessionUser, expires: '' })
+      const event = mockEvent({ headers: { authorization: 'Bearer unknown-token' } })
+
+      const user = await getRealUser(event)
+
+      expect(user?.id).toBe('session-user')
+    })
+
+    it('falls back to session when resolveToken throws', async () => {
+      vi.mocked(tokenService.resolveToken).mockRejectedValue(new Error('DB error'))
+      const sessionUser = { id: 'session-user', email: 'session@example.com', role: 'user' as const, teams: [] }
+      vi.mocked(getServerSession).mockResolvedValue({ user: sessionUser, expires: '' })
+      const event = mockEvent({ headers: { authorization: 'Bearer bad-token' } })
+
+      const user = await getRealUser(event)
+
+      expect(user?.id).toBe('session-user')
+    })
+
+    it('returns null when no Authorization header and no session', async () => {
+      const event = mockEvent()
+
+      const user = await getRealUser(event)
+
+      expect(user).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Description

Fixes two bugs in the Bearer token extraction in `server/utils/auth.ts`:

1. **Case-sensitive scheme matching** — `startsWith('Bearer ')` rejected valid headers like `bearer token` or `BEARER token`, silently falling through to session auth. RFC 7235 requires scheme names to be treated case-insensitively.
2. **Empty token passed to `resolveToken`** — `"Bearer "` (scheme with no token) passed the check and produced `token = ""`, which was forwarded to `resolveToken` causing a wasted DB round-trip against a hash of an empty string.

Both are fixed with a single regex replacement:

```ts
// Before
if (authHeader && authHeader.startsWith('Bearer ')) {
  const token = authHeader.substring(7)

// After
const match = authHeader?.match(/^Bearer\s+(\S+)$/i)
if (match) {
  const token = match[1]
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Closes #481

## Changes Made

- Replace `startsWith` + `substring` with `/^Bearer\s+(\S+)$/i` regex in `getRealUser` (`server/utils/auth.ts`)
- Add `test/server/utils/auth.spec.ts` with 10 tests covering all extraction edge cases (previously untested)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed