### PR TITLE
fix: replace cypher-shell Neo4j health check with HTTP check

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -7,15 +7,6 @@ services:
       - ..:/workspaces/polaris:cached
     command: sleep infinity
     network_mode: host
-    depends_on:
-      neo4j:
-        condition: service_healthy
-    healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
 
   neo4j:
     image: neo4j:5-community
@@ -36,15 +27,10 @@ services:
       options:
         max-size: "10m"
         max-file: "5"
+        
     volumes:
       - ../.data/neo4j/data:/data
       - ../.data/neo4j/logs:/logs
       - ../.data/neo4j/import:/var/lib/neo4j/import
       - ../.data/neo4j/plugins:/plugins
     network_mode: host
-    healthcheck:
-      test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "devpassword", "RETURN 1"]
-      interval: 15s
-      timeout: 15s
-      retries: 10
-      start_period: 60s

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,11 +77,11 @@ jobs:
                   - /opt/polaris/data/neo4j/import:/var/lib/neo4j/import
                   - /opt/polaris/data/neo4j/plugins:/plugins
                 healthcheck:
-                  test: ["CMD", "cypher-shell", "-u", "neo4j", "-p", "${NEO4J_PASSWORD}", "RETURN 1"]
+                  test: ["CMD-SHELL", "wget -qO- http://localhost:7474 > /dev/null 2>&1 || exit 1"]
                   interval: 15s
                   timeout: 15s
-                  retries: 10
-                  start_period: 60s
+                  retries: 20
+                  start_period: 120s
                 networks:
                   - polaris-net
 


### PR DESCRIPTION
## Description

The Neo4j health check used `cypher-shell`, which requires Neo4j to be fully initialised including the Bolt protocol. When the APOC plugin is downloaded on first start, this takes longer than the previous budget allowed, causing the devcontainer and production deploy to fail.

Switch to `wget` against the HTTP discovery endpoint (`http://localhost:7474`), which becomes available earlier in the startup sequence. Also increase `start_period` to 120s and `retries` to 20 to cover slow first-start scenarios.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- `.devcontainer/docker-compose.yml`: remove `depends_on` health condition on `app` (Neo4j readiness is handled by the `wait-neo4j` automation task); remove `healthcheck` from Neo4j service
- `.github/workflows/deploy.yml`: replace `cypher-shell` health check with `wget http://localhost:7474`; increase `start_period` from 60s to 120s and `retries` from 10 to 20

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues