### PR TITLE
feat: use Simple Icons for package manager types

### DIFF
--- a/app/components/SystemDependencyGraph.vue
+++ b/app/components/SystemDependencyGraph.vue
@@ -10,9 +10,10 @@
       <!-- Legend -->
       <div class="flex flex-wrap gap-3 text-sm">
         <div v-for="pm in packageManagers" :key="pm" class="flex items-center gap-1.5">
-          <span
-            class="inline-block w-3 h-3 rounded-full flex-shrink-0"
-            :style="{ backgroundColor: pmColor(pm) }"
+          <UIcon
+            :name="pmIcon(pm)"
+            class="flex-shrink-0 size-4"
+            :style="{ color: pmColor(pm) }"
           />
           <span class="text-(--ui-text-muted)">{{ pm }}</span>
         </div>
@@ -56,7 +57,14 @@
         <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
           <div v-if="selectedNode.packageManager">
             <span class="text-(--ui-text-muted) block">Package Manager</span>
-            <span class="font-medium">{{ selectedNode.packageManager }}</span>
+            <span class="font-medium flex items-center gap-1">
+              <UIcon
+                :name="pmIcon(selectedNode.packageManager)"
+                class="size-4 flex-shrink-0"
+                :style="{ color: pmColor(selectedNode.packageManager) }"
+              />
+              {{ selectedNode.packageManager }}
+            </span>
           </div>
           <div v-if="selectedNode.componentType">
             <span class="text-(--ui-text-muted) block">Type</span>
@@ -161,7 +169,7 @@ const containerRef = ref<HTMLDivElement | null>(null)
 
 const hasNodes = computed(() => props.nodes.length > 0)
 
