### PR TITLE
fix: add Bolt port check to Neo4j healthcheck to prevent app startup race

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - ../.data/neo4j/plugins:/plugins
     network_mode: host
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:7474"]
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7474 > /dev/null 2>&1 && (echo > /dev/tcp/localhost/7687) 2>/dev/null || exit 1"]
       interval: 15s
       timeout: 10s
       retries: 20

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
                   - /opt/polaris/data/neo4j/import:/var/lib/neo4j/import
                   - /opt/polaris/data/neo4j/plugins:/plugins
                 healthcheck:
-                  test: ["CMD-SHELL", "wget -qO- http://localhost:7474 > /dev/null 2>&1 || exit 1"]
+                  test: ["CMD-SHELL", "wget -qO- http://localhost:7474 > /dev/null 2>&1 && (echo > /dev/tcp/localhost/7687) 2>/dev/null || exit 1"]
                   interval: 15s
                   timeout: 15s
                   retries: 20


### PR DESCRIPTION
## Description

The Neo4j healthcheck only verified HTTP port 7474 (browser UI), which becomes available before the Bolt listener on port 7687 is ready. Docker would declare Neo4j healthy and start the app, but `verifyAuthentication()` in the Nitro plugin would fail to connect via Bolt, throw, and abort Nitro — making the app container unhealthy.

This was the root cause of the recurring deploy failure in [run #138](https://github.com/localgod/polaris/actions/runs/26149461522/job/76912913496):

```
Container polaris-app-1 Error dependency app failed to start
dependency failed to start: container polaris-app-1 is unhealthy
```

The healthcheck now also verifies TCP port 7687 using bash `/dev/tcp`, so Docker only considers Neo4j healthy when both the HTTP interface and the Bolt listener are accepting connections.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Related Issues

Relates to #525 (deploy timeout fix that introduced the HTTP-only healthcheck)

## Changes Made

- `.github/workflows/deploy.yml`: extend Neo4j healthcheck to also check Bolt port 7687 via `/dev/tcp`
- `.devcontainer/docker-compose.yml`: same fix for the dev environment

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues

## Additional Notes

The `/dev/tcp` pseudo-device is available in the `neo4j:5-community` image (Debian base with bash). The check is a no-op TCP connect — it does not authenticate or send data, just confirms the port is open before the app is allowed to start.