### PR TITLE
fix: four impersonation security issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,3 +51,8 @@ SEED_API_TOKEN=
 # Controls server-side log verbosity. Valid values: trace, debug, info, warn, error, fatal
 # Set to "debug" for incident investigation without a redeploy.
 LOG_LEVEL=info
+
+# Cookie security
+# Defaults to true (secure flag set on all auth cookies). Set to "false" only for local
+# development without HTTPS. Never set this to "false" in production.
+# COOKIE_SECURE=false

--- a/app/composables/useImpersonation.ts
+++ b/app/composables/useImpersonation.ts
@@ -10,10 +10,11 @@ interface ImpersonationState {
   user: ImpersonatedUser | null
 }
 
-const state = ref<ImpersonationState>({ active: false, user: null })
-const loading = ref(false)
-
 export function useImpersonation() {
+  // useState is request-scoped on the server and hydrated to the client,
+  // preventing state bleed between concurrent SSR requests.
+  const state = useState<ImpersonationState>('impersonation', () => ({ active: false, user: null }))
+  const loading = useState<boolean>('impersonation-loading', () => false)
   async function fetchStatus() {
     try {
       const data = await $fetch<ImpersonationState>('/api/admin/impersonate')

--- a/server/api/admin/impersonate.delete.ts
+++ b/server/api/admin/impersonate.delete.ts
@@ -1,4 +1,5 @@
 import { getRealUser } from '../../utils/auth'
+import { AuditLogRepository } from '../../repositories/audit-log.repository'
 
 /**
  * Stop impersonating. Clears the impersonation cookie.
@@ -10,9 +11,26 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, message: 'Superuser access required' })
   }
 
+  // Capture the impersonated user id before clearing the cookie
+  const impersonatedUserId = getCookie(event, 'polaris-impersonate')
+
   deleteCookie(event, 'polaris-impersonate', {
-    path: '/'
+    httpOnly: true,
+    sameSite: 'lax',
+    path: '/',
+    secure: process.env.COOKIE_SECURE !== 'false',
   })
+
+  if (impersonatedUserId) {
+    const auditRepo = new AuditLogRepository()
+    await auditRepo.create({
+      operation: 'IMPERSONATION_STOPPED',
+      entityType: 'User',
+      entityId: impersonatedUserId,
+      entityLabel: impersonatedUserId,
+      userId: realUser.id,
+    })
+  }
 
   return { success: true }
 })

--- a/server/api/admin/impersonate.get.ts
+++ b/server/api/admin/impersonate.get.ts
@@ -22,7 +22,12 @@ export default defineEventHandler(async (event) => {
 
   if (!target) {
     // Stale cookie — clear it
-    deleteCookie(event, 'polaris-impersonate', { path: '/' })
+    deleteCookie(event, 'polaris-impersonate', {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      secure: process.env.COOKIE_SECURE !== 'false',
+    })
     return { active: false, user: null }
   }
 

--- a/server/api/admin/impersonate.post.ts
+++ b/server/api/admin/impersonate.post.ts
@@ -1,5 +1,6 @@
 import { getRealUser } from '../../utils/auth'
 import { userService } from '../../services/singletons'
+import { AuditLogRepository } from '../../repositories/audit-log.repository'
 
 /**
  * Start impersonating a user. Superuser only.
@@ -34,8 +35,17 @@ export default defineEventHandler(async (event) => {
     httpOnly: true,
     sameSite: 'lax',
     path: '/',
-    secure: process.env.NODE_ENV === 'production',
+    secure: process.env.COOKIE_SECURE !== 'false',
     maxAge: 60 * 60 // 1 hour
+  })
+
+  const auditRepo = new AuditLogRepository()
+  await auditRepo.create({
+    operation: 'IMPERSONATION_STARTED',
+    entityType: 'User',
+    entityId: body.userId,
+    entityLabel: target.email,
+    userId: realUser.id,
   })
 
   return {


### PR DESCRIPTION
## Description

Fixes four distinct security issues in the impersonation feature.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Closes #482

## Changes Made

**1. SSR shared state (`app/composables/useImpersonation.ts`)**

Module-level `ref()` is a singleton on the server — shared across all concurrent requests. Replaced with `useState()`, which is request-scoped on the server and hydrated to the client.

**2. Cookie attribute mismatch (`impersonate.delete.ts`, `impersonate.get.ts`)**

`deleteCookie` calls were missing `httpOnly`, `sameSite`, and `secure` attributes that `setCookie` sets in `impersonate.post.ts`. Cookie deletion works by setting `Max-Age=0` with matching attributes — mismatches can prevent reliable deletion in some browser/proxy configurations. Fixed in both `impersonate.delete.ts` and `impersonate.get.ts` (stale-cookie clear — a third call site not mentioned in the issue).

**3. Audit logging (`impersonate.post.ts`, `impersonate.delete.ts`)**

Neither endpoint wrote an audit log entry. Added `IMPERSONATION_STARTED` on start and `IMPERSONATION_STOPPED` on stop via `AuditLogRepository`, consistent with the pattern used throughout the codebase. The stop entry is only written when a cookie was actually present.

**4. `secure` cookie flag (`impersonate.post.ts`, `impersonate.delete.ts`, `impersonate.get.ts`)**

`NODE_ENV === 'production'` replaced with `COOKIE_SECURE !== 'false'` — secure by default in all environments, with an explicit opt-out for local development without HTTPS. Added `COOKIE_SECURE` to `.env.example` with a warning against disabling it in production.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed