### PR TITLE
Fix Watchtower Docker API version negotiation via socket-proxy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,6 +165,7 @@ jobs:
                   disable: true
                 environment:
                   DOCKER_HOST: tcp://socket-proxy:2375
+                  DOCKER_API_VERSION: "1.41"
                   WATCHTOWER_LABEL_ENABLE: "true"
                   WATCHTOWER_POLL_INTERVAL: "86400"
                   WATCHTOWER_CLEANUP: "true"

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -118,6 +118,7 @@ services:
       disable: true
     environment:
       DOCKER_HOST: tcp://socket-proxy:2375
+      DOCKER_API_VERSION: "1.41"
       WATCHTOWER_LABEL_ENABLE: "true"
       WATCHTOWER_POLL_INTERVAL: "86400"
       WATCHTOWER_CLEANUP: "true"

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -129,6 +129,7 @@ services:
       disable: true
     environment:
       DOCKER_HOST: tcp://socket-proxy:2375
+      DOCKER_API_VERSION: "1.41"
       WATCHTOWER_LABEL_ENABLE: "true"
       WATCHTOWER_POLL_INTERVAL: "86400"
       WATCHTOWER_CLEANUP: "true"


### PR DESCRIPTION
## Description

Watchtower logs are full of:

```
client version 1.25 is too old. Minimum supported API version is 1.40
```

The `tecnativa/docker-socket-proxy` is a transparent HTTP proxy — it does not rewrite the Docker API version in requests. Watchtower's embedded Docker client defaults to negotiating API version 1.25, which is below the production server's minimum of 1.40.

Setting `DOCKER_API_VERSION=1.41` on the Watchtower container forces its client to use a compatible version.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Configuration or build changes

## Changes Made

- Added `DOCKER_API_VERSION: "1.41"` to the `watchtower` service environment in `deploy.yml`, `infra/docker-compose.yml`, and `infra/ansible/templates/docker-compose.yml.j2`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues