### PR TITLE
fix: retry Neo4j verifyAuthentication on startup instead of failing immediately

### DIFF
--- a/server/plugins/neo4j.ts
+++ b/server/plugins/neo4j.ts
@@ -1,20 +1,31 @@
 import { logger } from '../utils/logger'
 
+const RETRY_ATTEMPTS = 10
+const RETRY_DELAY_MS = 3000
+
 /**
  * Neo4j server plugin
- * Verifies the database connection at startup and aborts if unreachable.
- *
- * The async callback is awaited by Nitro — an unhandled throw here aborts
- * the startup process cleanly rather than letting the app start in a broken
- * state. Both environments guarantee Neo4j is healthy before this runs:
- * production via docker-compose depends_on/service_healthy, dev via the
- * devcontainer compose healthcheck added alongside this change.
+ * Verifies the database connection at startup, retrying up to RETRY_ATTEMPTS
+ * times before aborting. Retries guard against the window between Neo4j's
+ * Bolt port accepting TCP connections and the database being ready to
+ * authenticate — which can occur even after the compose healthcheck passes.
  */
 export default defineNitroPlugin(async (nitroApp) => {
   const driver = useDriver()
 
-  await driver.verifyAuthentication()
-  logger.info('Neo4j connected successfully')
+  for (let attempt = 1; attempt <= RETRY_ATTEMPTS; attempt++) {
+    try {
+      await driver.verifyAuthentication()
+      logger.info('Neo4j connected successfully')
+      break
+    } catch (err) {
+      if (attempt === RETRY_ATTEMPTS) {
+        throw err
+      }
+      logger.warn({ attempt, err }, `Neo4j not ready, retrying in ${RETRY_DELAY_MS}ms`)
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS))
+    }
+  }
 
   nitroApp.hooks.hook('close', async () => {
     logger.info('Closing Neo4j connection')


### PR DESCRIPTION
## Description

The compose healthcheck now correctly waits for both HTTP 7474 and Bolt 7687 to be open before starting the app (#529, #531). However, a TCP port accepting connections does not mean Neo4j is ready to complete the Bolt handshake and authenticate. There is a window — sometimes several seconds — between the port opening and the database being fully initialised.

The Nitro plugin called `verifyAuthentication()` once with no retry. If it hit that window, it threw, Nitro aborted, and the app container became unhealthy. This was the failure in [run #140](https://github.com/localgod/polaris/actions/runs/26151601544/job/76920186986):

```
Container polaris-neo4j-1 Healthy   (08:44:52)
Container polaris-app-1 Started     (08:44:52)
Container polaris-app-1 Error       (08:46:23)   ← 91s = start_period + 3 failed checks
```

The fix retries up to 10 times with a 3-second delay (30s total budget) before giving up. Fail-fast behaviour on genuine connection failures is preserved — if all retries are exhausted, the last error is re-thrown and Nitro still aborts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Relates to #529, #531

## Changes Made

- `server/plugins/neo4j.ts`: wrap `verifyAuthentication()` in a retry loop (10 attempts, 3s delay)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues