### PR TITLE
fix: neo4j plugin fails fast on connection failure at startup

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,6 +7,9 @@ services:
       - ..:/workspaces/polaris:cached
     command: sleep infinity
     network_mode: host
+    depends_on:
+      neo4j:
+        condition: service_healthy
 
   neo4j:
     image: neo4j:5-community
@@ -23,3 +26,9 @@ services:
       - ../.data/neo4j/import:/var/lib/neo4j/import
       - ../.data/neo4j/plugins:/plugins
     network_mode: host
+    healthcheck:
+      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "devpassword", "RETURN 1"]
+      interval: 15s
+      timeout: 15s
+      retries: 10
+      start_period: 60s

--- a/server/plugins/neo4j.ts
+++ b/server/plugins/neo4j.ts
@@ -2,21 +2,20 @@ import { logger } from '../utils/logger'
 
 /**
  * Neo4j server plugin
- * Initializes and verifies Neo4j connection at startup
+ * Verifies the database connection at startup and aborts if unreachable.
+ *
+ * The async callback is awaited by Nitro — an unhandled throw here aborts
+ * the startup process cleanly rather than letting the app start in a broken
+ * state. Both environments guarantee Neo4j is healthy before this runs:
+ * production via docker-compose depends_on/service_healthy, dev via the
+ * devcontainer compose healthcheck added alongside this change.
  */
-export default defineNitroPlugin((nitroApp) => {
+export default defineNitroPlugin(async (nitroApp) => {
   const driver = useDriver()
-  
-  // Verify connection at startup
-  driver.verifyAuthentication()
-    .then(() => {
-      logger.info('Neo4j connected successfully')
-    })
-    .catch((err) => {
-      logger.error({ err }, 'Neo4j connection failed')
-    })
-  
-  // Cleanup on shutdown
+
+  await driver.verifyAuthentication()
+  logger.info('Neo4j connected successfully')
+
   nitroApp.hooks.hook('close', async () => {
     logger.info('Closing Neo4j connection')
     await driver.close()


### PR DESCRIPTION
## Description

The Neo4j server plugin called `driver.verifyAuthentication()` as a fire-and-forget promise. The `.catch()` handler logged the error and continued, allowing the app to start in a broken state where every request would fail at runtime rather than at startup.

This PR makes the plugin fail fast and also adds the missing Neo4j healthcheck to the devcontainer so the fix is safe in both environments.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Closes #480

## Changes Made

**`server/plugins/neo4j.ts`**
- Plugin callback is now `async`; `verifyAuthentication()` is awaited
- Removed the `.then/.catch` chain — an unhandled throw propagates to Nitro and aborts startup cleanly
- The app can no longer start silently in a state where the database is unreachable

**`.devcontainer/docker-compose.yml`**
- Added `healthcheck` to the `neo4j` service (same parameters as production: `cypher-shell`, 15s interval, 60s start period, 10 retries)
- Added `depends_on: neo4j: condition: service_healthy` to the `app` service

Without the devcontainer healthcheck, making the plugin throw would break `nuxt dev` whenever Neo4j is slow to initialise. Both environments now guarantee Neo4j is healthy before the app starts, making the fail-fast behaviour safe in both.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed