### PR TITLE
Add Neo4j log rotation to prevent disk exhaustion

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,6 +20,16 @@ services:
       NEO4J_dbms_security_procedures_unrestricted: apoc.*
       NEO4J_server_memory_heap_initial__size: 512m
       NEO4J_server_memory_heap_max__size: 2G
+      # Rotate Neo4j internal log files: keep 7 files, max 20MB each
+      NEO4J_server_logs_debug_rotation_keep__number: 7
+      NEO4J_server_logs_debug_rotation_size: 20m
+      NEO4J_server_logs_user_rotation_keep__number: 7
+      NEO4J_server_logs_user_rotation_size: 20m
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     volumes:
       - ../.data/neo4j/data:/data
       - ../.data/neo4j/logs:/logs

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -19,6 +19,16 @@ services:
       NEO4J_dbms_security_procedures_unrestricted: apoc.*
       NEO4J_server_memory_heap_initial__size: 512m
       NEO4J_server_memory_heap_max__size: 2G
+      # Rotate Neo4j internal log files: keep 7 files, max 20MB each
+      NEO4J_server_logs_debug_rotation_keep__number: 7
+      NEO4J_server_logs_debug_rotation_size: 20m
+      NEO4J_server_logs_user_rotation_keep__number: 7
+      NEO4J_server_logs_user_rotation_size: 20m
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     volumes:
       - /opt/polaris/data/neo4j/data:/data
       - /opt/polaris/data/neo4j/logs:/logs

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -19,6 +19,16 @@ services:
       NEO4J_server_memory_heap_initial__size: 256m
       NEO4J_server_memory_heap_max__size: 512m
       NEO4J_server_memory_pagecache__size: 256m
+      # Rotate Neo4j internal log files: keep 7 files, max 20MB each
+      NEO4J_server_logs_debug_rotation_keep__number: 7
+      NEO4J_server_logs_debug_rotation_size: 20m
+      NEO4J_server_logs_user_rotation_keep__number: 7
+      NEO4J_server_logs_user_rotation_size: 20m
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     volumes:
       - /opt/polaris/data/neo4j/data:/data
       - /opt/polaris/data/neo4j/logs:/logs


### PR DESCRIPTION
## Description

On 2026-05-19 the production server's 38GB disk filled to 100%. Neo4j could no longer write to `/logs/debug.log`, which prevented checkpointing and caused all transactions to fail with `TransactionStartFailed`. The root cause was unbounded log growth with no rotation policy configured.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- Add `NEO4J_server_logs_debug_rotation_*` and `NEO4J_server_logs_user_rotation_*` env vars to cap Neo4j internal logs at 20MB per file, retaining 7 files (~280MB max total)
- Add Docker `logging` driver config (`json-file`, `max-size: 10m`, `max-file: 5`) to cap container stdout/stderr at 50MB
- Applied to all three compose files: `infra/docker-compose.yml`, `infra/ansible/templates/docker-compose.yml.j2`, and `.devcontainer/docker-compose.yml`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues

## Additional Notes

The immediate fix on the production server was to truncate `debug.log` and free space by removing orphaned containerd layer data (~34GB). This PR prevents recurrence by capping log growth at the source.