### PR TITLE
fix: upsert Team→USES→Technology edges after SBOM ingestion

### DIFF
--- a/server/database/queries/sboms/upsert-team-uses-technology.cypher
+++ b/server/database/queries/sboms/upsert-team-uses-technology.cypher
@@ -1,0 +1,18 @@
+// Upsert (Team)-[:USES]->(Technology) edges derived from a single system.
+//
+// Called after each SBOM ingestion to keep team→technology usage current.
+// Scoped to $systemName so only the affected system's ownership chain is
+// re-evaluated — avoids a full-graph scan on every SBOM submission.
+MATCH (team:Team)-[:OWNS]->(sys:System {name: $systemName})
+MATCH (sys)-[:USES]->(comp:Component)-[:IS_VERSION_OF]->(tech:Technology)
+WITH team, tech,
+     count(DISTINCT sys) AS systemCount,
+     datetime() AS now
+MERGE (team)-[u:USES]->(tech)
+ON CREATE SET
+  u.firstUsed    = now,
+  u.lastVerified = now,
+  u.systemCount  = systemCount
+ON MATCH SET
+  u.lastVerified = now,
+  u.systemCount  = systemCount

--- a/server/repositories/sbom.repository.ts
+++ b/server/repositories/sbom.repository.ts
@@ -122,6 +122,20 @@ export class SBOMRepository extends BaseRepository {
     }
   }
 
+  /**
+   * Upsert (Team)-[:USES]->(Technology) edges for a system.
+   *
+   * Derives team→technology usage from the ownership chain:
+   *   Team -[:OWNS]-> System -[:USES]-> Component -[:IS_VERSION_OF]-> Technology
+   *
+   * Called after every SBOM ingestion so compliance violation queries
+   * have up-to-date USES edges to match against.
+   */
+  async upsertTeamUsesTechnology(systemName: string): Promise<void> {
+    const query = await loadQuery('sboms/upsert-team-uses-technology.cypher')
+    await this.executeQuery(query, { systemName })
+  }
+
   async createAuditLog(params: {
     systemName: string
     userId: string

--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -106,10 +106,14 @@ export class SBOMService {
       timestamp: new Date()
     })
     
-    // 6. Update repository last scan timestamp
+    // 6. Upsert (Team)-[:USES]->(Technology) edges so compliance violation
+    //    queries have current data after every SBOM submission.
+    await this.sbomRepo.upsertTeamUsesTechnology(system.name)
+
+    // 7. Update repository last scan timestamp
     await this.sourceRepoRepo.updateLastScan(normalizedUrl)
     
-    // 7. Audit log for SBOM import
+    // 8. Audit log for SBOM import
     await this.sbomRepo.createAuditLog({
       systemName: system.name,
       userId: input.userId,

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -89,6 +89,7 @@ describe('SBOMService', () => {
       name: 'test-system'
     })
     vi.mocked(SourceRepositoryRepository.prototype.updateLastScan).mockResolvedValue()
+    vi.mocked(SBOMRepository.prototype.upsertTeamUsesTechnology).mockResolvedValue()
   })
 
   describe('processSBOM', () => {
@@ -552,6 +553,44 @@ describe('SBOMService', () => {
       // metadata.component excluded; component + nested = 2
       expect(persistCall.components).toHaveLength(2)
       expect(persistCall.components.some(c => c.name === 'nested-lib')).toBe(true)
+    })
+
+    it('should upsert Team→USES→Technology edges after persisting components', async () => {
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1,
+        componentsUpdated: 0,
+        relationshipsCreated: 1
+      })
+
+      await service.processSBOM({
+        sbom: {
+          bomFormat: 'CycloneDX',
+          specVersion: '1.4',
+          components: [{ type: 'library', name: 'react', version: '18.0.0', purl: 'pkg:npm/react@18.0.0' }]
+        },
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx'
+      })
+
+      expect(SBOMRepository.prototype.upsertTeamUsesTechnology).toHaveBeenCalledOnce()
+      expect(SBOMRepository.prototype.upsertTeamUsesTechnology).toHaveBeenCalledWith('test-system')
+    })
+
+    it('should upsert Team→USES→Technology edges before updating last scan timestamp', async () => {
+      const callOrder: string[] = []
+      vi.mocked(SBOMRepository.prototype.upsertTeamUsesTechnology).mockImplementation(async () => { callOrder.push('upsert') })
+      vi.mocked(SourceRepositoryRepository.prototype.updateLastScan).mockImplementation(async () => { callOrder.push('scan') })
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 0, componentsUpdated: 0, relationshipsCreated: 0
+      })
+
+      await service.processSBOM({
+        sbom: { bomFormat: 'CycloneDX', specVersion: '1.4', components: [] },
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx'
+      })
+
+      expect(callOrder).toEqual(['upsert', 'scan'])
     })
   })
 })


### PR DESCRIPTION
## Description

After submitting an SBOM, the `/violations` compliance page always showed zero results. The `find-violations.cypher` query starts with `MATCH (team:Team)-[u:USES]->(tech:Technology)` — so without `USES` edges it returns nothing. These edges were never written during SBOM ingestion.

After `persistSBOM()` completes, `upsertTeamUsesTechnology(systemName)` now traverses the ownership chain:

```
Team -[:OWNS]-> System -[:USES]-> Component -[:IS_VERSION_OF]-> Technology
```

and `MERGE`s the `USES` edge with `firstUsed`, `lastVerified`, and `systemCount` properties. The query is scoped to the ingested system to avoid a full-graph scan on every submission.

**Note:** Existing systems ingested before this fix have no `USES` edges. They will be populated on the next SBOM submission. To backfill immediately, run `schema/migrations/common/20251022_140437_add_team_uses_technology_relationship.up.cypher` manually.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #549

## Changes Made

- `server/database/queries/sboms/upsert-team-uses-technology.cypher` — new query scoped to a single system
- `server/repositories/sbom.repository.ts` — `upsertTeamUsesTechnology(systemName)` method
- `server/services/sbom.service.ts` — call after `persistSBOM`, before `updateLastScan`
- `test/server/services/sbom.service.spec.ts` — 2 new tests: verifies the method is called with the correct system name, and verifies call order relative to `updateLastScan`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues