### PR TITLE
Add healthchecks for app and caddy services

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,6 +10,12 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   neo4j:
     image: neo4j:5-community

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,12 @@ jobs:
                 depends_on:
                   neo4j:
                     condition: service_healthy
+                healthcheck:
+                  test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+                  interval: 30s
+                  timeout: 10s
+                  retries: 3
+                  start_period: 30s
                 networks:
                   - polaris-net
 
@@ -103,9 +109,15 @@ jobs:
                   - caddy_config:/config
                 depends_on:
                   app:
-                    condition: service_started
+                    condition: service_healthy
                   dozzle:
                     condition: service_healthy
+                healthcheck:
+                  test: ["CMD", "wget", "-qO-", "http://localhost:2019/config/"]
+                  interval: 30s
+                  timeout: 10s
+                  retries: 3
+                  start_period: 15s
                 networks:
                   - polaris-net
 

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -6,6 +6,12 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - polaris-net
 
@@ -56,9 +62,15 @@ services:
       - caddy_config:/config
     depends_on:
       app:
-        condition: service_started
+        condition: service_healthy
       dozzle:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:2019/config/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     networks:
       - polaris-net
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -6,6 +6,12 @@ services:
     depends_on:
       neo4j:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
     networks:
       - polaris-net
 
@@ -67,9 +73,15 @@ services:
       - caddy_config:/config
     depends_on:
       app:
-        condition: service_started
+        condition: service_healthy
       dozzle:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:2019/config/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
     networks:
       - polaris-net
 


### PR DESCRIPTION
## Description

`app` and `caddy` had no healthchecks, so Docker had no way to detect when either service was down or degraded. This also meant `caddy` started proxying immediately on container start (`service_started`) rather than waiting for the app to be ready.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Changes Made

- `app`: healthcheck via `GET http://localhost:3000/api/health` — returns 503 when Neo4j is unreachable, so this reflects real application health
- `caddy`: healthcheck via Caddy's local admin API at `http://localhost:2019/config/` — available on loopback regardless of TLS configuration
- `caddy` `depends_on` app upgraded from `service_started` → `service_healthy` so Caddy does not begin proxying until the app passes its healthcheck
- Applied to all four compose files: `infra/docker-compose.yml`, `infra/ansible/templates/docker-compose.yml.j2`, `.devcontainer/docker-compose.yml`, and `.github/workflows/deploy.yml`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues