### PR TITLE
Add Watchtower for caddy/dozzle auto-updates, fix migration ordering

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,22 +143,42 @@ jobs:
                 networks:
                   - polaris-net
 
-              watchtower:
-                image: containrrr/watchtower
+              socket-proxy:
+                image: tecnativa/docker-socket-proxy
                 restart: unless-stopped
+                privileged: true
                 volumes:
                   - /var/run/docker.sock:/var/run/docker.sock
                 environment:
+                  CONTAINERS: 1
+                  IMAGES: 1
+                  POST: 1
+                  ALLOW_STOP: 1
+                  ALLOW_RESTARTS: 1
+                networks:
+                  - socket-proxy-net
+
+              watchtower:
+                image: containrrr/watchtower
+                restart: unless-stopped
+                environment:
+                  DOCKER_HOST: tcp://socket-proxy:2375
                   WATCHTOWER_LABEL_ENABLE: "true"
                   WATCHTOWER_POLL_INTERVAL: "86400"
                   WATCHTOWER_CLEANUP: "true"
+                depends_on:
+                  - socket-proxy
                 networks:
                   - polaris-net
+                  - socket-proxy-net
 
             networks:
               polaris-net:
                 driver: bridge
                 enable_ipv6: true
+              socket-proxy-net:
+                driver: bridge
+                internal: true
 
             volumes:
               caddy_data:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,8 @@ jobs:
                   timeout: 10s
                   retries: 3
                   start_period: 15s
+                labels:
+                  - "com.centurylinklabs.watchtower.enable=true"
                 networks:
                   - polaris-net
 
@@ -136,6 +138,20 @@ jobs:
                   timeout: 5s
                   retries: 5
                   start_period: 10s
+                labels:
+                  - "com.centurylinklabs.watchtower.enable=true"
+                networks:
+                  - polaris-net
+
+              watchtower:
+                image: containrrr/watchtower
+                restart: unless-stopped
+                volumes:
+                  - /var/run/docker.sock:/var/run/docker.sock
+                environment:
+                  WATCHTOWER_LABEL_ENABLE: "true"
+                  WATCHTOWER_POLL_INTERVAL: "86400"
+                  WATCHTOWER_CLEANUP: "true"
                 networks:
                   - polaris-net
 
@@ -191,10 +207,14 @@ jobs:
 
             cd /opt/polaris
 
-            # Pull new image and restart stack
+            # Pull all images (app, neo4j, caddy, dozzle, watchtower)
             docker compose pull
-            docker compose up -d --wait
 
-            # Run database migrations
+            # Pull migrator image separately (profile-gated, not included above)
             docker compose pull migrate
+
+            # Run migrations before starting the new app image
             docker compose run --rm migrate npm run migrate:up
+
+            # Start (or restart) the stack with the new images
+            docker compose up -d --wait

--- a/infra/README.md
+++ b/infra/README.md
@@ -7,9 +7,10 @@ Production deployment for Polaris on a single Hetzner Ubuntu VM.
 - **App**: Nuxt 4 SSR in a Docker container (image from Docker Hub)
 - **Database**: Neo4j 5 Community + APOC in a Docker container
 - **Proxy**: Caddy in a Docker container (HTTP on port 80; swap `:80` for a domain name to get automatic TLS)
-- **Orchestration**: Docker Compose at `/opt/polaris/` (all three services)
+- **Orchestration**: Docker Compose at `/opt/polaris/` (all services)
 - **Provisioning**: Ansible playbook (one-time, idempotent) — installs Docker, configures UFW, creates system user
 - **Deploys**: GitHub Actions on push to `main`
+- **Auto-updates**: Watchtower polls Docker Hub daily and auto-updates `caddy` and `dozzle` when upstream images change. `app` and `neo4j` are excluded — `app` is managed by the deploy workflow, `neo4j` is never restarted automatically.
 
 ## Prerequisites
 
@@ -75,13 +76,15 @@ In your repository go to **Settings → Secrets and variables → Actions** and 
 
 ### 4. Trigger the first deploy
 
-Push any commit to `main`. The `Deploy` workflow will:
+Push any commit to `main`. The `Publish` workflow builds and pushes the Docker images, then the `Deploy` workflow:
 
-1. Build the Docker image and push it to Docker Hub
-2. SSH into the VM as `polaris`
-3. Write `/opt/polaris/.env` from the secrets above
-4. Run `docker compose pull && docker compose up -d`
-5. Run `npm run migrate:up` inside the app container
+1. SSHes into the VM as `polaris`
+2. Writes `/opt/polaris/.env`, `docker-compose.yml`, `Caddyfile`, and `dozzle/users.yml`
+3. Pulls all images (including the migrator)
+4. Runs database migrations (`docker compose run --rm migrate npm run migrate:up`)
+5. Starts the stack with the new images (`docker compose up -d --wait`)
+
+Migrations always run before the new `app` image starts, ensuring the database schema is up to date before the app serves traffic.
 
 After the workflow completes, `curl http://[2a01:4f9:c014:472c::1]` should return the Polaris app.
 

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -96,22 +96,42 @@ services:
     networks:
       - polaris-net
 
-  watchtower:
-    image: containrrr/watchtower
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
     restart: unless-stopped
+    privileged: true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      CONTAINERS: 1
+      IMAGES: 1
+      POST: 1
+      ALLOW_STOP: 1
+      ALLOW_RESTARTS: 1
+    networks:
+      - socket-proxy-net
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    environment:
+      DOCKER_HOST: tcp://socket-proxy:2375
       WATCHTOWER_LABEL_ENABLE: "true"
       WATCHTOWER_POLL_INTERVAL: "86400"
       WATCHTOWER_CLEANUP: "true"
+    depends_on:
+      - socket-proxy
     networks:
       - polaris-net
+      - socket-proxy-net
 
 networks:
   polaris-net:
     driver: bridge
     enable_ipv6: true
+  socket-proxy-net:
+    driver: bridge
+    internal: true
 
 volumes:
   caddy_data:

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -71,6 +71,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     networks:
       - polaris-net
 
@@ -89,6 +91,20 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
+    networks:
+      - polaris-net
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      WATCHTOWER_LABEL_ENABLE: "true"
+      WATCHTOWER_POLL_INTERVAL: "86400"
+      WATCHTOWER_CLEANUP: "true"
     networks:
       - polaris-net
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -107,10 +107,42 @@ services:
     networks:
       - polaris-net
 
+  socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    restart: unless-stopped
+    privileged: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      CONTAINERS: 1
+      IMAGES: 1
+      POST: 1
+      ALLOW_STOP: 1
+      ALLOW_RESTARTS: 1
+    networks:
+      - socket-proxy-net
+
+  watchtower:
+    image: containrrr/watchtower
+    restart: unless-stopped
+    environment:
+      DOCKER_HOST: tcp://socket-proxy:2375
+      WATCHTOWER_LABEL_ENABLE: "true"
+      WATCHTOWER_POLL_INTERVAL: "86400"
+      WATCHTOWER_CLEANUP: "true"
+    depends_on:
+      - socket-proxy
+    networks:
+      - polaris-net
+      - socket-proxy-net
+
 networks:
   polaris-net:
     driver: bridge
     enable_ipv6: true
+  socket-proxy-net:
+    driver: bridge
+    internal: true
 
 volumes:
   caddy_data:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -82,6 +82,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 15s
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     networks:
       - polaris-net
 
@@ -100,6 +102,8 @@ services:
       timeout: 5s
       retries: 5
       start_period: 10s
+    labels:
+      - "com.centurylinklabs.watchtower.enable=true"
     networks:
       - polaris-net
 


### PR DESCRIPTION
## Description

Two related improvements to the production deployment pipeline:

1. **Fix migration ordering** — migrations now run before the new `app` image starts, ensuring the database schema is always up to date before the app serves traffic. Previously, `docker compose up -d` started the new app first, then migrations ran against an already-live container.

2. **Add Watchtower** — monitors `caddy` and `dozzle` only (label-enable mode), polling Docker Hub every 24 hours to pick up upstream image updates (security patches, etc.) without requiring a full application deploy. `app` and `neo4j` are explicitly excluded.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Related Issues

Relates to #

## Changes Made

- `deploy.yml`: reorder deploy steps — pull images → run migrations → `docker compose up -d --wait`
- `deploy.yml`: add `watchtower` service to inline compose definition
- `deploy.yml`: add `com.centurylinklabs.watchtower.enable=true` labels to `caddy` and `dozzle`
- `infra/docker-compose.yml`: add Watchtower enable labels to `caddy` and `dozzle` (dev reference)
- `infra/ansible/templates/docker-compose.yml.j2`: add labels and `watchtower` service
- `infra/README.md`: update stack description and first-deploy steps

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have updated documentation if needed

## Additional Notes

Watchtower mounts `/var/run/docker.sock` — this is the standard trade-off for any container auto-update tool and is unchanged from the existing Dozzle socket mount. The socket is not exposed outside the internal `polaris-net` network.

No new GitHub Actions secrets are required.