### PR TITLE
fix: prevent spurious pkg:maven components in SBOM generation

### DIFF
--- a/.github/workflows/polaris-sbom.yml
+++ b/.github/workflows/polaris-sbom.yml
@@ -90,6 +90,13 @@ jobs:
           # Domain used when POLARIS_AUTO_REGISTER creates the system entry.
           # POLARIS_DOMAIN: 'Development'
 
+          # Restrict cdxgen to specific language scanner(s). Without this, cdxgen runs all
+          # scanners including the JAR scanner, which picks up .jar files bundled inside
+          # node_modules (e.g. from @appthreat/atom) and produces spurious pkg:maven components.
+          # Set to a comma-separated list matching your project: js, java, py, ruby, rust, go, php, dotnet.
+          # Omit to let cdxgen auto-detect (safe when node_modules is not present during the scan).
+          # POLARIS_PROJECT_TYPE: 'js'
+
           # Populated automatically by GitHub Actions — used as the SBOM version.
           GITHUB_SHA: ${{ github.sha }}
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/scripts/polaris-push.mjs
+++ b/scripts/polaris-push.mjs
@@ -60,7 +60,10 @@ const POLARIS_REPO_URL =
     ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
     : null)
 const AUTO_REGISTER = process.env.POLARIS_AUTO_REGISTER === 'true'
-const POLARIS_PROJECT_TYPE = (process.env.POLARIS_PROJECT_TYPE || '').split(',').filter(Boolean)
+const POLARIS_PROJECT_TYPE = (process.env.POLARIS_PROJECT_TYPE || '')
+  .split(',')
+  .map((type) => type.trim())
+  .filter(Boolean)
 // POLARIS_DOMAIN is reserved for future use when system creation is supported via this script.
 
 // ---------------------------------------------------------------------------

--- a/scripts/polaris-push.mjs
+++ b/scripts/polaris-push.mjs
@@ -16,6 +16,11 @@
  * Optional environment variables:
  *   POLARIS_REPO_URL       - Full repository URL. Defaults to https://github.com/$GITHUB_REPOSITORY
  *   POLARIS_AUTO_REGISTER  - Set to "true" to register the repo with the system before pushing
+ *   POLARIS_PROJECT_TYPE   - Comma-separated cdxgen project type(s) to scan (e.g. "js", "java", "py").
+ *                            When set, only the matching language scanner(s) run, preventing cdxgen
+ *                            from scanning unrelated artifacts such as JAR files bundled inside
+ *                            node_modules. Valid values: js, java, py, ruby, rust, go, php, dotnet.
+ *                            Omit to let cdxgen auto-detect all project types.
  */
 
 import { createBom } from '@cyclonedx/cdxgen'
@@ -55,6 +60,7 @@ const POLARIS_REPO_URL =
     ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
     : null)
 const AUTO_REGISTER = process.env.POLARIS_AUTO_REGISTER === 'true'
+const POLARIS_PROJECT_TYPE = (process.env.POLARIS_PROJECT_TYPE || '').split(',').filter(Boolean)
 // POLARIS_DOMAIN is reserved for future use when system creation is supported via this script.
 
 // ---------------------------------------------------------------------------
@@ -86,6 +92,7 @@ async function generateSbom() {
       projectName: POLARIS_SYSTEM,
       projectVersion: process.env.GITHUB_SHA?.slice(0, 7) || '0.0.0',
       multiProject: true,
+      ...(POLARIS_PROJECT_TYPE.length > 0 && { projectType: POLARIS_PROJECT_TYPE }),
     })
 
     if (!bom) return null

