### PR TITLE
feat: technology radar visualization (TIME framework distribution)

### DIFF
--- a/app/components/TechnologyRadar.vue
+++ b/app/components/TechnologyRadar.vue
@@ -1,0 +1,241 @@
+<template>
+  <div ref="containerRef" class="relative w-full">
+    <svg ref="svgRef" class="w-full" :viewBox="viewBox" />
+
+    <!-- Tooltip -->
+    <div
+      v-if="tooltip.visible"
+      class="absolute pointer-events-none z-10 px-2 py-1.5 rounded text-xs bg-(--ui-bg) border border-(--ui-border) shadow-md text-(--ui-text) max-w-56"
+      :style="{ left: tooltip.x + 'px', top: tooltip.y + 'px', transform: 'translate(-50%, -110%)' }"
+    >
+      <p class="font-medium">{{ tooltip.name }}</p>
+      <p v-if="tooltip.domain" class="text-(--ui-text-muted)">{{ tooltip.domain }}</p>
+      <p v-if="tooltip.type" class="text-(--ui-text-muted)">{{ tooltip.type }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount } from 'vue'
+import { select } from 'd3'
+import type { RadarTechnology } from '~~/server/services/technology.service'
+
+const props = defineProps<{ data: RadarTechnology[] }>()
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const SIZE = 800
+const CX = SIZE / 2
+const CY = SIZE / 2
+const MARGIN = 30  // padding around the outermost label
+
+// Ring order: innermost = invest, outermost = unclassified
+const RINGS: Array<{ key: string; label: string; color: string }> = [
+  { key: 'invest',       label: 'Invest',       color: 'var(--ui-color-success-500, #22c55e)' },
+  { key: 'tolerate',     label: 'Tolerate',     color: 'var(--ui-color-warning-500, #f59e0b)' },
+  { key: 'migrate',      label: 'Migrate',      color: 'var(--ui-color-warning-600, #d97706)' },
+  { key: 'eliminate',    label: 'Eliminate',    color: 'var(--ui-color-error-500, #ef4444)' },
+  { key: 'unclassified', label: 'Unclassified', color: 'var(--ui-color-neutral-400, #9ca3af)' },
+]
+
+const DOMAINS = [
+  'foundational-runtime',
+  'framework',
+  'data-platform',
+  'integration-platform',
+  'security-identity',
+  'infrastructure',
+  'observability',
+  'developer-tooling',
+  'other',
+]
+
+const RING_INNER_RADIUS = 60
+const LABEL_SPACE = 110  // space reserved outside the outer ring for domain labels
+const RING_OUTER_RADIUS = CX - LABEL_SPACE
+const RING_BAND = (RING_OUTER_RADIUS - RING_INNER_RADIUS) / RINGS.length
+
+const BLIP_RADIUS = 6
+const SECTOR_ANGLE = (2 * Math.PI) / DOMAINS.length
+
+// ── Template refs ────────────────────────────────────────────────────────────
+
+const svgRef = ref<SVGSVGElement | null>(null)
+const containerRef = ref<HTMLDivElement | null>(null)
+
+// Tight viewBox: crop to the full content extent including label space, minus the
+// unused margin that was originally between labels and the SVG edge.
+const contentRadius = RING_OUTER_RADIUS + LABEL_SPACE - MARGIN
+const viewBox = computed(() => `${CX - contentRadius} ${CY - contentRadius} ${contentRadius * 2} ${contentRadius * 2}`)
+
+// ── Tooltip state ────────────────────────────────────────────────────────────
+
+const tooltip = ref({ visible: false, x: 0, y: 0, name: '', domain: '', type: '' })
+
+// ── Seeded pseudo-random jitter (deterministic per technology name) ───────────
+
+function seededRandom(seed: string): () => number {
+  let h = 0
+  for (let i = 0; i < seed.length; i++) h = (Math.imul(31, h) + seed.charCodeAt(i)) | 0
+  return () => {
+    h = (Math.imul(1664525, h) + 1013904223) | 0
+    return ((h >>> 0) / 0xffffffff)
+  }
+}
+
+// ── Draw ─────────────────────────────────────────────────────────────────────
+
+function draw() {
+  const svgEl = svgRef.value
+  if (!svgEl) return
+
+  const svg = select(svgEl)
+  svg.selectAll('*').remove()
+
+  const g = svg.append('g')
+
+  // ── Background rings ──────────────────────────────────────────────────────
+  RINGS.forEach((ring, ri) => {
+    const inner = RING_INNER_RADIUS + ri * RING_BAND
+    const outer = inner + RING_BAND
+
+    // Alternating subtle fill for readability
+    g.append('circle')
+      .attr('cx', CX).attr('cy', CY)
+      .attr('r', outer)
+      .attr('fill', ri % 2 === 0 ? 'var(--ui-bg-elevated, #f9fafb)' : 'var(--ui-bg, #ffffff)')
+      .attr('stroke', 'var(--ui-border, #e5e7eb)')
+      .attr('stroke-width', 1)
+  })
+
+  // Centre hole
+  g.append('circle')
+    .attr('cx', CX).attr('cy', CY)
+    .attr('r', RING_INNER_RADIUS)
+    .attr('fill', 'var(--ui-bg, #ffffff)')
+    .attr('stroke', 'var(--ui-border, #e5e7eb)')
+    .attr('stroke-width', 1)
+
+  // ── Sector dividers ───────────────────────────────────────────────────────
+  DOMAINS.forEach((_, di) => {
+    const angle = di * SECTOR_ANGLE - Math.PI / 2
+    const x1 = CX + RING_INNER_RADIUS * Math.cos(angle)
+    const y1 = CY + RING_INNER_RADIUS * Math.sin(angle)
+    const x2 = CX + RING_OUTER_RADIUS * Math.cos(angle)
+    const y2 = CY + RING_OUTER_RADIUS * Math.sin(angle)
+    g.append('line')
+      .attr('x1', x1).attr('y1', y1)
+      .attr('x2', x2).attr('y2', y2)
+      .attr('stroke', 'var(--ui-border, #e5e7eb)')
+      .attr('stroke-width', 1)
+  })
+
+  // ── Ring labels (TIME category) ───────────────────────────────────────────
+  RINGS.forEach((ring, ri) => {
+    const inner = RING_INNER_RADIUS + ri * RING_BAND
+    const mid = inner + RING_BAND / 2
+    g.append('text')
+      .attr('x', CX)
+      .attr('y', CY - mid)
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'middle')
+      .attr('font-size', 11)
+      .attr('font-weight', '600')
+      .attr('fill', ring.color)
+      .attr('opacity', 0.85)
+      .text(ring.label)
+  })
+
+  // ── Sector labels (domain name) ───────────────────────────────────────────
+  DOMAINS.forEach((domain, di) => {
+    const midAngle = (di + 0.5) * SECTOR_ANGLE - Math.PI / 2
+    const labelR = RING_OUTER_RADIUS + 16
+    const lx = CX + labelR * Math.cos(midAngle)
+    const ly = CY + labelR * Math.sin(midAngle)
+
+    const anchor = Math.cos(midAngle) > 0.1 ? 'start'
+      : Math.cos(midAngle) < -0.1 ? 'end'
+      : 'middle'
+
+    g.append('text')
+      .attr('x', lx).attr('y', ly)
+      .attr('text-anchor', anchor)
+      .attr('dominant-baseline', 'middle')
+      .attr('font-size', 9)
+      .attr('fill', 'var(--ui-text-muted, #6b7280)')
+      .text(domain)
+  })
+
+  // ── Blips ─────────────────────────────────────────────────────────────────
+  props.data.forEach(tech => {
+    const ringIndex = RINGS.findIndex(r => r.key === tech.timeValue)
+    if (ringIndex === -1) return
+
+    const domainIndex = tech.domain ? DOMAINS.indexOf(tech.domain) : DOMAINS.indexOf('other')
+    const di = domainIndex === -1 ? DOMAINS.indexOf('other') : domainIndex
+
+    const ring = RINGS[ringIndex]!
+    const inner = RING_INNER_RADIUS + ringIndex * RING_BAND + BLIP_RADIUS + 4
+    const outer = inner + RING_BAND - BLIP_RADIUS * 2 - 8
+
+    const rng = seededRandom(tech.name)
+    const r = inner + rng() * Math.max(0, outer - inner)
+    const sectorStart = di * SECTOR_ANGLE - Math.PI / 2
+    const angle = sectorStart + (0.1 + rng() * 0.8) * SECTOR_ANGLE
+
+    const bx = CX + r * Math.cos(angle)
+    const by = CY + r * Math.sin(angle)
+
+    const blip = g.append('circle')
+      .attr('cx', bx).attr('cy', by)
+      .attr('r', BLIP_RADIUS)
+      .attr('fill', ring.color)
+      .attr('fill-opacity', 0.85)
+      .attr('stroke', 'var(--ui-bg, #ffffff)')
+      .attr('stroke-width', 1.5)
+      .attr('cursor', 'pointer')
+
+    blip
+      .on('mouseenter', (event: MouseEvent) => {
+        select(event.currentTarget as SVGCircleElement)
+          .attr('r', BLIP_RADIUS + 2)
+          .attr('fill-opacity', 1)
+
+        const rect = containerRef.value!.getBoundingClientRect()
+        tooltip.value = {
+          visible: true,
+          x: event.clientX - rect.left,
+          y: event.clientY - rect.top,
+          name: tech.name,
+          domain: tech.domain ?? '',
+          type: tech.type ?? '',
+        }
+      })
+      .on('mousemove', (event: MouseEvent) => {
+        const rect = containerRef.value!.getBoundingClientRect()
+        tooltip.value.x = event.clientX - rect.left
+        tooltip.value.y = event.clientY - rect.top
+      })
+      .on('mouseleave', (event: MouseEvent) => {
+        select(event.currentTarget as SVGCircleElement)
+          .attr('r', BLIP_RADIUS)
+          .attr('fill-opacity', 0.85)
+        tooltip.value.visible = false
+      })
+  })
+}
+
+// ── Lifecycle ─────────────────────────────────────────────────────────────────
+
+onMounted(draw)
+watch(() => props.data, draw, { deep: true })
+
+let ro: ResizeObserver | null = null
+onMounted(() => {
+  if (containerRef.value) {
+    ro = new ResizeObserver(draw)
+    ro.observe(containerRef.value)
+  }
+})
+onBeforeUnmount(() => ro?.disconnect())
+</script>

--- a/app/pages/technologies/index.vue
+++ b/app/pages/technologies/index.vue
@@ -1,15 +1,36 @@
 <template>
-  <div class="space-y-6">
+  <div class="space-y-4">
     <div class="flex justify-between items-center">
       <UPageHeader
         title="Technologies"
         description="Governed technology choices across the organization"
+        :ui="{ root: 'py-2' }"
       />
-      <UButton
-        v-if="session?.user"
-        label="+ Create Technology"
-        to="/technologies/new"
-      />
+      <div class="flex items-center gap-2">
+        <!-- View mode toggle -->
+        <UButtonGroup size="sm">
+          <UButton
+            icon="i-lucide-table"
+            :color="viewMode === 'table' ? 'primary' : 'neutral'"
+            :variant="viewMode === 'table' ? 'solid' : 'outline'"
+            aria-label="Table view"
+            @click="viewMode = 'table'"
+          />
+          <UButton
+            icon="i-lucide-radar"
+            :color="viewMode === 'radar' ? 'primary' : 'neutral'"
+            :variant="viewMode === 'radar' ? 'solid' : 'outline'"
+            aria-label="Radar view"
+            @click="viewMode = 'radar'"
+          />
+        </UButtonGroup>
+        <UButton
+          v-if="session?.user"
+          size="sm"
+          label="+ Create Technology"
+          to="/technologies/new"
+        />
+      </div>
     </div>
 
     <UAlert
@@ -22,7 +43,8 @@
     />
 
     <template v-else>
-      <UCard>
+      <!-- Table view -->
+      <UCard v-if="viewMode === 'table'">
         <UTable
           v-model:sorting="sorting"
           :manual-sorting="true"
@@ -48,6 +70,22 @@
           />
         </div>
       </UCard>
+
+      <!-- Radar view -->
+      <template v-if="viewMode === 'radar'">
+        <div class="flex items-center gap-3 mb-4">
+          <label class="text-sm font-medium text-(--ui-text)">Team</label>
+          <USelect
+            v-model="radarTeam"
+            :items="radarTeamItems"
+            class="w-56"
+          />
+          <UBadge v-if="radarPending" color="neutral" variant="subtle">Loading…</UBadge>
+        </div>
+        <UCard>
+          <TechnologyRadar :data="radarData" />
+        </UCard>
+      </template>
     </template>
 
     <!-- Edit Technology Modal -->
@@ -241,10 +279,13 @@ import { h } from 'vue'
 import * as z from 'zod'
 import type { TableColumn, FormSubmitEvent } from '@nuxt/ui'
 import type { ApiResponse, Technology } from '~~/types/api'
+import type { RadarTechnology } from '~~/server/services/technology.service'
 
 const { getSortableHeader } = useSortableTable()
 const { data: session } = useAuth()
 const { isSuperuser } = useEffectiveRole()
+
+
 
 const userTeams = computed(() =>
   (session.value?.user?.teams as { name: string }[] | undefined)?.map(t => t.name) || []
@@ -697,6 +738,37 @@ const { data, pending, error } = await useFetch<ApiResponse<Technology>>('/api/t
 
 const technologies = computed(() => data.value?.data || [])
 const total = computed(() => data.value?.total || data.value?.count || 0)
+
+// ── View mode (declared after await so it's bound to the correct component instance) ──
+const LS_KEY = 'polaris:technologies:viewMode'
+const viewMode = ref<'table' | 'radar'>('table')
+
+onMounted(() => {
+  const stored = localStorage.getItem(LS_KEY)
+  if (stored === 'radar' || stored === 'table') viewMode.value = stored
+  watch(viewMode, v => localStorage.setItem(LS_KEY, v))
+})
+
+// ── Radar data ────────────────────────────────────────────────────────────────
+const ALL_TEAMS_VALUE = '__all__'
+const radarTeam = ref<string>(ALL_TEAMS_VALUE)
+
+const radarTeamItems = computed(() => [
+  { label: 'All teams', value: ALL_TEAMS_VALUE },
+  ...(teamsData.value?.data || []).map(t => ({ label: t.name, value: t.name })).sort((a, b) => a.label.localeCompare(b.label))
+])
+
+const radarQuery = computed(() => radarTeam.value !== ALL_TEAMS_VALUE ? { team: radarTeam.value } : {})
+
+const { data: radarResponse, pending: radarPending } = useLazyFetch<ApiResponse<RadarTechnology>>(
+  '/api/technologies/radar',
+  {
+    query: radarQuery,
+    watch: [radarQuery],
+  }
+)
+
+const radarData = computed(() => radarResponse.value?.data || [])
 
 useHead({ title: 'Technologies - Polaris' })
 </script>

--- a/server/api/technologies/radar.get.ts
+++ b/server/api/technologies/radar.get.ts
@@ -1,0 +1,72 @@
+import type { ApiResponse } from '~~/types/api'
+import type { RadarTechnology } from '../../services/technology.service'
+import { technologyService } from '../../services/singletons'
+
+/**
+ * @openapi
+ * /technologies/radar:
+ *   get:
+ *     tags:
+ *       - Technologies
+ *     summary: Get technologies shaped for the radar visualization
+ *     description: >
+ *       Returns all technologies with a resolved TIME value for the radar view.
+ *       When `team` is provided each technology is placed in the ring matching
+ *       that team's TIME approval. Without `team` the dominant TIME value across
+ *       all approvals is used (majority vote; ties broken by severity).
+ *       Technologies with no applicable approval are marked 'unclassified'.
+ *     parameters:
+ *       - in: query
+ *         name: team
+ *         schema:
+ *           type: string
+ *         required: false
+ *         description: Filter TIME values by this team name
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved radar data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiSuccessResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         type: object
+ *                         properties:
+ *                           name:
+ *                             type: string
+ *                           type:
+ *                             type: string
+ *                             nullable: true
+ *                           domain:
+ *                             type: string
+ *                             nullable: true
+ *                           timeValue:
+ *                             type: string
+ *                             enum: [invest, tolerate, migrate, eliminate, unclassified]
+ *                           approvalCount:
+ *                             type: integer
+ *       500:
+ *         description: Failed to fetch radar data
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ */
+export default defineEventHandler(async (event): Promise<ApiResponse<RadarTechnology>> => {
+  try {
+    const query = getQuery(event)
+    const team = typeof query.team === 'string' ? query.team.trim() || undefined : undefined
+
+    const data = await technologyService.findForRadar(team)
+
+    return { success: true, data, count: data.length }
+  } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'Failed to fetch radar data'
+    return { success: false, error: message, data: [] }
+  }
+})

--- a/server/database/queries/technologies/find-for-radar.cypher
+++ b/server/database/queries/technologies/find-for-radar.cypher
@@ -1,0 +1,11 @@
+MATCH (t:Technology)
+OPTIONAL MATCH (approvalTeam:Team)-[approval:APPROVES]->(t)
+WITH t,
+     collect(DISTINCT {
+       team: approvalTeam.name,
+       time: approval.time
+     }) as approvals
+RETURN t.name    as name,
+       t.type    as type,
+       t.domain  as domain,
+       approvals

--- a/server/repositories/technology.repository.ts
+++ b/server/repositories/technology.repository.ts
@@ -181,6 +181,29 @@ export class TechnologyRepository extends BaseRepository {
     }
   }
 
+  /**
+   * Find all technologies with their team approvals for the radar view.
+   *
+   * Returns a lightweight projection — no versions, components, or constraints.
+   */
+  async findForRadar(): Promise<Array<{
+    name: string
+    type: string | null
+    domain: string | null
+    approvals: Array<{ team: string; time: string }>
+  }>> {
+    const query = await loadQuery('technologies/find-for-radar.cypher')
+    const { records } = await this.executeQuery(query, {})
+    return records.map(record => ({
+      name: record.get('name') as string,
+      type: record.get('type') as string | null,
+      domain: record.get('domain') as string | null,
+      approvals: (record.get('approvals') as Array<{ team?: string; time?: string }>)
+        .filter(a => a.team && a.time)
+        .map(a => ({ team: a.team!, time: a.time! })),
+    }))
+  }
+
   async update(params: UpdateTechnologyParams & { changes: Record<string, { before: unknown; after: unknown }> }): Promise<string> {
     const query = await loadQuery('technologies/update.cypher')
     const { records } = await this.executeQuery(query, { ...params, changes: JSON.stringify(params.changes) })

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -301,4 +301,62 @@ export class TechnologyService {
 
     return await this.techRepo.upsertApproval({ ...params, changes })
   }
+
+  /**
+   * Get all technologies shaped for the radar visualization.
+   *
+   * When `team` is provided each technology is placed in the ring matching
+   * that team's TIME value; technologies without an approval from that team
+   * are marked 'unclassified'.
+   *
+   * When no `team` is given the dominant TIME value across all approvals is
+   * used (majority vote; ties broken by severity: eliminate > migrate >
+   * tolerate > invest). Technologies with no approvals at all are
+   * 'unclassified'.
+   */
+  async findForRadar(team?: string): Promise<RadarTechnology[]> {
+    const rows = await this.techRepo.findForRadar()
+
+    const severityOrder: TimeValue[] = ['eliminate', 'migrate', 'tolerate', 'invest']
+
+    return rows.map(row => {
+      let timeValue: TimeValue | 'unclassified' = 'unclassified'
+
+      if (team) {
+        const approval = row.approvals.find(a => a.team === team)
+        if (approval && VALID_TIME_VALUES.includes(approval.time as TimeValue)) {
+          timeValue = approval.time as TimeValue
+        }
+      } else if (row.approvals.length > 0) {
+        // Count votes per TIME value
+        const counts: Partial<Record<TimeValue, number>> = {}
+        for (const a of row.approvals) {
+          if (VALID_TIME_VALUES.includes(a.time as TimeValue)) {
+            const t = a.time as TimeValue
+            counts[t] = (counts[t] ?? 0) + 1
+          }
+        }
+        const maxCount = Math.max(...Object.values(counts) as number[])
+        // Among tied values pick the most severe
+        const tied = severityOrder.filter(t => (counts[t] ?? 0) === maxCount)
+        if (tied.length > 0) timeValue = tied[0]!
+      }
+
+      return {
+        name: row.name,
+        type: (row.type as ComponentType | null) ?? null,
+        domain: (row.domain as TechnologyDomain | null) ?? null,
+        timeValue,
+        approvalCount: row.approvals.length,
+      }
+    })
+  }
+}
+
+export interface RadarTechnology {
+  name: string
+  type: ComponentType | null
+  domain: TechnologyDomain | null
+  timeValue: TimeValue | 'unclassified'
+  approvalCount: number
 }

--- a/spec.md
+++ b/spec.md
@@ -1,94 +1,132 @@
-# Spec: Collapsible Sidebar
+# Spec: Technology Radar Visualization (Issue #553)
 
 ## Problem Statement
 
-The sidebar is a fixed `w-64` `<aside>` with no responsive behaviour. On small screens it consumes a disproportionate share of the viewport, leaving little room for main content.
+The technologies page is a flat sortable table. There is no way to see the health of the technology portfolio at a glance — which technologies are strategic investments vs. migration candidates vs. scheduled for elimination. Engineering leadership needs a visual representation of the TIME (Tolerate/Invest/Migrate/Eliminate) framework distribution across the portfolio.
 
-## Nuxt UI v4 Capability Summary
+## Solution
 
-All requirements are achievable with standard Nuxt UI v4 components — no custom CSS width toggling or manual tooltip wrappers are needed:
+Add a **D3 ring radar** view to `app/pages/technologies/index.vue`, toggled via a view-mode selector alongside the existing table view. A new API endpoint aggregates technology TIME classifications filtered by team.
 
-| Requirement | Nuxt UI solution |
-|---|---|
-| Collapsible sidebar with icon-only mode | `<USidebar collapsible="icon">` |
-| Rail toggle button on sidebar edge | `<USidebar :rail="true">` |
-| Nav items icon-only + tooltips on hover | `<UNavigationMenu :collapsed="true" :tooltip="true">` |
-| Mobile: full-screen slideover | `<USidebar mode="slideover">` (auto below 1024px) |
-| Persist state across reloads | `useLocalStorage` from `@vueuse/core` (already a dependency) |
+---
 
 ## Requirements
 
-### Collapse Trigger
+### Radar Layout
 
-- A rail (thin clickable strip) on the right edge of the sidebar toggles collapse/expand.
-- The user controls this manually on all screen sizes.
-- On screens narrower than 1024px, `USidebar` automatically switches to a slideover (mobile drawer) — this is built-in behaviour.
+- Five concentric rings, from inner to outer: **Invest → Tolerate → Migrate → Eliminate → Unclassified**
+- Technology blips are plotted as circles within their ring, distributed by **domain** along the angular axis (each domain occupies an equal-angle sector of the circle)
+- Domains are the existing `TechnologyDomain` values: `foundational-runtime`, `framework`, `data-platform`, `integration-platform`, `security-identity`, `infrastructure`, `observability`, `developer-tooling`, `other`
+- Blips show the **technology name in a tooltip on hover** — no always-visible labels
+- Ring boundaries are labelled with the TIME category name; sector boundaries are labelled with the domain name
 
-### Collapsed State (icon-only mode)
+### Team Filter
 
-- Sidebar narrows to icon-only width (`--sidebar-width-icon: 4rem`, built into `USidebar`).
-- Each navigation item shows only its icon; labels are hidden.
-- Hovering an icon shows the item label as a tooltip (right-side, built into `UNavigationMenu :tooltip="true"`).
-- The main content area expands to fill the freed space (handled by `USidebar`'s gap spacer).
-- Width transition is animated (built into `USidebar` — `transition-[width] duration-200 ease-linear`).
+- A **team dropdown** above the radar selects which team's TIME approvals are used to place blips
+- When a team is selected, each technology is placed in the ring matching that team's TIME value for it
+- Technologies with no approval from the selected team appear in the **Unclassified** ring
+- The dropdown includes an **"All teams"** option — when selected, the most common TIME value across all teams is used; ties broken by severity order (Eliminate > Migrate > Tolerate > Invest); technologies with no approvals at all are Unclassified
 
-### Logo / Header Area (collapsed)
+### View Toggle
 
-- Hide "Polaris" text label (`v-show="sidebarOpen"`).
-- Hide `UColorModeButton` (`v-show="sidebarOpen"`).
-- The zap icon remains visible as the only logo element.
+- A toggle control (table icon / radar icon) in the page header switches between the existing table view and the new radar view
+- The selected view mode is persisted in `localStorage` (key: `polaris:technologies:viewMode`)
+- Default is table view
 
-### User Section (collapsed)
+### New API Endpoint
 
-- Hide user name, email, and role badge (`v-show="sidebarOpen"`).
-- Avatar remains visible.
-- Profile and Sign Out items show icon-only with tooltips (handled by `UNavigationMenu :collapsed` + `:tooltip`).
-- "Sign In" button: hide the full button, show an icon-only button when collapsed.
+`GET /api/technologies/radar`
 
-### Documentation Section (collapsed)
+**Query parameters:**
+- `team` (optional string) — team name to filter TIME approvals by
 
-- The "Documentation" label (`type: 'label'`) is hidden automatically by `UNavigationMenu` when `collapsed` is true.
-- All doc nav items show icon-only with tooltips.
+**Response shape:**
+```ts
+{
+  success: true,
+  data: RadarTechnology[]
+}
 
-### Version Footer (collapsed)
+interface RadarTechnology {
+  name: string
+  domain: TechnologyDomain | null
+  type: ComponentType | null
+  timeValue: TimeValue | 'unclassified'
+  approvalCount: number   // total number of team approvals for this technology
+}
+```
 
-- Version string hidden (`v-show="sidebarOpen"`).
+**Logic:**
+- Fetches all technologies with their approvals
+- If `team` param provided: uses that team's TIME value; `unclassified` if no approval exists for that team
+- If no `team` param: computes dominant TIME value across all team approvals using majority vote; ties broken by severity (Eliminate > Migrate > Tolerate > Invest); `unclassified` if no approvals at all
+- No pagination — returns all technologies (radar is a full-portfolio view)
+- Auth: public (same as existing `/api/technologies`)
 
-### State Persistence
-
-- `sidebarOpen` is backed by `useLocalStorage('polaris:sidebar:open', true)`.
-- Restores last state on page reload.
+---
 
 ## Acceptance Criteria
 
-1. The sidebar renders using `<USidebar collapsible="icon" :rail="true">`.
-2. Clicking the rail toggles between expanded (`w-64`) and collapsed (`w-16`) states.
-3. In collapsed mode, all navigation icons are visible and links work.
-4. In collapsed mode, hovering any nav icon shows a tooltip with the item label.
-5. In collapsed mode, the logo area shows only the zap icon.
-6. In collapsed mode, the user section shows only the avatar.
-7. The collapsed/expanded state persists across page reloads via `localStorage`.
-8. The width transition is smooth (no layout jump).
-9. The main content area fills the remaining width in both states.
-10. On screens < 1024px, the sidebar opens as a slideover (mobile behaviour).
-11. Dark mode continues to work correctly in both states.
+1. The technologies page has a view toggle (table / radar icons); default is table
+2. Selecting the radar view renders a D3 SVG with five concentric rings labelled Invest / Tolerate / Migrate / Eliminate / Unclassified (inner to outer)
+3. The radar is divided into equal-angle sectors by domain; each sector is labelled with the domain name
+4. Each technology appears as a blip in the correct ring for the selected team's TIME value
+5. Hovering a blip shows a tooltip with the technology name, domain, and type
+6. The team dropdown filters blips correctly; "All teams" uses dominant TIME logic
+7. Technologies with no TIME approval for the selected team appear in the Unclassified ring
+8. The view mode persists across page reloads via localStorage
+9. `GET /api/technologies/radar?team=<name>` returns correctly shaped data
+10. The radar SVG scales to container width (responsive via viewBox)
+11. Existing table view and all its functionality is unchanged
+12. New endpoint and service method have unit tests
 
-## Implementation Approach
+---
 
-1. **Verify `@vueuse/core` import** — confirm `useLocalStorage` is importable (it is, already used by `@nuxt/ui` internally).
-2. **Replace `<aside>` with `<USidebar>`** in `app/layouts/default.vue`:
-   - `collapsible="icon"` for icon-only collapse mode.
-   - `:rail="true"` for the edge toggle strip.
-   - `v-model:open="sidebarOpen"` bound to a `useLocalStorage` ref.
-   - Move all sidebar content into the default slot (header, nav, footer slots as appropriate).
-3. **Add `sidebarOpen` state** using `useLocalStorage('polaris:sidebar:open', true)`.
-4. **Update all three `UNavigationMenu` instances** to pass `:collapsed="!sidebarOpen"` and `:tooltip="!sidebarOpen"`.
-5. **Guard text-only elements** with `v-show="sidebarOpen"`:
-   - "Polaris" `<span>` in the logo.
-   - `UColorModeButton`.
-   - User name `<div>`, email `<div>`, role `UBadge`.
-   - Version `<span>` in the footer.
-6. **Handle Sign In button** — show full `UButton` when expanded (`v-if="sidebarOpen"`), icon-only button when collapsed (`v-else`).
-7. **Adjust nav padding** — `USidebar`'s body slot uses `p-4`; remove the existing `px-6` from the `<nav>` to avoid double padding.
-8. **Verify layout** — confirm `<main>` fills remaining width correctly with `USidebar`'s gap spacer approach (the `flex min-h-screen` wrapper on the outer div should still work).
-9. **Test** — expanded/collapsed toggle, tooltip display, localStorage persistence, mobile slideover, dark mode.
+## Implementation Steps
+
+1. **New Cypher query** `server/database/queries/technologies/find-for-radar.cypher`
+   - Returns all technologies with domain, type, and all team approvals (team name + time value)
+   - No pagination, no ORDER BY
+
+2. **Repository method** `TechnologyRepository.findForRadar()`
+   - Executes the new query
+   - Returns `Array<{ name, domain, type, approvals: { team, time }[] }>`
+
+3. **Service method** `TechnologyService.findForRadar(team?: string): Promise<RadarTechnology[]>`
+   - If `team` provided: find that team's approval for each technology; assign `unclassified` if absent
+   - If no `team`: compute dominant TIME via majority vote with severity tie-break; assign `unclassified` if no approvals
+   - Returns `RadarTechnology[]` (name, domain, type, timeValue, approvalCount)
+
+4. **Unit tests** `test/server/services/technology.service.spec.ts`
+   - Dominant TIME logic (majority, tie-breaking by severity)
+   - Team filter (found, not found → unclassified)
+   - All-unclassified case
+
+5. **API endpoint** `server/api/technologies/radar.get.ts`
+   - Reads optional `team` query param with `typeof === 'string' + trim()` validation
+   - Calls `technologyService.findForRadar(team)`
+   - Returns `{ success: true, data }` with OpenAPI doc comment
+
+6. **Radar component** `app/components/TechnologyRadar.vue`
+   - Props: `data: RadarTechnology[]`
+   - D3 SVG with five concentric rings (Invest innermost, Unclassified outermost)
+   - Equal-angle sectors per domain (9 domains → 40° each)
+   - Blips as `<circle>` elements, coloured by TIME value:
+     - invest → green (`success`)
+     - tolerate → amber (`warning`)
+     - migrate → amber (`warning`)
+     - eliminate → red (`error`)
+     - unclassified → grey (`neutral`)
+   - Blips jittered within their ring+sector cell to avoid overlap
+   - Tooltip on hover: technology name, domain, type
+   - Ring labels (TIME category) and sector labels (domain name) rendered as SVG text
+   - SVG `viewBox` set to fixed coordinate space; `width="100%"` for responsiveness
+
+7. **Page integration** `app/pages/technologies/index.vue`
+   - Add view-mode toggle buttons (table / radar icons) to page header area
+   - `const viewMode = useLocalStorage('polaris:technologies:viewMode', 'table')`
+   - Team dropdown (fetches `/api/teams`) rendered above radar, hidden in table mode; default "All teams"
+   - `useFetch('/api/technologies/radar', { query: { team: selectedTeam } })` — lazy, only fetches when radar mode is active
+   - Render `<TechnologyRadar :data="radarData" />` when `viewMode === 'radar'`
+
+8. **Lint, build, test** — verify no regressions

--- a/test/server/repositories/system.repository.spec.ts
+++ b/test/server/repositories/system.repository.spec.ts
@@ -108,10 +108,10 @@ describe('SystemRepository', () => {
   describe('create()', () => {
     it('should create a system and return its name', async () => {
       if (!ctx.neo4jAvailable) return
-      await seed(ctx.driver, `MERGE (:Team { name: $t })`, { t: 'Platform Team' })
+      await seed(ctx.driver, `MERGE (:Team { name: $t })`, { t: `${PREFIX}Platform Team` })
       const name = await repo.create({
         name: `${PREFIX}new-system`, domain: 'Platform',
-        ownerTeam: 'Platform Team', businessCriticality: 'high',
+        ownerTeam: `${PREFIX}Platform Team`, businessCriticality: 'high',
         environment: 'prod', repositories: [], userId: 'test-user'
       })
 

--- a/test/server/services/technology.service.spec.ts
+++ b/test/server/services/technology.service.spec.ts
@@ -193,4 +193,56 @@ describe('TechnologyService', () => {
       expect(params.vendor).toBe('Meta')
     })
   })
+
+  describe('findForRadar()', () => {
+    const mockRows = [
+      { name: 'React',   type: 'framework', domain: 'framework',    approvals: [{ team: 'A', time: 'invest' }, { team: 'B', time: 'invest' }] },
+      { name: 'Angular', type: 'framework', domain: 'framework',    approvals: [{ team: 'A', time: 'migrate' }, { team: 'B', time: 'invest' }] },
+      { name: 'Vue',     type: 'framework', domain: 'framework',    approvals: [{ team: 'A', time: 'eliminate' }, { team: 'B', time: 'migrate' }, { team: 'C', time: 'migrate' }] },
+      { name: 'Svelte',  type: 'framework', domain: 'developer-tooling', approvals: [] },
+    ]
+
+    beforeEach(() => {
+      vi.mocked(TechnologyRepository.prototype.findForRadar).mockResolvedValue(mockRows)
+    })
+
+    it('returns all technologies with unclassified for no approvals', async () => {
+      const result = await service.findForRadar()
+      const svelte = result.find(r => r.name === 'Svelte')
+      expect(svelte?.timeValue).toBe('unclassified')
+      expect(svelte?.approvalCount).toBe(0)
+    })
+
+    it('uses majority vote when no team filter', async () => {
+      const result = await service.findForRadar()
+      // React: 2x invest → invest
+      expect(result.find(r => r.name === 'React')?.timeValue).toBe('invest')
+    })
+
+    it('breaks ties by severity (eliminate > migrate > tolerate > invest)', async () => {
+      const result = await service.findForRadar()
+      // Angular: 1x migrate, 1x invest → tie → migrate wins (more severe)
+      expect(result.find(r => r.name === 'Angular')?.timeValue).toBe('migrate')
+      // Vue: 1x eliminate, 2x migrate → migrate wins (majority)
+      expect(result.find(r => r.name === 'Vue')?.timeValue).toBe('migrate')
+    })
+
+    it('filters by team when team param provided', async () => {
+      const result = await service.findForRadar('A')
+      expect(result.find(r => r.name === 'React')?.timeValue).toBe('invest')
+      expect(result.find(r => r.name === 'Angular')?.timeValue).toBe('migrate')
+      expect(result.find(r => r.name === 'Vue')?.timeValue).toBe('eliminate')
+    })
+
+    it('marks unclassified when team has no approval for a technology', async () => {
+      const result = await service.findForRadar('Z')
+      expect(result.every(r => r.timeValue === 'unclassified')).toBe(true)
+    })
+
+    it('includes approvalCount', async () => {
+      const result = await service.findForRadar()
+      expect(result.find(r => r.name === 'React')?.approvalCount).toBe(2)
+      expect(result.find(r => r.name === 'Svelte')?.approvalCount).toBe(0)
+    })
+  })
 })


### PR DESCRIPTION
## Description

Implements the technology radar visualization from issue #553. Adds a D3 ring radar view to the technologies page showing the TIME (Tolerate/Invest/Migrate/Eliminate) framework distribution across the portfolio, filterable by team.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #553

## Changes Made

- `server/database/queries/technologies/find-for-radar.cypher` — new query returning all technologies with team approvals
- `server/repositories/technology.repository.ts` — `findForRadar()` method
- `server/services/technology.service.ts` — `findForRadar(team?)` with majority-vote dominant TIME logic and severity tie-breaking
- `server/api/technologies/radar.get.ts` — new `GET /api/technologies/radar?team=<name>` endpoint
- `app/components/TechnologyRadar.vue` — D3 SVG component: 5 concentric rings (Invest→Unclassified), 9 domain sectors, hover tooltips, responsive viewBox
- `app/pages/technologies/index.vue` — view toggle (table/radar) with localStorage persistence, team dropdown, lazy radar fetch
- `test/server/services/technology.service.spec.ts` — 6 new unit tests for dominant TIME logic, team filter, unclassified fallback
- `test/server/repositories/system.repository.spec.ts` — fix: prefix `Platform Team` seed to prevent test data leaking into the live database

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have updated documentation if needed

## Additional Notes

The radar uses deterministic blip placement (seeded by technology name) so positions are stable across re-renders. Since the dev database currently has no TIME approvals set, all technologies appear in the Unclassified ring until approvals are added via the "Set TIME" action on the table view.