-// ── Colors ─────────────────────────────────────────────────────────────────
+// ── Colors & icons ─────────────────────────────────────────────────────────
 
 const PM_COLORS: Record<string, string> = {
   npm: '#cb3837', yarn: '#2c8ebb', maven: '#c71a36', gradle: '#02303a',
@@ -169,8 +177,25 @@ const PM_COLORS: Record<string, string> = {
   go: '#00add8', composer: '#885630', unknown: '#6b7280',
 }
 
+const PM_ICONS: Record<string, string> = {
+  npm:      'i-simple-icons-npm',
+  yarn:     'i-simple-icons-yarn',
+  maven:    'i-simple-icons-apachemaven',
+  gradle:   'i-simple-icons-gradle',
+  pypi:     'i-simple-icons-pypi',
+  cargo:    'i-simple-icons-rust',
+  nuget:    'i-simple-icons-nuget',
+  gem:      'i-simple-icons-rubygems',
+  go:       'i-simple-icons-go',
+  composer: 'i-simple-icons-composer',
+}
+
 function pmColor(pm: string | null | undefined): string {
   return PM_COLORS[(pm ?? 'unknown').toLowerCase()] ?? PM_COLORS.unknown
+}
+
+function pmIcon(pm: string | null | undefined): string {
+  return PM_ICONS[(pm ?? 'unknown').toLowerCase()] ?? 'i-lucide-package'
 }
 
 const packageManagers = computed(() =>

--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -75,6 +75,33 @@ import { useDebounceFn } from '@vueuse/core'
 import type { TableColumn } from '@nuxt/ui'
 import type { ApiResponse, Component } from '~~/types/api'
 
+const PM_COLORS: Record<string, string> = {
+  npm: '#cb3837', yarn: '#2c8ebb', maven: '#c71a36', gradle: '#02303a',
+  pypi: '#3572a5', cargo: '#dea584', nuget: '#004880', gem: '#cc342d',
+  go: '#00add8', composer: '#885630', unknown: '#6b7280',
+}
+
+const PM_ICONS: Record<string, string> = {
+  npm:      'i-simple-icons-npm',
+  yarn:     'i-simple-icons-yarn',
+  maven:    'i-simple-icons-apachemaven',
+  gradle:   'i-simple-icons-gradle',
+  pypi:     'i-simple-icons-pypi',
+  cargo:    'i-simple-icons-rust',
+  nuget:    'i-simple-icons-nuget',
+  gem:      'i-simple-icons-rubygems',
+  go:       'i-simple-icons-go',
+  composer: 'i-simple-icons-composer',
+}
+
+function pmIcon(pm: string | null | undefined): string {
+  return PM_ICONS[(pm ?? 'unknown').toLowerCase()] ?? 'i-lucide-package'
+}
+
+function pmColor(pm: string | null | undefined): string {
+  return PM_COLORS[(pm ?? 'unknown').toLowerCase()] ?? PM_COLORS.unknown
+}
+
 const { status } = useAuth()
 const { getSortableHeader } = useSortableTable()
 
@@ -133,7 +160,15 @@ const columns: TableColumn<Component>[] = [
   },
   {
     accessorKey: 'packageManager',
-    header: ({ column }) => getSortableHeader(column, 'Package Manager')
+    header: ({ column }) => getSortableHeader(column, 'Package Manager'),
+    cell: ({ row }) => {
+      const pm = row.getValue('packageManager') as string | null
+      if (!pm) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return h('span', { class: 'flex items-center gap-1' }, [
+        h(resolveComponent('UIcon'), { name: pmIcon(pm), style: { color: pmColor(pm) }, class: 'size-4 flex-shrink-0' }),
+        pm,
+      ])
+    },
   },
   {
     accessorKey: 'licenses',

--- a/app/pages/technologies/[name].vue
+++ b/app/pages/technologies/[name].vue
@@ -258,10 +258,37 @@
 </template>
 
 <script setup lang="ts">
-import { h } from 'vue'
+import { h, resolveComponent } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
 import type { TechnologyApproval } from '~~/types/api'
 import semver from 'semver'
+
+const PM_COLORS: Record<string, string> = {
+  npm: '#cb3837', yarn: '#2c8ebb', maven: '#c71a36', gradle: '#02303a',
+  pypi: '#3572a5', cargo: '#dea584', nuget: '#004880', gem: '#cc342d',
+  go: '#00add8', composer: '#885630', unknown: '#6b7280',
+}
+
+const PM_ICONS: Record<string, string> = {
+  npm:      'i-simple-icons-npm',
+  yarn:     'i-simple-icons-yarn',
+  maven:    'i-simple-icons-apachemaven',
+  gradle:   'i-simple-icons-gradle',
+  pypi:     'i-simple-icons-pypi',
+  cargo:    'i-simple-icons-rust',
+  nuget:    'i-simple-icons-nuget',
+  gem:      'i-simple-icons-rubygems',
+  go:       'i-simple-icons-go',
+  composer: 'i-simple-icons-composer',
+}
+
+function pmIcon(pm: string | null | undefined): string {
+  return PM_ICONS[(pm ?? 'unknown').toLowerCase()] ?? 'i-lucide-package'
+}
+
+function pmColor(pm: string | null | undefined): string {
+  return PM_COLORS[(pm ?? 'unknown').toLowerCase()] ?? PM_COLORS.unknown
+}
 
 const { getSortableHeader } = useSortableTable()
 const approvalSorting = ref([])
@@ -469,7 +496,14 @@ const componentColumns: TableColumn<ComponentRef>[] = [
   {
     accessorKey: 'packageManager',
     header: ({ column }) => getSortableHeader(column, 'Package Manager'),
-    cell: ({ row }) => row.getValue('packageManager') || '—'
+    cell: ({ row }) => {
+      const pm = row.getValue('packageManager') as string | null
+      if (!pm) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return h('span', { class: 'flex items-center gap-1' }, [
+        h(resolveComponent('UIcon'), { name: pmIcon(pm), style: { color: pmColor(pm) }, class: 'size-4 flex-shrink-0' }),
+        pm,
+      ])
+    },
   },
   {
     id: 'violation',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@cyclonedx/cdxgen": "^12.4.1",
+        "@iconify-json/simple-icons": "^1.2.83",
         "@nuxt/eslint": "^1.13.0",
         "@nuxt/image": "^2.0.0",
         "@nuxt/test-utils": "^4.0.3",
@@ -1999,6 +2000,15 @@
       "integrity": "sha512-jnmMx7xxShfsKeNNJhn47IKj3gD/AbRz+poKLIPn4rSIXw+yVbXCfUBXza/Jo9YIEEFajBk6Zayet8DqGCvX6w==",
       "dev": true,
       "license": "ISC",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.83",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.83.tgz",
+      "integrity": "sha512-6Pp9V++XisT9RKH7FB4RLPqUDzcmLtSma0ovOEIoEWGrXtHwBFsH7oN1z8vvCVCb95fb87QgR46/zRLyN9Y3kg==",
+      "license": "CC0-1.0",
       "dependencies": {
         "@iconify/types": "*"
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@cyclonedx/cdxgen": "^12.4.1",
+    "@iconify-json/simple-icons": "^1.2.83",
     "@nuxt/eslint": "^1.13.0",
     "@nuxt/image": "^2.0.0",
     "@nuxt/test-utils": "^4.0.3",


### PR DESCRIPTION
## Description

Replaces color-only dots in the dependency graph legend with brand icons from Simple Icons, and adds icon prefixes to package manager name fields in table views. Users now get immediate visual recognition of ecosystems (npm, yarn, maven, gradle, pypi, cargo, nuget, gem, go, composer) via their familiar brand icons rendered in brand colors.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Closes #494

## Changes Made

- Install `@iconify-json/simple-icons`
- Add `PM_ICONS` map and `pmIcon()` helper in `SystemDependencyGraph.vue`; update legend to use `<UIcon>` and add icon to the component detail panel's Package Manager field
- Add `PM_ICONS`/`pmIcon()`/`pmColor()` to `app/pages/components/index.vue`; render icon + text in the `packageManager` table column
- Add `PM_ICONS`/`pmIcon()`/`pmColor()` to `app/pages/technologies/[name].vue`; render icon + text in the components table `packageManager` column
- Unknown package managers fall back to `i-lucide-package`
- D3 SVG graph nodes are intentionally unchanged (out of scope per issue)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested the build with `npm run build`
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have updated documentation if needed