--- a/server/services/github-import.service.ts
+++ b/server/services/github-import.service.ts
@@ -142,6 +142,36 @@ export class GitHubImportService {
   }
 
   /**
+   * Derive cdxgen project type(s) from the set of manifest files present.
+   * Returning a non-empty array restricts cdxgen to the matching language
+   * scanners, preventing unrelated scanners (e.g. createJarBom) from running.
+   */
+  private inferProjectTypes(manifests: GitHubFileContent[]): string[] {
+    const NODE_MANIFESTS = new Set(['package.json', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml'])
+    const JAVA_MANIFESTS = new Set(['pom.xml', 'build.gradle', 'build.gradle.kts', 'gradle.lockfile'])
+    const PYTHON_MANIFESTS = new Set(['requirements.txt', 'pyproject.toml', 'Pipfile', 'Pipfile.lock', 'poetry.lock', 'setup.py', 'setup.cfg'])
+    const GO_MANIFESTS = new Set(['go.mod', 'go.sum'])
+    const RUBY_MANIFESTS = new Set(['Gemfile', 'Gemfile.lock'])
+    const RUST_MANIFESTS = new Set(['Cargo.toml', 'Cargo.lock'])
+    const PHP_MANIFESTS = new Set(['composer.json', 'composer.lock'])
+    const DOTNET_MANIFESTS = new Set(['packages.config', 'packages.lock.json'])
+
+    const types = new Set<string>()
+    for (const { path } of manifests) {
+      const filename = path.split('/').pop()!
+      if (NODE_MANIFESTS.has(filename)) types.add('js')
+      if (JAVA_MANIFESTS.has(filename)) types.add('java')
+      if (PYTHON_MANIFESTS.has(filename)) types.add('py')
+      if (GO_MANIFESTS.has(filename)) types.add('go')
+      if (RUBY_MANIFESTS.has(filename)) types.add('ruby')
+      if (RUST_MANIFESTS.has(filename)) types.add('rust')
+      if (PHP_MANIFESTS.has(filename)) types.add('php')
+      if (DOTNET_MANIFESTS.has(filename) || filename.endsWith('.csproj')) types.add('dotnet')
+    }
+    return [...types]
+  }
+
+  /**
    * Write manifest files to a temp directory and run cdxgen to generate an SBOM.
    */
   private async generateSBOM(
@@ -158,14 +188,17 @@ export class GitHubImportService {
         writeFileSync(filePath, file.content, 'utf-8')
       }
 
-      logger.info({ projectName, manifestCount: manifests.length }, 'Running cdxgen for GitHub import')
+      const projectTypes = this.inferProjectTypes(manifests)
+      logger.info({ projectName, manifestCount: manifests.length, projectTypes }, 'Running cdxgen for GitHub import')
 
-      // Run cdxgen
+      // Run cdxgen — restrict to detected project types to prevent unrelated
+      // language scanners (e.g. createJarBom) from producing spurious components.
       const bom = await createBom(tempDir, {
         installDeps: false,
         projectName,
         projectVersion: '1.0.0',
-        multiProject: true
+        multiProject: true,
+        ...(projectTypes.length > 0 && { projectType: projectTypes }),
       })
 
       if (!bom) {

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -204,7 +204,11 @@ export async function fetchManifestFiles(
   const tree = await fetchFileTree(owner, repo, branch)
 
   const manifestPaths = tree
-    .filter(entry => entry.type === 'blob' && isManifestFile(entry.path))
+    .filter(entry =>
+      entry.type === 'blob' &&
+      isManifestFile(entry.path) &&
+      !entry.path.includes('node_modules/')
+    )
     .map(entry => entry.path)
 
   if (manifestPaths.length === 0) {


### PR DESCRIPTION
## Description

When `cdxgen` is called with `multiProject: true` and no `projectType`, it runs all language scanners unconditionally — including `createJarBom`, which explicitly overrides the `node_modules` exclusion and scans `**/*.jar` across the entire project tree. For projects using `@cyclonedx/cdxgen` as a dependency, this causes the 117 JAR files bundled in `node_modules/@appthreat/atom/plugins/lib/` to appear as spurious `pkg:maven/` components in the SBOM.

This PR fixes the issue in both the CI push script and the UI GitHub import path, and adds a defensive filter against committed `node_modules/` manifests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #572

## Changes Made

- **`scripts/polaris-push.mjs`**: Read `POLARIS_PROJECT_TYPE` env var (comma-separated) and pass it to `createBom` as `projectType`. When unset, behavior is unchanged. Updated file header to document the new variable.
- **`.github/workflows/polaris-sbom.yml`**: Added `POLARIS_PROJECT_TYPE` as a commented-out optional override with an explanation of the JAR scanner issue.
- **`server/services/github-import.service.ts`**: Added `inferProjectTypes()` which maps the manifest filenames already fetched from GitHub to cdxgen type strings (`js`, `java`, `py`, `go`, `ruby`, `rust`, `php`, `dotnet`). The result is passed to `createBom` as `projectType`. Multi-ecosystem repos naturally produce multiple types, which `multiProject: true` handles correctly. If inference returns empty, `projectType` is omitted and cdxgen auto-detects — same as before.
- **`server/utils/github.ts`**: Added `!entry.path.includes('node_modules/')` to the manifest filter in `fetchManifestFiles`, preventing manifests from committed `node_modules/` directories from being fetched.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have updated documentation if needed