### PR TITLE
fix: move dependency scope from Component node to USES/DIRECT_DEP edges

### DIFF
--- a/app/pages/docs/architecture/graph-model.vue
+++ b/app/pages/docs/architecture/graph-model.vue
@@ -121,7 +121,8 @@ const keyRelationships = [
   { label: 'MAINTAINS', description: 'Team maintains Repository', detail: 'Repository maintenance responsibility' },
   { label: 'HAS_VERSION', description: 'Technology has Version', detail: 'Version tracking per technology' },
   { label: 'IS_VERSION_OF', description: 'Component is version of Technology', detail: 'Component to technology mapping' },
-  { label: 'USES', description: 'System uses Component', detail: 'System dependency on a component' },
+  { label: 'USES', description: 'System uses Component', detail: 'System dependency on a component. Carries a scope property (e.g. required, optional, dev, runtime, test) describing how this system uses the component.' },
+  { label: 'DIRECT_DEP', description: 'System directly depends on Component', detail: 'Marks components that are direct (non-transitive) dependencies of the system root. Carries the same scope property as USES.' },
   { label: 'HAS_SOURCE_IN', description: 'System has source in Repository', detail: 'Source code location' },
   { label: 'GOVERNS', description: 'VersionConstraint governs Technology', detail: 'Constraint scope' },
   { label: 'PERFORMED_BY', description: 'AuditLog performed by User', detail: 'Who made the change' },
@@ -135,6 +136,7 @@ const queryExamples = [
   { title: 'Trace component dependencies across systems' },
   { title: 'Identify compliance violations' },
   { title: 'Track all changes made by a specific user' },
+  { title: 'Find all systems that use a component at runtime vs. dev-only' },
 ]
 
 useHead({ title: 'Graph Model - Polaris' })
@@ -169,6 +171,7 @@ const diagram = `graph TB
 
     System -->|USES| Technology
     System -->|USES| Component
+
     System -->|HAS_SOURCE_IN| Repository
 
     VersionConstraint -->|GOVERNS| Technology

--- a/schema/migrations/common/20260522_080000_move_scope_to_edges.down.cypher
+++ b/schema/migrations/common/20260522_080000_move_scope_to_edges.down.cypher
@@ -1,0 +1,10 @@
+// Rollback: Restore scope on Component nodes from USES edges
+//
+// This is a best-effort rollback. Because multiple systems may use the same
+// Component with different scopes, only one scope value can be stored on the
+// node. The rollback picks an arbitrary value per component (last SET wins).
+// Data fidelity is not guaranteed after rollback.
+
+MATCH (s:System)-[r:USES]->(c:Component)
+WHERE r.scope IS NOT NULL
+SET c.scope = r.scope;

--- a/schema/migrations/common/20260522_080000_move_scope_to_edges.up.cypher
+++ b/schema/migrations/common/20260522_080000_move_scope_to_edges.up.cypher
@@ -1,0 +1,10 @@
+// Migration: Remove stale scope property from Component nodes
+//
+// scope describes how a specific system uses a component, not what the
+// component intrinsically is. It now lives on the USES and DIRECT_DEP edges.
+// Any scope values stored on Component nodes are unreliable (last-write-wins
+// across systems) and must be removed.
+
+MATCH (c:Component)
+WHERE c.scope IS NOT NULL
+REMOVE c.scope;

--- a/server/database/queries/sboms/persist-components-core.cypher
+++ b/server/database/queries/sboms/persist-components-core.cypher
@@ -32,7 +32,6 @@ FOREACH (_ IN CASE WHEN comp.cpe IS NOT NULL THEN [1] ELSE [] END | SET c.cpe = 
 FOREACH (_ IN CASE WHEN comp.bomRef IS NOT NULL THEN [1] ELSE [] END | SET c.bomRef = comp.bomRef)
 FOREACH (_ IN CASE WHEN comp.type IS NOT NULL THEN [1] ELSE [] END | SET c.type = comp.type)
 FOREACH (_ IN CASE WHEN comp.group IS NOT NULL THEN [1] ELSE [] END | SET c.group = comp.group)
-FOREACH (_ IN CASE WHEN comp.scope IS NOT NULL THEN [1] ELSE [] END | SET c.scope = comp.scope)
 FOREACH (_ IN CASE WHEN comp.copyright IS NOT NULL THEN [1] ELSE [] END | SET c.copyright = comp.copyright)
 FOREACH (_ IN CASE WHEN comp.supplier IS NOT NULL THEN [1] ELSE [] END | SET c.supplier = comp.supplier)
 FOREACH (_ IN CASE WHEN comp.author IS NOT NULL THEN [1] ELSE [] END | SET c.author = comp.author)
@@ -40,9 +39,11 @@ FOREACH (_ IN CASE WHEN comp.publisher IS NOT NULL THEN [1] ELSE [] END | SET c.
 FOREACH (_ IN CASE WHEN comp.homepage IS NOT NULL THEN [1] ELSE [] END | SET c.homepage = comp.homepage)
 FOREACH (_ IN CASE WHEN comp.description IS NOT NULL THEN [1] ELSE [] END | SET c.description = comp.description)
 
+// scope belongs on the edge, not the node — it describes how this system uses
+// the component, not what the component intrinsically is.
 MERGE (s)-[r:USES]->(c)
-ON CREATE SET r.addedAt = $timestamp, r._new = true
-ON MATCH SET r.lastSeenAt = $timestamp, r._new = false
+ON CREATE SET r.addedAt = $timestamp, r.scope = comp.scope, r._new = true
+ON MATCH SET r.lastSeenAt = $timestamp, r.scope = comp.scope, r._new = false
 
 WITH isNew, r, r._new AS relIsNew
 REMOVE r._new

--- a/server/database/queries/sboms/persist-direct-deps.cypher
+++ b/server/database/queries/sboms/persist-direct-deps.cypher
@@ -1,12 +1,12 @@
 // Create (System)-[:DIRECT_DEP]->(Component) edges for each component
 // that the root component directly depends on.
-// $rootBomRef: bomRef of the root component (metadata.component)
 // $systemName: name of the system
 // $timestamp: ISO timestamp
+// $directDeps: array of { bomRef: string, scope: string | null }
 MATCH (sys:System {name: $systemName})
-UNWIND $directBomRefs AS targetRef
-MATCH (tgt:Component {bomRef: targetRef})
+UNWIND $directDeps AS dep
+MATCH (tgt:Component {bomRef: dep.bomRef})
 MERGE (sys)-[r:DIRECT_DEP]->(tgt)
-ON CREATE SET r.addedAt = $timestamp
-ON MATCH SET r.lastSeenAt = $timestamp
+ON CREATE SET r.addedAt = $timestamp, r.scope = dep.scope
+ON MATCH SET r.lastSeenAt = $timestamp, r.scope = dep.scope
 RETURN count(r) AS edgesCreated

--- a/server/repositories/sbom.repository.ts
+++ b/server/repositories/sbom.repository.ts
@@ -1,5 +1,5 @@
 import { BaseRepository } from './base.repository'
-import type { PersistSBOMParams, PersistSBOMResult, ComponentDependency } from '../types/sbom'
+import type { PersistSBOMParams, PersistSBOMResult, ComponentDependency, DirectDep } from '../types/sbom'
 
 /**
  * Repository for SBOM-related data access
@@ -24,7 +24,8 @@ export class SBOMRepository extends BaseRepository {
     const relationsQuery = await loadQuery('sboms/persist-components-relations.cypher')
     const timestamp = params.timestamp.toISOString()
 
-    // Scalar fields only — sent in phase 1 (large batches, cheap)
+    // Scalar fields only — sent in phase 1 (large batches, cheap).
+    // scope is intentionally excluded: it belongs on the USES edge, not the node.
     const coreComponents = params.components.map((comp) => ({
       name: comp.name,
       version: comp.version,
@@ -34,7 +35,7 @@ export class SBOMRepository extends BaseRepository {
       bomRef: comp.bomRef,
       type: comp.type,
       group: comp.group,
-      scope: comp.scope,
+      scope: comp.scope, // passed through so the USES edge can be set in the same query
       copyright: comp.copyright,
       supplier: comp.supplier,
       author: comp.author,
@@ -91,22 +92,23 @@ export class SBOMRepository extends BaseRepository {
       await this.persistDirectDeps(params.systemName, params.directDeps, params.timestamp)
     }
 
+
     return { componentsAdded, componentsUpdated, relationshipsCreated }
   }
 
   /**
-   * Create DEPENDS_ON edges between Component nodes.
+   * Create (System)-[:DIRECT_DEP]->(Component) edges.
    *
    * Matches components by bomRef. Refs that don't resolve to a known
    * Component node are silently skipped by the Cypher query.
    */
-  private async persistDirectDeps(systemName: string, directBomRefs: string[], timestamp: Date): Promise<void> {
-    if (directBomRefs.length === 0) return
+  private async persistDirectDeps(systemName: string, directDeps: DirectDep[], timestamp: Date): Promise<void> {
+    if (directDeps.length === 0) return
     const query = await loadQuery('sboms/persist-direct-deps.cypher')
     const ts = timestamp.toISOString()
-    for (let i = 0; i < directBomRefs.length; i += SBOMRepository.BATCH_SIZE) {
-      const batch = directBomRefs.slice(i, i + SBOMRepository.BATCH_SIZE)
-      await this.executeQuery(query, { systemName, directBomRefs: batch, timestamp: ts })
+    for (let i = 0; i < directDeps.length; i += SBOMRepository.BATCH_SIZE) {
+      const batch = directDeps.slice(i, i + SBOMRepository.BATCH_SIZE)
+      await this.executeQuery(query, { systemName, directDeps: batch, timestamp: ts })
     }
   }
 

--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -10,7 +10,8 @@ import type {
   ComponentDependency,
   ComponentHash,
   ComponentLicense,
-  ExternalReference
+  ExternalReference,
+  DirectDep,
 } from '../types/sbom'
 
 // SPDX relationship types that represent a dependency edge.
@@ -23,6 +24,17 @@ const SPDX_DEPENDENCY_TYPES = new Set([
   'RUNTIME_DEPENDENCY_OF',
   'TEST_DEPENDENCY_OF',
 ])
+
+// Maps SPDX relationship types to the scope value stored on the edge.
+// Relationship types not present here (e.g. DYNAMIC_LINK, STATIC_LINK) yield null.
+const SPDX_SCOPE_MAP: Record<string, string> = {
+  DEV_DEPENDENCY_OF: 'dev',
+  OPTIONAL_DEPENDENCY_OF: 'optional',
+  PROVIDED_DEPENDENCY_OF: 'provided',
+  RUNTIME_DEPENDENCY_OF: 'runtime',
+  TEST_DEPENDENCY_OF: 'test',
+  DEPENDS_ON: 'required',
+}
 
 /**
  * Service for SBOM processing and persistence
@@ -90,10 +102,19 @@ export class SBOMService {
     const components = this.extractComponents(sbomData, input.format)
     const dependencies = this.extractDependencies(sbomData, input.format)
     const { bomRef: rootBomRef, name: rootName } = this.extractRootBomRef(sbomData, input.format)
+
+    // Build a bomRef → scope map so resolveDirectDeps can attach scope to each
+    // direct dep without re-scanning the components or relationships arrays.
+    // CycloneDX: scope comes from ExtractedComponent.scope (set per component).
+    // SPDX: scope is derived from the relationship type (e.g. DEV_DEPENDENCY_OF → 'dev').
+    const scopeMap = input.format === 'cyclonedx'
+      ? this.buildCycloneDXScopeMap(components)
+      : this.buildSPDXScopeMap(sbomData)
+
     // Resolve direct deps here so the repository doesn't need to re-scan dependencies.
     // Uses a fallback for SBOMs where the root bom-ref type differs between
     // metadata.component and the dependencies[] entry (e.g. cdxgen without node_modules).
-    const directDeps = this.resolveDirectDeps(rootBomRef, rootName, dependencies)
+    const directDeps = this.resolveDirectDeps(rootBomRef, rootName, dependencies, scopeMap)
 
     // 5. Persist to database
     const result = await this.sbomRepo.persistSBOM({
@@ -174,7 +195,7 @@ export class SBOMService {
   }
 
   /**
-   * Resolve the direct dependency bomRefs for the root component.
+   * Resolve the direct dependency bomRefs for the root component, with scope.
    *
    * cdxgen sometimes uses different purl types for the root component in
    * `metadata.component` vs `dependencies[]`. For example, when run without
@@ -186,15 +207,23 @@ export class SBOMService {
    * 1. Exact match on `rootBomRef` — use it if `dependsOn` is non-empty.
    * 2. Fallback: find the dependency entry whose purl name segment matches
    *    `rootName` and has the most `dependsOn` entries.
+   *
+   * @param scopeMap - bomRef → scope, used to attach scope to each direct dep.
+   *   For CycloneDX this is built from ExtractedComponent.scope.
+   *   For SPDX this is built from relationship types.
    */
   private resolveDirectDeps(
     rootBomRef: string | null,
     rootName: string | null,
-    dependencies: ComponentDependency[]
-  ): string[] {
+    dependencies: ComponentDependency[],
+    scopeMap: Map<string, string | null>,
+  ): DirectDep[] {
+    const toBomRefs = (refs: string[]): DirectDep[] =>
+      refs.map(bomRef => ({ bomRef, scope: scopeMap.get(bomRef) ?? null }))
+
     if (rootBomRef) {
       const exact = dependencies.find(d => d.ref === rootBomRef)
-      if (exact && exact.dependsOn.length > 0) return exact.dependsOn
+      if (exact && exact.dependsOn.length > 0) return toBomRefs(exact.dependsOn)
     }
 
     if (!rootName) return []
@@ -209,7 +238,7 @@ export class SBOMService {
       .filter(d => nameFromRef(d.ref) === rootName && d.dependsOn.length > 0)
       .sort((a, b) => b.dependsOn.length - a.dependsOn.length)
 
-    return candidates[0]?.dependsOn ?? []
+    return toBomRefs(candidates[0]?.dependsOn ?? [])
   }
 
   /**
@@ -310,14 +339,21 @@ export class SBOMService {
   }
 
   /**
-   * Extract components from SPDX SBOM
+   * Extract components from SPDX SBOM.
+   *
+   * Builds a scope map from relationships before mapping packages so that
+   * each package can receive the correct scope derived from its relationship type.
    */
   private extractSPDXComponents(sbom: Record<string, unknown>): ExtractedComponent[] {
     const packages = sbom.packages as unknown[] | undefined
     if (!packages || !Array.isArray(packages)) {
       return []
     }
-    return packages.map((pkg) => this.mapSPDXPackage(pkg as Record<string, unknown>))
+    // Build SPDXID → scope from relationships so mapSPDXPackage can set scope.
+    // A package may appear as the target of multiple relationship types; the
+    // first recognised type wins (relationships are typically ordered root-first).
+    const scopeMap = this.buildSPDXScopeMap(sbom)
+    return packages.map((pkg) => this.mapSPDXPackage(pkg as Record<string, unknown>, scopeMap))
   }
 
   /**
@@ -349,21 +385,25 @@ export class SBOMService {
   }
 
   /**
-   * Map SPDX package to ExtractedComponent
+   * Map SPDX package to ExtractedComponent.
+   *
+   * @param scopeMap - SPDXID → scope derived from relationship types. Packages
+   *   not present in the map (e.g. the document root) receive scope: null.
    */
-  private mapSPDXPackage(pkg: Record<string, unknown>): ExtractedComponent {
+  private mapSPDXPackage(pkg: Record<string, unknown>, scopeMap: Map<string, string | null>): ExtractedComponent {
     const purl = this.normalizePurl(this.extractPurlFromExternalRefs((pkg.externalRefs as unknown[]) || []))
-    
+    const spdxId = pkg.SPDXID as string
+
     return {
       name: pkg.name as string,
       version: (pkg.versionInfo as string)?.trim() || null,
       packageManager: this.extractPackageManager(purl),
       purl: purl,
       cpe: this.extractCpeFromExternalRefs((pkg.externalRefs as unknown[]) || []),
-      bomRef: pkg.SPDXID as string,
+      bomRef: spdxId,
       type: this.mapSPDXPurpose(pkg.primaryPackagePurpose as string | undefined),
       group: this.extractGroupFromPurl(purl),
-      scope: null,
+      scope: scopeMap.get(spdxId) ?? null,
       hashes: this.extractSPDXHashes((pkg.checksums as unknown[]) || []),
       licenses: this.extractSPDXLicenses(pkg),
       copyright: (pkg.copyrightText as string)?.trim() || null,
@@ -374,6 +414,49 @@ export class SBOMService {
       description: (pkg.description as string)?.trim() || null,
       externalReferences: this.extractSPDXReferences((pkg.externalRefs as unknown[]) || [])
     }
+  }
+
+  /**
+   * Build a bomRef → scope map from CycloneDX ExtractedComponents.
+   *
+   * CycloneDX encodes scope directly on the component object, so we just
+   * index by bomRef. Components without a bomRef are skipped.
+   */
+  private buildCycloneDXScopeMap(components: ExtractedComponent[]): Map<string, string | null> {
+    const map = new Map<string, string | null>()
+    for (const comp of components) {
+      if (comp.bomRef) {
+        map.set(comp.bomRef, comp.scope)
+      }
+    }
+    return map
+  }
+
+  /**
+   * Build a SPDXID → scope map from SPDX relationships.
+   *
+   * SPDX encodes scope in the relationship type rather than on the package.
+   * This method scans `relationships[]` and maps each target SPDXID to the
+   * scope derived from the first recognised relationship type that points to it.
+   * Relationship types not in SPDX_SCOPE_MAP yield null.
+   */
+  private buildSPDXScopeMap(sbom: Record<string, unknown>): Map<string, string | null> {
+    const map = new Map<string, string | null>()
+    const relationships = sbom.relationships as unknown[] | undefined
+    if (!Array.isArray(relationships)) return map
+
+    for (const rel of relationships) {
+      const r = rel as Record<string, unknown>
+      const type = r.relationshipType as string | undefined
+      if (!type || !SPDX_DEPENDENCY_TYPES.has(type)) continue
+      const tgt = (r.relatedSpdxElement as string)?.trim()
+      if (!tgt) continue
+      // First relationship type wins; don't overwrite an already-resolved scope.
+      if (!map.has(tgt)) {
+        map.set(tgt, SPDX_SCOPE_MAP[type] ?? null)
+      }
+    }
+    return map
   }
 
   /**

--- a/server/types/sbom.ts
+++ b/server/types/sbom.ts
@@ -66,13 +66,19 @@ export interface ComponentDependency {
   dependsOn: string[]
 }
 
+export interface DirectDep {
+  bomRef: string
+  /** Dependency scope (e.g. 'required', 'optional', 'dev', 'runtime', 'test'). Null when unknown. */
+  scope: string | null
+}
+
 export interface PersistSBOMParams {
   systemName: string
   repositoryUrl: string
   components: ExtractedComponent[]
   dependencies: ComponentDependency[]
-  /** bomRefs of components that are direct dependencies of the system root */
-  directDeps: string[]
+  /** Direct dependencies of the system root, with per-edge scope. */
+  directDeps: DirectDep[]
   format: 'cyclonedx' | 'spdx'
   timestamp: Date
 }

--- a/test/server/repositories/sbom.repository.spec.ts
+++ b/test/server/repositories/sbom.repository.spec.ts
@@ -93,7 +93,7 @@ describe('SBOMRepository', () => {
           { ref: refA, dependsOn: [refB] },
           { ref: refB, dependsOn: [] },
         ],
-        directDeps: [refA, refB],
+        directDeps: [{ bomRef: refA, scope: 'required' }, { bomRef: refB, scope: null }],
         components: [
           {
             name: `${PREFIX}direct-comp-a`, version: '1.0.0',

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -358,8 +358,9 @@ describe('SBOMService', () => {
         ref: 'pkg:npm/test-app@1.0.0',
         dependsOn: ['pkg:npm/lodash@4.17.21'],
       })
-      // directDeps is resolved from the root's dependsOn list in the service layer
-      expect(persistCall.directDeps).toEqual(['pkg:npm/lodash@4.17.21'])
+      // directDeps is resolved from the root's dependsOn list in the service layer.
+      // CycloneDX: scope comes from the component's scope field (null here since not set).
+      expect(persistCall.directDeps).toEqual([{ bomRef: 'pkg:npm/lodash@4.17.21', scope: null }])
     })
 
     it('should extract SPDX dependency relationships and pass them to persistSBOM', async () => {
@@ -452,7 +453,10 @@ describe('SBOMService', () => {
       })
 
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
-      expect(persistCall.directDeps).toEqual(['pkg:npm/lodash@4.17.21', 'pkg:npm/express@4.18.2'])
+      expect(persistCall.directDeps).toEqual([
+        { bomRef: 'pkg:npm/lodash@4.17.21', scope: null },
+        { bomRef: 'pkg:npm/express@4.18.2', scope: null },
+      ])
     })
 
     it('should use exact match directDeps when root bom-ref matches a non-empty dependsOn entry', async () => {
@@ -484,7 +488,7 @@ describe('SBOMService', () => {
       })
 
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
-      expect(persistCall.directDeps).toEqual(['pkg:npm/lodash@4.17.21'])
+      expect(persistCall.directDeps).toEqual([{ bomRef: 'pkg:npm/lodash@4.17.21', scope: null }])
     })
 
     it('should return empty directDeps when no dependency entry matches the root name', async () => {


### PR DESCRIPTION
## Description

`scope` (runtime vs dev vs optional etc.) was stored on the **Component node** rather than on the edges connecting a System to a Component. This is semantically incorrect: scope describes *how a specific system uses a component*, not what the component intrinsically is.

When `lodash` is a `devDependency` in System A but a `required` dependency in System B, the last SBOM to run overwrites the shared node — the data is wrong for at least one system at all times. It also makes queries like "which systems use this component at runtime?" impossible.

This PR moves scope to the `USES` and `DIRECT_DEP` edges where it belongs, and derives SPDX scope from relationship types instead of hardcoding `null`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Schema update (changes to database schemas)
- [x] Documentation update

## Related Issues

Fixes #577

## Changes Made

- `server/types/sbom.ts` — Added `DirectDep { bomRef, scope }` interface; `PersistSBOMParams.directDeps` changed from `string[]` to `DirectDep[]`
- `server/services/sbom.service.ts` — Added `SPDX_SCOPE_MAP` to derive scope from SPDX relationship types; added `buildCycloneDXScopeMap` and `buildSPDXScopeMap` helpers; `resolveDirectDeps` now returns `DirectDep[]`; `mapSPDXPackage` sets scope from the map instead of hardcoding `null`
- `server/database/queries/sboms/persist-components-core.cypher` — Removed `FOREACH` that wrote `c.scope` to the node; added `r.scope = comp.scope` to the `USES` edge
- `server/database/queries/sboms/persist-direct-deps.cypher` — Rewrote to accept `{ bomRef, scope }` objects and set `r.scope` on the `DIRECT_DEP` edge
- `server/repositories/sbom.repository.ts` — Updated `persistDirectDeps` to accept `DirectDep[]` and pass `directDeps` parameter to the query
- `schema/migrations/common/20260522_080000_move_scope_to_edges` — Migration removes stale `c.scope` from existing Component nodes; down migration restores best-effort from USES edges (lossy by design, documented)
- `app/pages/docs/architecture/graph-model.vue` — Added `DIRECT_DEP` relationship, documented `scope` edge property on `USES` and `DIRECT_DEP`, added `DIRECT_DEP` to Mermaid diagram

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

**SPDX scope derivation:** A package may be the target of multiple relationship types. The implementation takes the first recognised type (by relationship array order), consistent with how `extractSPDXDependencies` already works.

**Down migration is lossy:** Rolling back cannot restore per-system scope fidelity since only one value can be stored on a node. This is documented in the migration file.
