### PR TITLE
feat(sbom): model runtime/dev/transitive dependency classification on USES edge

### DIFF
--- a/app/pages/docs/architecture/graph-model.vue
+++ b/app/pages/docs/architecture/graph-model.vue
@@ -121,8 +121,7 @@ const keyRelationships = [
   { label: 'MAINTAINS', description: 'Team maintains Repository', detail: 'Repository maintenance responsibility' },
   { label: 'HAS_VERSION', description: 'Technology has Version', detail: 'Version tracking per technology' },
   { label: 'IS_VERSION_OF', description: 'Component is version of Technology', detail: 'Component to technology mapping' },
-  { label: 'USES', description: 'System uses Component', detail: 'System dependency on a component. Carries a scope property (e.g. required, optional, dev, runtime, test) describing how this system uses the component.' },
-  { label: 'DIRECT_DEP', description: 'System directly depends on Component', detail: 'Marks components that are direct (non-transitive) dependencies of the system root. Carries the same scope property as USES.' },
+  { label: 'USES', description: 'System uses Component', detail: 'System dependency on a component. Carries scope (runtime, required, dev, optional, excluded, or null) and isDirect (true for root-level deps, false for transitive). Scope and isDirect are computed by BFS propagation at ingest time.' },
   { label: 'HAS_SOURCE_IN', description: 'System has source in Repository', detail: 'Source code location' },
   { label: 'GOVERNS', description: 'VersionConstraint governs Technology', detail: 'Constraint scope' },
   { label: 'PERFORMED_BY', description: 'AuditLog performed by User', detail: 'Who made the change' },
@@ -136,6 +135,7 @@ const queryExamples = [
   { title: 'Trace component dependencies across systems' },
   { title: 'Identify compliance violations' },
   { title: 'Track all changes made by a specific user' },
+  { title: 'Find all direct runtime dependencies of a system' },
   { title: 'Find all systems that use a component at runtime vs. dev-only' },
 ]
 

--- a/schema/migrations/common/20260522_120000_add_isdirect_to_uses_drop_direct_dep.down.cypher
+++ b/schema/migrations/common/20260522_120000_add_isdirect_to_uses_drop_direct_dep.down.cypher
@@ -1,0 +1,18 @@
+// Rollback: Restore DIRECT_DEP edges from USES {isDirect: true} and drop indexes
+//
+// This is a best-effort rollback. scope on the restored DIRECT_DEP edges is
+// copied from the USES edge; it may differ from the original if re-ingestion
+// has occurred since the up migration ran.
+
+// Step 1: Drop the relationship indexes added by the up migration.
+DROP INDEX uses_scope IF EXISTS;
+DROP INDEX uses_is_direct IF EXISTS;
+
+// Step 2: Recreate DIRECT_DEP edges from USES edges where isDirect=true.
+MATCH (s:System)-[u:USES {isDirect: true}]->(c:Component)
+MERGE (s)-[r:DIRECT_DEP]->(c)
+ON CREATE SET r.addedAt = u.addedAt, r.scope = u.scope;
+
+// Step 3: Remove isDirect from all USES edges.
+MATCH ()-[r:USES]->()
+REMOVE r.isDirect;

--- a/schema/migrations/common/20260522_120000_add_isdirect_to_uses_drop_direct_dep.up.cypher
+++ b/schema/migrations/common/20260522_120000_add_isdirect_to_uses_drop_direct_dep.up.cypher
@@ -1,0 +1,20 @@
+// Migration: Add isDirect to USES edges and drop the DIRECT_DEP relationship type
+//
+// isDirect=true on a USES edge replaces the separate DIRECT_DEP relationship.
+// This collapses two relationship types into one, enabling queries like:
+//   MATCH (s:System)-[:USES {isDirect: true, scope: 'runtime'}]->(c) RETURN c
+//
+// Step 1: For existing USES edges that have a corresponding DIRECT_DEP edge,
+//         set isDirect=true. All other USES edges get isDirect=false.
+MATCH (s:System)-[u:USES]->(c:Component)
+WITH s, u, c,
+     EXISTS { MATCH (s)-[:DIRECT_DEP]->(c) } AS hasDirect
+SET u.isDirect = hasDirect;
+
+// Step 2: Drop all DIRECT_DEP relationships — isDirect on USES supersedes them.
+MATCH ()-[r:DIRECT_DEP]->()
+DELETE r;
+
+// Step 3: Add indexes on USES.scope and USES.isDirect for efficient filtering.
+CREATE INDEX uses_scope IF NOT EXISTS FOR ()-[r:USES]-() ON (r.scope);
+CREATE INDEX uses_is_direct IF NOT EXISTS FOR ()-[r:USES]-() ON (r.isDirect);

--- a/server/database/queries/sboms/persist-components-core.cypher
+++ b/server/database/queries/sboms/persist-components-core.cypher
@@ -39,11 +39,13 @@ FOREACH (_ IN CASE WHEN comp.publisher IS NOT NULL THEN [1] ELSE [] END | SET c.
 FOREACH (_ IN CASE WHEN comp.homepage IS NOT NULL THEN [1] ELSE [] END | SET c.homepage = comp.homepage)
 FOREACH (_ IN CASE WHEN comp.description IS NOT NULL THEN [1] ELSE [] END | SET c.description = comp.description)
 
-// scope belongs on the edge, not the node — it describes how this system uses
-// the component, not what the component intrinsically is.
+// scope and isDirect belong on the edge, not the node — they describe how this
+// system uses the component, not what the component intrinsically is.
+// comp.scope and comp.isDirect are pre-computed by the BFS propagation pass
+// in the service layer and passed in alongside the component scalar fields.
 MERGE (s)-[r:USES]->(c)
-ON CREATE SET r.addedAt = $timestamp, r.scope = comp.scope, r._new = true
-ON MATCH SET r.lastSeenAt = $timestamp, r.scope = comp.scope
+ON CREATE SET r.addedAt = $timestamp, r.scope = comp.scope, r.isDirect = comp.isDirect, r._new = true
+ON MATCH SET r.lastSeenAt = $timestamp, r.scope = comp.scope, r.isDirect = comp.isDirect
 
 WITH isNew, r, (r._new IS NOT NULL) AS relIsNew
 REMOVE r._new

--- a/server/database/queries/systems/graph.cypher
+++ b/server/database/queries/systems/graph.cypher
@@ -3,20 +3,20 @@
 // allowing the caller to distinguish not-found from empty without a separate
 // exists() query.
 MATCH (sys:System {name: $name})
-OPTIONAL MATCH (sys)-[:USES]->(c:Component)
+OPTIONAL MATCH (sys)-[u:USES]->(c:Component)
 OPTIONAL MATCH (c)-[:IS_VERSION_OF]->(tech:Technology)
 OPTIONAL MATCH (c)-[:HAS_LICENSE]->(l:License)
-WITH sys, c, tech,
+WITH sys, c, u, tech,
      collect(DISTINCT {id: l.id, name: l.name, allowed: l.allowed}) AS licenses
-// direct=true when the system has a DIRECT_DEP edge to this component
-// (set at ingest time from the root component's dependsOn list)
-WITH sys, c, tech, licenses,
-     EXISTS { (sys)-[:DIRECT_DEP]->(c) } AS direct
+// isDirect and scope come from the USES edge, set at ingest time by BFS propagation.
+WITH sys, c, u, tech, licenses,
+     coalesce(u.isDirect, false) AS direct,
+     u.scope AS scope
 // Collect purls of c's direct dependencies that are also used by this system.
 // Filter null purls at match time to avoid collecting them into the list.
 OPTIONAL MATCH (c)-[:DEPENDS_ON]->(dep:Component)<-[:USES]-(sys)
 WHERE dep.purl IS NOT NULL
-WITH sys, c, tech, licenses, direct,
+WITH sys, c, tech, licenses, direct, scope,
      collect(DISTINCT dep.purl) AS dependsOnPurls
 RETURN sys.name AS systemName,
        c.name AS name,
@@ -26,7 +26,7 @@ RETURN sys.name AS systemName,
        c.cpe AS cpe,
        c.type AS type,
        c.group AS `group`,
-       c.scope AS scope,
+       scope,
        c.description AS description,
        [lic IN licenses WHERE lic.id IS NOT NULL OR lic.name IS NOT NULL | lic] AS licenses,
        tech.name AS technologyName,

--- a/server/repositories/sbom.repository.ts
+++ b/server/repositories/sbom.repository.ts
@@ -1,5 +1,5 @@
 import { BaseRepository } from './base.repository'
-import type { PersistSBOMParams, PersistSBOMResult, ComponentDependency, DirectDep } from '../types/sbom'
+import type { PersistSBOMParams, PersistSBOMResult, ComponentDependency } from '../types/sbom'
 
 /**
  * Repository for SBOM-related data access
@@ -27,24 +27,30 @@ export class SBOMRepository extends BaseRepository {
     const timestamp = params.timestamp.toISOString()
 
     // Scalar fields only — sent in phase 1 (large batches, cheap).
-    // scope is passed through so the USES edge can be set in the same query.
-    const coreComponents = params.components.map((comp) => ({
-      name: comp.name,
-      version: comp.version,
-      packageManager: comp.packageManager,
-      purl: comp.purl,
-      cpe: comp.cpe,
-      bomRef: comp.bomRef,
-      type: comp.type,
-      group: comp.group,
-      scope: comp.scope,
-      copyright: comp.copyright,
-      supplier: comp.supplier,
-      author: comp.author,
-      publisher: comp.publisher,
-      homepage: comp.homepage,
-      description: comp.description,
-    }))
+    // scope and isDirect come from the BFS-computed componentUsage map rather
+    // than directly from the component object — they are edge properties that
+    // describe how this system uses the component, not intrinsic component data.
+    const coreComponents = params.components.map((comp) => {
+      const usage = comp.bomRef ? params.componentUsage.get(comp.bomRef) : undefined
+      return {
+        name: comp.name,
+        version: comp.version,
+        packageManager: comp.packageManager,
+        purl: comp.purl,
+        cpe: comp.cpe,
+        bomRef: comp.bomRef,
+        type: comp.type,
+        group: comp.group,
+        scope: usage?.scope ?? null,
+        isDirect: usage?.isDirect ?? false,
+        copyright: comp.copyright,
+        supplier: comp.supplier,
+        author: comp.author,
+        publisher: comp.publisher,
+        homepage: comp.homepage,
+        description: comp.description,
+      }
+    })
 
     // Relation fields — sent in phase 2 (small batches, three separate transactions).
     // license text is intentionally omitted: it is only stored on first creation
@@ -92,30 +98,12 @@ export class SBOMRepository extends BaseRepository {
       await this.persistDependencies(params.dependencies, params.timestamp)
     }
 
-    // Persist (System)-[:DIRECT_DEP]->(Component) edges
-    if (params.directDeps.length > 0) {
-      await this.persistDirectDeps(params.systemName, params.directDeps, params.timestamp)
-    }
 
 
     return { componentsAdded, componentsUpdated, relationshipsCreated }
   }
 
-  /**
-   * Create (System)-[:DIRECT_DEP]->(Component) edges.
-   *
-   * Matches components by bomRef. Refs that don't resolve to a known
-   * Component node are silently skipped by the Cypher query.
-   */
-  private async persistDirectDeps(systemName: string, directDeps: DirectDep[], timestamp: Date): Promise<void> {
-    if (directDeps.length === 0) return
-    const query = await loadQuery('sboms/persist-direct-deps.cypher')
-    const ts = timestamp.toISOString()
-    for (let i = 0; i < directDeps.length; i += SBOMRepository.BATCH_SIZE) {
-      const batch = directDeps.slice(i, i + SBOMRepository.BATCH_SIZE)
-      await this.executeQuery(query, { systemName, directDeps: batch, timestamp: ts })
-    }
-  }
+
 
   private async persistDependencies(dependencies: ComponentDependency[], timestamp: Date): Promise<void> {
     if (dependencies.length === 0) return

--- a/server/repositories/system.repository.ts
+++ b/server/repositories/system.repository.ts
@@ -39,7 +39,7 @@ export interface GraphComponentRow {
   description: string | null
   licenses: Array<{ id?: string; name?: string; allowed?: boolean }>
   technologyName: string | null
-  /** True when this component is a direct dependency (has a DEPENDS_ON edge from another system component) */
+  /** True when this component is a direct dependency of the system root (USES {isDirect: true}) */
   direct: boolean
   /** PURLs of components this component directly depends on (within the same system) */
   dependsOnPurls: string[]

--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -11,7 +11,8 @@ import type {
   ComponentHash,
   ComponentLicense,
   ExternalReference,
-  DirectDep,
+  ScopedEdge,
+  ComponentUsage,
 } from '../types/sbom'
 
 // SPDX relationship types that represent a dependency edge.
@@ -25,15 +26,25 @@ const SPDX_DEPENDENCY_TYPES = new Set([
   'TEST_DEPENDENCY_OF',
 ])
 
-// Maps SPDX relationship types to the scope value stored on the edge.
+// Maps SPDX relationship types to the scope value stored on the USES edge.
 // Relationship types not present here (e.g. DYNAMIC_LINK, STATIC_LINK) yield null.
 const SPDX_SCOPE_MAP: Record<string, string> = {
   DEV_DEPENDENCY_OF: 'dev',
   OPTIONAL_DEPENDENCY_OF: 'optional',
   PROVIDED_DEPENDENCY_OF: 'provided',
   RUNTIME_DEPENDENCY_OF: 'runtime',
-  TEST_DEPENDENCY_OF: 'test',
+  TEST_DEPENDENCY_OF: 'dev',   // test deps are treated as dev for scope propagation
   DEPENDS_ON: 'required',
+}
+
+// Scope priority for BFS propagation: when a component is reachable via
+// multiple paths with different scopes, the highest-priority scope wins.
+// runtime/required > optional > dev > null
+const SCOPE_PRIORITY: Record<string, number> = {
+  runtime: 3,
+  required: 3,
+  optional: 2,
+  dev: 1,
 }
 
 /**
@@ -100,21 +111,27 @@ export class SBOMService {
     // 4. Extract components and dependency relationships from SBOM
     const sbomData = input.sbom as Record<string, unknown>
     const components = this.extractComponents(sbomData, input.format)
-    const dependencies = this.extractDependencies(sbomData, input.format)
     const { bomRef: rootBomRef, name: rootName } = this.extractRootBomRef(sbomData, input.format)
 
-    // Build a bomRef → scope map so resolveDirectDeps can attach scope to each
-    // direct dep without re-scanning the components or relationships arrays.
-    // CycloneDX: scope comes from ExtractedComponent.scope (set per component).
-    // SPDX: scope is derived from the relationship type (e.g. DEV_DEPENDENCY_OF → 'dev').
-    const scopeMap = input.format === 'cyclonedx'
-      ? this.buildCycloneDXScopeMap(components)
-      : this.buildSPDXScopeMap(sbomData)
+    // For SPDX, extract scoped edges (carry per-edge scope from relationship type).
+    // For CycloneDX, extract plain dependency edges (scope comes from component field).
+    const scopedEdges = input.format === 'spdx'
+      ? this.extractSPDXScopedEdges(sbomData)
+      : null
 
-    // Resolve direct deps here so the repository doesn't need to re-scan dependencies.
-    // Uses a fallback for SBOMs where the root bom-ref type differs between
-    // metadata.component and the dependencies[] entry (e.g. cdxgen without node_modules).
-    const directDeps = this.resolveDirectDeps(rootBomRef, rootName, dependencies, scopeMap)
+    // Build plain ComponentDependency[] for DEPENDS_ON edge persistence (unchanged).
+    const dependencies = input.format === 'cyclonedx'
+      ? this.extractCycloneDXDependencies(sbomData)
+      : this.scopedEdgesToDependencies(scopedEdges!)
+
+    // BFS scope propagation: compute {scope, isDirect} for every component.
+    const componentUsage = this.propagateScope(
+      rootBomRef,
+      rootName,
+      components,
+      dependencies,
+      input.format === 'spdx' ? scopedEdges! : null,
+    )
 
     // 5. Persist to database
     const result = await this.sbomRepo.persistSBOM({
@@ -122,7 +139,7 @@ export class SBOMService {
       repositoryUrl: normalizedUrl,
       components,
       dependencies,
-      directDeps,
+      componentUsage,
       format: input.format,
       timestamp: new Date()
     })
@@ -195,7 +212,7 @@ export class SBOMService {
   }
 
   /**
-   * Resolve the direct dependency bomRefs for the root component, with scope.
+   * Resolve the bomRefs of the root component's direct dependencies.
    *
    * cdxgen sometimes uses different purl types for the root component in
    * `metadata.component` vs `dependencies[]`. For example, when run without
@@ -207,23 +224,15 @@ export class SBOMService {
    * 1. Exact match on `rootBomRef` — use it if `dependsOn` is non-empty.
    * 2. Fallback: find the dependency entry whose purl name segment matches
    *    `rootName` and has the most `dependsOn` entries.
-   *
-   * @param scopeMap - bomRef → scope, used to attach scope to each direct dep.
-   *   For CycloneDX this is built from ExtractedComponent.scope.
-   *   For SPDX this is built from relationship types.
    */
-  private resolveDirectDeps(
+  private resolveRootDirectDeps(
     rootBomRef: string | null,
     rootName: string | null,
     dependencies: ComponentDependency[],
-    scopeMap: Map<string, string | null>,
-  ): DirectDep[] {
-    const toBomRefs = (refs: string[]): DirectDep[] =>
-      refs.map(bomRef => ({ bomRef, scope: scopeMap.get(bomRef) ?? null }))
-
+  ): string[] {
     if (rootBomRef) {
       const exact = dependencies.find(d => d.ref === rootBomRef)
-      if (exact && exact.dependsOn.length > 0) return toBomRefs(exact.dependsOn)
+      if (exact && exact.dependsOn.length > 0) return exact.dependsOn
     }
 
     if (!rootName) return []
@@ -238,24 +247,132 @@ export class SBOMService {
       .filter(d => nameFromRef(d.ref) === rootName && d.dependsOn.length > 0)
       .sort((a, b) => b.dependsOn.length - a.dependsOn.length)
 
-    return toBomRefs(candidates[0]?.dependsOn ?? [])
+    return candidates[0]?.dependsOn ?? []
   }
 
   /**
-   * Extract component dependency relationships from a CycloneDX or SPDX SBOM.
+   * BFS scope propagation: compute {scope, isDirect} for every component.
    *
-   * CycloneDX: reads the top-level `dependencies` array.
-   * SPDX: reads the top-level `relationships` array, filtered to dependency types.
+   * Algorithm:
+   * 1. Identify direct deps of the root (via resolveRootDirectDeps).
+   * 2. Assign each direct dep isDirect=true and its own scope.
+   * 3. BFS from runtime/required directs → all reachable: isDirect=false, scope='runtime'
+   * 4. BFS from optional directs → remaining: isDirect=false, scope='optional'
+   * 5. BFS from dev directs → remaining: isDirect=false, scope='dev'
+   * 6. Any component not reached: isDirect=false, scope=null
    *
-   * Returns an empty array if the SBOM has no dependency section.
+   * When a component is reachable via multiple paths, the highest-priority
+   * scope wins (runtime/required > optional > dev > null).
+   *
+   * For SPDX, scopedEdges carries per-edge scope so the BFS uses the edge
+   * scope rather than the target component's own scope field.
+   * For CycloneDX, scope comes from ExtractedComponent.scope.
    */
-  private extractDependencies(sbom: Record<string, unknown>, format: 'cyclonedx' | 'spdx'): ComponentDependency[] {
-    if (format === 'cyclonedx') {
-      return this.extractCycloneDXDependencies(sbom)
-    } else {
-      return this.extractSPDXDependencies(sbom)
+  private propagateScope(
+    rootBomRef: string | null,
+    rootName: string | null,
+    components: ExtractedComponent[],
+    dependencies: ComponentDependency[],
+    scopedEdges: ScopedEdge[] | null,
+  ): Map<string, ComponentUsage> {
+    const usage = new Map<string, ComponentUsage>()
+
+    // Index component scope by bomRef (CycloneDX path)
+    const componentScopeByBomRef = new Map<string, string | null>()
+    for (const comp of components) {
+      if (comp.bomRef) {
+        componentScopeByBomRef.set(comp.bomRef, comp.scope)
+      }
     }
+
+    // Build adjacency: bomRef → [{ to, scope }]
+    // For SPDX: use per-edge scope from scopedEdges
+    // For CycloneDX: use target component's scope field
+    const adjacency = new Map<string, Array<{ to: string; scope: string | null }>>()
+
+    if (scopedEdges) {
+      for (const edge of scopedEdges) {
+        if (!adjacency.has(edge.from)) adjacency.set(edge.from, [])
+        adjacency.get(edge.from)!.push({ to: edge.to, scope: edge.scope })
+      }
+    } else {
+      for (const dep of dependencies) {
+        const edges = dep.dependsOn.map(to => ({
+          to,
+          scope: componentScopeByBomRef.get(to) ?? null,
+        }))
+        adjacency.set(dep.ref, edges)
+      }
+    }
+
+    // Resolve direct deps of the root
+    const directBomRefs = this.resolveRootDirectDeps(rootBomRef, rootName, dependencies)
+
+    // Determine scope for each direct dep
+    const directScopes = new Map<string, string | null>()
+    for (const bomRef of directBomRefs) {
+      let scope: string | null = null
+      if (scopedEdges) {
+        // For SPDX: find the edge from root to this bomRef and use its scope
+        const edge = scopedEdges.find(e =>
+          (e.from === rootBomRef || (rootName && e.from.includes(rootName))) && e.to === bomRef
+        )
+        scope = edge?.scope ?? null
+      } else {
+        scope = componentScopeByBomRef.get(bomRef) ?? null
+      }
+      directScopes.set(bomRef, scope)
+    }
+
+    // Assign direct deps
+    for (const [bomRef, scope] of directScopes) {
+      usage.set(bomRef, { bomRef, scope, isDirect: true })
+    }
+
+    // BFS helper: propagate a given scope from a set of seed bomRefs
+    const bfs = (seeds: string[], propagatedScope: string) => {
+      const queue = [...seeds]
+      while (queue.length > 0) {
+        const current = queue.shift()!
+        const edges = adjacency.get(current) ?? []
+        for (const { to } of edges) {
+          const existing = usage.get(to)
+          const existingPriority = existing?.scope ? (SCOPE_PRIORITY[existing.scope] ?? 0) : -1
+          const newPriority = SCOPE_PRIORITY[propagatedScope] ?? 0
+          if (!existing || newPriority > existingPriority) {
+            usage.set(to, { bomRef: to, scope: propagatedScope, isDirect: false })
+            queue.push(to)
+          }
+        }
+      }
+    }
+
+    // BFS in priority order: runtime/required first, then optional, then dev
+    const runtimeSeeds = directBomRefs.filter(r => {
+      const s = directScopes.get(r)
+      return s === 'runtime' || s === 'required'
+    })
+    const optionalSeeds = directBomRefs.filter(r => directScopes.get(r) === 'optional')
+    const devSeeds = directBomRefs.filter(r => {
+      const s = directScopes.get(r)
+      return s === 'dev' || s === 'test'
+    })
+
+    bfs(runtimeSeeds, 'runtime')
+    bfs(optionalSeeds, 'optional')
+    bfs(devSeeds, 'dev')
+
+    // Any component with a bomRef not yet classified: scope=null, isDirect=false
+    for (const comp of components) {
+      if (comp.bomRef && !usage.has(comp.bomRef)) {
+        usage.set(comp.bomRef, { bomRef: comp.bomRef, scope: null, isDirect: false })
+      }
+    }
+
+    return usage
   }
+
+
 
   private extractCycloneDXDependencies(sbom: Record<string, unknown>): ComponentDependency[] {
     const depsArray = sbom.dependencies as unknown[] | undefined
@@ -274,22 +391,41 @@ export class SBOMService {
     })
   }
 
-  private extractSPDXDependencies(sbom: Record<string, unknown>): ComponentDependency[] {
+  /**
+   * Extract SPDX relationships as ScopedEdge[], preserving per-edge scope.
+   *
+   * Unlike the CycloneDX path, SPDX encodes scope in the relationship type
+   * (DEV_DEPENDENCY_OF, RUNTIME_DEPENDENCY_OF, etc.) rather than on the
+   * package object. Preserving the type here allows the BFS propagation pass
+   * to use the correct scope for each edge.
+   */
+  private extractSPDXScopedEdges(sbom: Record<string, unknown>): ScopedEdge[] {
     const relationships = sbom.relationships as unknown[] | undefined
     if (!Array.isArray(relationships)) return []
 
-    // Group by spdxElementId → list of relatedSpdxElement
-    const map = new Map<string, string[]>()
+    const edges: ScopedEdge[] = []
     for (const rel of relationships) {
       const r = rel as Record<string, unknown>
-      if (!SPDX_DEPENDENCY_TYPES.has(r.relationshipType as string)) continue
-      const src = (r.spdxElementId as string)?.trim()
-      const tgt = (r.relatedSpdxElement as string)?.trim()
-      if (!src || !tgt) continue
-      if (!map.has(src)) map.set(src, [])
-      map.get(src)!.push(tgt)
+      const type = r.relationshipType as string | undefined
+      if (!type || !SPDX_DEPENDENCY_TYPES.has(type)) continue
+      const from = (r.spdxElementId as string)?.trim()
+      const to = (r.relatedSpdxElement as string)?.trim()
+      if (!from || !to) continue
+      edges.push({ from, to, scope: SPDX_SCOPE_MAP[type] ?? null })
     }
+    return edges
+  }
 
+  /**
+   * Convert ScopedEdge[] to ComponentDependency[] for DEPENDS_ON edge persistence.
+   * Scope is discarded here — it lives on the USES edge, not DEPENDS_ON.
+   */
+  private scopedEdgesToDependencies(edges: ScopedEdge[]): ComponentDependency[] {
+    const map = new Map<string, string[]>()
+    for (const { from, to } of edges) {
+      if (!map.has(from)) map.set(from, [])
+      map.get(from)!.push(to)
+    }
     return Array.from(map.entries()).map(([ref, dependsOn]) => ({ ref, dependsOn }))
   }
 
@@ -343,6 +479,8 @@ export class SBOMService {
    *
    * Builds a scope map from relationships before mapping packages so that
    * each package can receive the correct scope derived from its relationship type.
+   * This scope is stored on ExtractedComponent.scope and later used by the
+   * BFS propagation pass to set scope on the USES edge.
    */
   private extractSPDXComponents(sbom: Record<string, unknown>): ExtractedComponent[] {
     const packages = sbom.packages as unknown[] | undefined
@@ -352,7 +490,7 @@ export class SBOMService {
     // Build SPDXID → scope from relationships so mapSPDXPackage can set scope.
     // A package may appear as the target of multiple relationship types; the
     // first recognised type wins (relationships are typically ordered root-first).
-    const scopeMap = this.buildSPDXScopeMap(sbom)
+    const scopeMap = this.buildSPDXComponentScopeMap(sbom)
     return packages.map((pkg) => this.mapSPDXPackage(pkg as Record<string, unknown>, scopeMap))
   }
 
@@ -417,30 +555,14 @@ export class SBOMService {
   }
 
   /**
-   * Build a bomRef → scope map from CycloneDX ExtractedComponents.
-   *
-   * CycloneDX encodes scope directly on the component object, so we just
-   * index by bomRef. Components without a bomRef are skipped.
-   */
-  private buildCycloneDXScopeMap(components: ExtractedComponent[]): Map<string, string | null> {
-    const map = new Map<string, string | null>()
-    for (const comp of components) {
-      if (comp.bomRef) {
-        map.set(comp.bomRef, comp.scope)
-      }
-    }
-    return map
-  }
-
-  /**
-   * Build a SPDXID → scope map from SPDX relationships.
+   * Build a SPDXID → scope map from SPDX relationships for use in mapSPDXPackage.
    *
    * SPDX encodes scope in the relationship type rather than on the package.
    * This method scans `relationships[]` and maps each target SPDXID to the
    * scope derived from the first recognised relationship type that points to it.
    * Relationship types not in SPDX_SCOPE_MAP yield null.
    */
-  private buildSPDXScopeMap(sbom: Record<string, unknown>): Map<string, string | null> {
+  private buildSPDXComponentScopeMap(sbom: Record<string, unknown>): Map<string, string | null> {
     const map = new Map<string, string | null>()
     const relationships = sbom.relationships as unknown[] | undefined
     if (!Array.isArray(relationships)) return map

--- a/server/types/sbom.ts
+++ b/server/types/sbom.ts
@@ -66,10 +66,38 @@ export interface ComponentDependency {
   dependsOn: string[]
 }
 
-export interface DirectDep {
-  bomRef: string
-  /** Dependency scope (e.g. 'required', 'optional', 'dev', 'runtime', 'test'). Null when unknown. */
+/**
+ * A single directed dependency edge with an associated scope.
+ * Used internally during SPDX ingestion to carry per-edge scope
+ * through the BFS propagation pass.
+ */
+export interface ScopedEdge {
+  /** bom-ref of the source component */
+  from: string
+  /** bom-ref of the target component */
+  to: string
+  /** Scope derived from the SPDX relationship type, or null for CycloneDX */
   scope: string | null
+}
+
+/**
+ * Computed classification for a single component relative to a system.
+ *
+ * Produced by the BFS scope propagation pass in the service layer and
+ * consumed by the repository to set properties on the USES edge.
+ *
+ * scope values:
+ *   'runtime'  — reachable from a runtime/required direct dep (or IS a runtime direct dep)
+ *   'required' — synonym for 'runtime'; used by CycloneDX 'required' and SPDX DEPENDS_ON
+ *   'dev'      — reachable only from dev/test direct deps
+ *   'optional' — reachable only from optional/provided direct deps
+ *   'excluded' — CycloneDX excluded scope; persisted but excluded from runtime queries
+ *   null       — not reachable by BFS (orphaned / missing bomRef)
+ */
+export interface ComponentUsage {
+  bomRef: string
+  scope: string | null
+  isDirect: boolean
 }
 
 export interface PersistSBOMParams {
@@ -77,8 +105,11 @@ export interface PersistSBOMParams {
   repositoryUrl: string
   components: ExtractedComponent[]
   dependencies: ComponentDependency[]
-  /** Direct dependencies of the system root, with per-edge scope. */
-  directDeps: DirectDep[]
+  /**
+   * Per-component usage classification (scope + isDirect) computed by BFS
+   * in the service layer. Keyed by bomRef.
+   */
+  componentUsage: Map<string, ComponentUsage>
   format: 'cyclonedx' | 'spdx'
   timestamp: Date
 }

--- a/test/server/repositories/sbom.repository.spec.ts
+++ b/test/server/repositories/sbom.repository.spec.ts
@@ -35,7 +35,7 @@ describe('SBOMRepository', () => {
         format: 'cyclonedx',
         timestamp: new Date(),
         dependencies: [],
-        directDeps: [],
+        componentUsage: new Map(),
         components: [
           {
             name: `${PREFIX}lodash`, version: '4.17.21',
@@ -68,8 +68,8 @@ describe('SBOMRepository', () => {
     })
   })
 
-  describe('DIRECT_DEP edges via persistSBOM()', () => {
-    it('should create DIRECT_DEP edges for components listed in directDeps', async () => {
+  describe('isDirect on USES edges via persistSBOM()', () => {
+    it('should set isDirect=true on USES edges for direct dependencies', async () => {
       if (!ctx.neo4jAvailable) return
 
       await seed(ctx.driver, `
@@ -93,7 +93,10 @@ describe('SBOMRepository', () => {
           { ref: refA, dependsOn: [refB] },
           { ref: refB, dependsOn: [] },
         ],
-        directDeps: [{ bomRef: refA, scope: 'required' }, { bomRef: refB, scope: null }],
+        componentUsage: new Map([
+          [refA, { bomRef: refA, scope: 'required', isDirect: true }],
+          [refB, { bomRef: refB, scope: 'runtime', isDirect: false }],
+        ]),
         components: [
           {
             name: `${PREFIX}direct-comp-a`, version: '1.0.0',
@@ -115,12 +118,16 @@ describe('SBOMRepository', () => {
       })
 
       const check = await session.run(`
-        MATCH (s:System { name: $sys })-[r:DIRECT_DEP]->(c:Component)
+        MATCH (s:System { name: $sys })-[r:USES]->(c:Component)
         WHERE c.purl STARTS WITH $prefix
-        RETURN count(r) AS count
+        RETURN r.isDirect AS isDirect, r.scope AS scope, c.purl AS purl
+        ORDER BY c.purl
       `, { sys: `${PREFIX}direct-system`, prefix: `pkg:npm/${PREFIX}` })
 
-      expect(check.records[0].get('count').toNumber()).toBe(2)
+      expect(check.records).toHaveLength(2)
+      const byPurl = Object.fromEntries(check.records.map(r => [r.get('purl'), { isDirect: r.get('isDirect'), scope: r.get('scope') }]))
+      expect(byPurl[refA]).toEqual({ isDirect: true, scope: 'required' })
+      expect(byPurl[refB]).toEqual({ isDirect: false, scope: 'runtime' })
     })
   })
 
@@ -146,7 +153,7 @@ describe('SBOMRepository', () => {
         format: 'cyclonedx',
         timestamp: new Date(),
         dependencies: [{ ref: purlA, dependsOn: [purlB] }],
-        directDeps: [],
+        componentUsage: new Map(),
         components: [
           {
             name: `${PREFIX}comp-a`, version: '1.0.0',
@@ -195,7 +202,7 @@ describe('SBOMRepository', () => {
           format: 'cyclonedx',
           timestamp: new Date(),
           dependencies: [{ ref: `${PREFIX}nonexistent`, dependsOn: [`${PREFIX}also-nonexistent`] }],
-          directDeps: [],
+          componentUsage: new Map(),
           components: [],
         })
       ).resolves.not.toThrow()
@@ -220,7 +227,7 @@ describe('SBOMRepository', () => {
           format: 'cyclonedx',
           timestamp: new Date(),
           dependencies: [],
-          directDeps: [],
+          componentUsage: new Map(),
           components: [],
         })
       ).resolves.not.toThrow()

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -358,9 +358,10 @@ describe('SBOMService', () => {
         ref: 'pkg:npm/test-app@1.0.0',
         dependsOn: ['pkg:npm/lodash@4.17.21'],
       })
-      // directDeps is resolved from the root's dependsOn list in the service layer.
-      // CycloneDX: scope comes from the component's scope field (null here since not set).
-      expect(persistCall.directDeps).toEqual([{ bomRef: 'pkg:npm/lodash@4.17.21', scope: null }])
+      // componentUsage is computed by BFS propagation in the service layer.
+      // lodash is a direct dep with no scope set on the component → scope: null, isDirect: true.
+      const lodashUsage = persistCall.componentUsage.get('pkg:npm/lodash@4.17.21')
+      expect(lodashUsage).toEqual({ bomRef: 'pkg:npm/lodash@4.17.21', scope: null, isDirect: true })
     })
 
     it('should extract SPDX dependency relationships and pass them to persistSBOM', async () => {
@@ -453,10 +454,9 @@ describe('SBOMService', () => {
       })
 
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
-      expect(persistCall.directDeps).toEqual([
-        { bomRef: 'pkg:npm/lodash@4.17.21', scope: null },
-        { bomRef: 'pkg:npm/express@4.18.2', scope: null },
-      ])
+      // Both lodash and express are direct deps resolved via the name-fallback path.
+      expect(persistCall.componentUsage.get('pkg:npm/lodash@4.17.21')).toMatchObject({ isDirect: true })
+      expect(persistCall.componentUsage.get('pkg:npm/express@4.18.2')).toMatchObject({ isDirect: true })
     })
 
     it('should use exact match directDeps when root bom-ref matches a non-empty dependsOn entry', async () => {
@@ -488,7 +488,7 @@ describe('SBOMService', () => {
       })
 
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
-      expect(persistCall.directDeps).toEqual([{ bomRef: 'pkg:npm/lodash@4.17.21', scope: null }])
+      expect(persistCall.componentUsage.get('pkg:npm/lodash@4.17.21')).toMatchObject({ isDirect: true })
     })
 
     it('should return empty directDeps when no dependency entry matches the root name', async () => {
@@ -520,7 +520,9 @@ describe('SBOMService', () => {
       })
 
       const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
-      expect(persistCall.directDeps).toEqual([])
+      // No direct deps resolved — no component should have isDirect: true
+      const anyDirect = [...persistCall.componentUsage.values()].some(u => u.isDirect)
+      expect(anyDirect).toBe(false)
     })
 
     it('should handle nested CycloneDX components', async () => {


### PR DESCRIPTION
## Description

Collapses `DIRECT_DEP` into `USES {isDirect, scope}`, enabling queries like:

```cypher
// All direct runtime deps
MATCH (s:System {name: 'X'})-[:USES {isDirect: true, scope: 'runtime'}]->(c) RETURN c

// All transitive deps regardless of scope
MATCH (s:System {name: 'X'})-[:USES {isDirect: false}]->(c) RETURN c

// Runtime deps (direct + transitive), excluding dev and their transitive closure
MATCH (s:System {name: 'X'})-[:USES {scope: 'runtime'}]->(c) RETURN c
```

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Schema update (changes to database schemas)
- [x] Documentation update

## Related Issues

Fixes #586

## Changes Made

- **BFS scope propagation** (`sbom.service.ts` — `propagateScope`) — runs before any DB writes. Classifies every component as `{scope, isDirect}`. Runtime/required paths win over optional > dev (priority 3 > 2 > 1). Components unreachable by BFS get `scope=null, isDirect=false`.

- **SPDX per-edge scope** — `extractSPDXScopedEdges()` replaces `extractSPDXDependencies()`, preserving relationship type as `ScopedEdge.scope` so BFS uses the correct scope per edge. `TEST_DEPENDENCY_OF` maps to `'dev'`.

- **`ComponentUsage` map** (`server/types/sbom.ts`) — replaces `DirectDep[]` as the service→repository handoff. Repository looks up `{scope, isDirect}` per component by `bomRef`.

- **`persist-components-core.cypher`** — sets `r.isDirect` on the `USES` edge alongside `r.scope`.

- **`server/database/queries/systems/graph.cypher`** — reads `direct` and `scope` from the `USES` edge (`u.isDirect`, `u.scope`) instead of `EXISTS { DIRECT_DEP }` and `c.scope`. Fixes the system dependency graph visualisation after the migration drops `DIRECT_DEP` and removes `c.scope`.

- **Migration `20260522_120000`** — sets `isDirect=true` on `USES` edges that have a corresponding `DIRECT_DEP` edge, `isDirect=false` on all others, deletes all `DIRECT_DEP` edges, adds indexes on `USES.scope` and `USES.isDirect`.

- **`graph-model.vue`** — removed `DIRECT_DEP` entry, updated `USES` description to document `scope` and `isDirect` edge properties.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

**Scope vocabulary:** `'runtime'` and `'required'` are both treated as runtime priority (`SCOPE_PRIORITY=3`) and are valid values on the edge. `'excluded'` CycloneDX components are persisted with `scope='excluded'`, not dropped.

**CycloneDX limitation:** CycloneDX has no dev/runtime distinction at the dependency edge level. All CycloneDX components default to `scope: 'runtime'` unless `component.scope = 'optional'` or `'excluded'`.

**`persist-direct-deps.cypher` is now dead code** — it is not deleted in this PR to avoid breaking any external tooling that may reference it, but it is no longer called by the repository.

**Down migration is best-effort** — rolling back restores `DIRECT_DEP` edges from `USES {isDirect: true}` but cannot guarantee the original `addedAt` timestamps are preserved exactly.
