### PR TITLE
fix: invoke bash explicitly in Neo4j healthcheck for /dev/tcp support

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       - ../.data/neo4j/plugins:/plugins
     network_mode: host
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:7474 > /dev/null 2>&1 && (echo > /dev/tcp/localhost/7687) 2>/dev/null || exit 1"]
+      test: ["CMD", "bash", "-c", "wget -qO- http://localhost:7474 > /dev/null 2>&1 && (echo > /dev/tcp/localhost/7687) 2>/dev/null"]
       interval: 15s
       timeout: 10s
       retries: 20

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
                   - /opt/polaris/data/neo4j/import:/var/lib/neo4j/import
                   - /opt/polaris/data/neo4j/plugins:/plugins
                 healthcheck:
-                  test: ["CMD-SHELL", "wget -qO- http://localhost:7474 > /dev/null 2>&1 && (echo > /dev/tcp/localhost/7687) 2>/dev/null || exit 1"]
+                  test: ["CMD", "bash", "-c", "wget -qO- http://localhost:7474 > /dev/null 2>&1 && (echo > /dev/tcp/localhost/7687) 2>/dev/null"]
                   interval: 15s
                   timeout: 15s
                   retries: 20


### PR DESCRIPTION
## Description

The previous fix (#529) used `CMD-SHELL` to run the Bolt port check via `/dev/tcp`. `CMD-SHELL` invokes `/bin/sh`, which on the neo4j image (Debian) is `dash` — and `dash` does not support the `/dev/tcp` pseudo-device. This caused the healthcheck to always fail, so Neo4j never became healthy and the deploy timed out after the full retry budget (~7 minutes).

Switching to `CMD` with `bash -c` makes the `/dev/tcp` check work as intended.

Failure evidence from [run #139](https://github.com/localgod/polaris/actions/runs/26150916421/job/76917841965):
```
Container polaris-neo4j-1 Waiting   (08:30:26)
Container polaris-neo4j-1 Error dependency neo4j failed to start  (08:37:16)
dependency failed to start: container polaris-neo4j-1 is unhealthy
```
Neo4j waited the full budget (120s start_period + 20×15s retries ≈ 7 min) before failing — consistent with a healthcheck that always exits non-zero.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Related Issues

Fixes regression introduced by #529

## Changes Made

- `.github/workflows/deploy.yml`: change `CMD-SHELL` to `CMD` with `bash -c` in Neo4j healthcheck
- `.devcontainer/docker-compose.yml`: same

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues