### PR TITLE
Fix watchtower healthcheck causing deploy failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,6 +161,8 @@ jobs:
               watchtower:
                 image: containrrr/watchtower
                 restart: unless-stopped
+                healthcheck:
+                  disable: true
                 environment:
                   DOCKER_HOST: tcp://socket-proxy:2375
                   WATCHTOWER_LABEL_ENABLE: "true"

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -114,6 +114,8 @@ services:
   watchtower:
     image: containrrr/watchtower
     restart: unless-stopped
+    healthcheck:
+      disable: true
     environment:
       DOCKER_HOST: tcp://socket-proxy:2375
       WATCHTOWER_LABEL_ENABLE: "true"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -125,6 +125,8 @@ services:
   watchtower:
     image: containrrr/watchtower
     restart: unless-stopped
+    healthcheck:
+      disable: true
     environment:
       DOCKER_HOST: tcp://socket-proxy:2375
       WATCHTOWER_LABEL_ENABLE: "true"


### PR DESCRIPTION
## Description

`docker compose up -d --wait` treats containers without a `healthcheck` as unhealthy, causing the deploy to fail with:

```
container polaris-watchtower-1 is unhealthy
```

Watchtower is a background daemon with no meaningful health endpoint. Adding `healthcheck: disable: true` tells Docker Compose to skip health waiting for this container.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Related Issues

Fixes deploy failure introduced in #541.

## Changes Made

- Added `healthcheck: disable: true` to the `watchtower` service in `deploy.yml`, `infra/docker-compose.yml`, and `infra/ansible/templates/docker-compose.yml.j2`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues