### PR TITLE
feat: expose direct/scope filters on component list and violation queries

### DIFF
--- a/server/api/compliance/violations.get.ts
+++ b/server/api/compliance/violations.get.ts
@@ -98,8 +98,12 @@ export default defineEventHandler(async (event) => {
   await requireAuth(event)
 
   try {
-    const result = await complianceService.findViolations()
-    
+    const query = getQuery(event)
+    const result = await complianceService.findViolations({
+      directOnly: query.direct === 'true' ? true : undefined,
+      depScope: query.depScope as string | undefined,
+    })
+
     return {
       success: true,
       data: result

--- a/server/api/components.get.ts
+++ b/server/api/components.get.ts
@@ -46,6 +46,17 @@ import { componentService } from '../services/singletons'
  *           type: string
  *         description: Filter by system name (only components used by this system)
  *       - in: query
+ *         name: direct
+ *         schema:
+ *           type: boolean
+ *         description: When true, restrict to direct dependencies of the system (requires system)
+ *       - in: query
+ *         name: depScope
+ *         schema:
+ *           type: string
+ *           enum: [runtime, required, dev, optional, excluded]
+ *         description: Filter by dependency scope on the USES edge (requires system)
+ *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
@@ -114,6 +125,8 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Component>>
       license: query.license as string | undefined,
       hasLicense: query.hasLicense === 'true' ? true : query.hasLicense === 'false' ? false : undefined,
       system: query.system as string | undefined,
+      directOnly: query.direct === 'true' ? true : undefined,
+      depScope: query.depScope as string | undefined,
       limit,
       offset,
       sortBy: query.sortBy as string | undefined,

--- a/server/api/licenses/violations.get.ts
+++ b/server/api/licenses/violations.get.ts
@@ -43,6 +43,17 @@ import type { ApiResponse, LicenseViolation } from '~~/types/api'
  *           enum: [asc, desc]
  *           default: asc
  *         description: Sort direction
+ *       - in: query
+ *         name: direct
+ *         schema:
+ *           type: boolean
+ *         description: When true, restrict to direct dependencies only
+ *       - in: query
+ *         name: depScope
+ *         schema:
+ *           type: string
+ *           enum: [runtime, required, dev, optional, excluded]
+ *         description: Filter by dependency scope on the USES edge
  *     responses:
  *       200:
  *         description: License violations
@@ -69,6 +80,8 @@ export default defineEventHandler(async (event): Promise<ApiResponse<LicenseViol
 
     const filters = {
       search: query.search as string | undefined,
+      directOnly: query.direct === 'true' ? true : undefined,
+      depScope: query.depScope as string | undefined,
       limit,
       offset,
       sortBy: query.sortBy as string | undefined,

--- a/server/api/version-constraints/violations.get.ts
+++ b/server/api/version-constraints/violations.get.ts
@@ -9,7 +9,9 @@ export default defineEventHandler(async (event) => {
     const result = await versionConstraintService.getViolations({
       severity: query.severity as string | undefined,
       team: query.team as string | undefined,
-      technology: query.technology as string | undefined
+      technology: query.technology as string | undefined,
+      directOnly: query.direct === 'true' ? true : undefined,
+      depScope: query.depScope as string | undefined,
     })
 
     return { success: true, ...result }

--- a/server/database/queries/compliance/find-violations.cypher
+++ b/server/database/queries/compliance/find-violations.cypher
@@ -4,10 +4,16 @@
 // For each (team, technology) pair, collect the systems that use the technology
 // and determine the most specific approval for each system's environment.
 // A violation exists when every system's resolved approval is absent or 'eliminate'.
+// Optional filters:
+//   $directOnly (boolean) — restrict to systems that use the technology via a direct dep
+//   $depScope   (string)  — restrict to systems that use the technology via a dep with this scope
 MATCH (team:Team)-[u:USES]->(tech:Technology)
-// Collect systems with their environments
+// Collect systems with their environments, optionally filtered by isDirect/scope on the USES edge
 WITH team, tech, u,
-     [(team)-[:OWNS]->(sys:System)-[:USES]->(:Component)-[:IS_VERSION_OF]->(tech) | {name: sys.name, environment: sys.environment}] as systemInfos
+     [(team)-[:OWNS]->(sys:System)-[cu:USES]->(comp:Component)-[:IS_VERSION_OF]->(tech)
+      WHERE ($directOnly IS NULL OR $directOnly = false OR cu.isDirect = true)
+        AND ($depScope IS NULL OR cu.scope = $depScope)
+      | {name: sys.name, environment: sys.environment}] as systemInfos
 // For each system, resolve the most specific approval:
 //   environment-specific approval takes precedence over blanket (environment IS NULL)
 WITH team, tech, u, systemInfos,

--- a/server/database/queries/components/find-all.cypher
+++ b/server/database/queries/components/find-all.cypher
@@ -11,13 +11,19 @@ UNWIND allRows as row
 WITH row.c as c, row.tech as tech, total{{PRE_AGG_UNWIND}}
 ORDER BY {{PRE_ORDER_BY}}
 {{PAGINATION}}
-// Phase 2: fetch related data only for the paginated subset
-OPTIONAL MATCH (sys:System)-[:USES]->(c)
+// Phase 2: fetch related data only for the paginated subset.
+// When a system filter is active, also fetch scope and isDirect from the USES edge
+// for that specific system. Without a system filter, scope is null (it is an edge
+// property and has no meaning outside a system context).
+OPTIONAL MATCH (sys:System)-[u:USES]->(c)
 OPTIONAL MATCH (c)-[:HAS_HASH]->(h:Hash)
 OPTIONAL MATCH (c)-[:HAS_LICENSE]->(l:License)
 OPTIONAL MATCH (c)-[:HAS_REFERENCE]->(ref:ExternalReference)
 WITH c, tech, total,
      count(DISTINCT sys) as systemCount,
+     // Collect scope/isDirect only for the filtered system (if any); take first non-null value
+     head([x IN collect(DISTINCT {scope: u.scope, isDirect: u.isDirect, sysName: sys.name}) WHERE x.sysName = $system | x.scope]) as scope,
+     head([x IN collect(DISTINCT {scope: u.scope, isDirect: u.isDirect, sysName: sys.name}) WHERE x.sysName = $system | x.isDirect]) as isDirect,
      collect(DISTINCT {algorithm: h.algorithm, value: h.value}) as hashes,
      collect(DISTINCT {id: l.id, name: l.name, url: l.url, text: l.text}) as licenses,
      collect(DISTINCT {type: ref.type, url: ref.url}) as externalReferences
@@ -29,7 +35,8 @@ RETURN c.name as name,
        c.bomRef as bomRef,
        c.type as type,
        c.group as `group`,
-       c.scope as scope,
+       scope,
+       isDirect,
        [hash IN hashes WHERE hash.algorithm IS NOT NULL | hash] as hashes,
        [lic IN licenses WHERE lic.id IS NOT NULL | lic] as licenses,
        c.copyright as copyright,

--- a/server/database/queries/licenses/find-violations.cypher
+++ b/server/database/queries/licenses/find-violations.cypher
@@ -1,6 +1,11 @@
-// Find components using disallowed licenses
-MATCH (team:Team)-[:OWNS]->(sys:System)-[:USES]->(comp:Component)-[:HAS_LICENSE]->(license:License)
+// Find components using disallowed licenses.
+// Optional filters:
+//   $directOnly (boolean) — restrict to direct dependencies (USES {isDirect: true})
+//   $depScope   (string)  — restrict to a specific scope on the USES edge
+MATCH (team:Team)-[:OWNS]->(sys:System)-[u:USES]->(comp:Component)-[:HAS_LICENSE]->(license:License)
 WHERE license.allowed = false
+  AND ($directOnly IS NULL OR $directOnly = false OR u.isDirect = true)
+  AND ($depScope IS NULL OR u.scope = $depScope)
 RETURN team.name as teamName,
        sys.name as systemName,
        comp.name as componentName,

--- a/server/database/queries/version-constraints/find-violations.cypher
+++ b/server/database/queries/version-constraints/find-violations.cypher
@@ -1,9 +1,14 @@
 // Find version-constraint violations: Team→System→Component→Technology
-// Semver range check is applied in the service layer after fetching candidates
-MATCH (team:Team)-[:OWNS]->(sys:System)-[:USES]->(comp:Component)-[:IS_VERSION_OF]->(tech:Technology)
+// Semver range check is applied in the service layer after fetching candidates.
+// Optional filters:
+//   $directOnly (boolean) — restrict to direct dependencies (USES {isDirect: true})
+//   $depScope   (string)  — restrict to a specific scope on the USES edge
+MATCH (team:Team)-[:OWNS]->(sys:System)-[u:USES]->(comp:Component)-[:IS_VERSION_OF]->(tech:Technology)
 MATCH (vc:VersionConstraint {status: 'active'})-[:GOVERNS]->(tech)
 MATCH (team)-[:SUBJECT_TO]->(vc)
-{{WHERE_CONDITIONS}}
+WHERE ($directOnly IS NULL OR $directOnly = false OR u.isDirect = true)
+  AND ($depScope IS NULL OR u.scope = $depScope)
+  {{AND_CONDITIONS}}
 RETURN team.name as teamName,
        sys.name as systemName,
        sys.businessCriticality as systemBusinessCriticality,

--- a/server/repositories/compliance.repository.ts
+++ b/server/repositories/compliance.repository.ts
@@ -15,22 +15,30 @@ export interface ComplianceViolation {
 /**
  * Repository for compliance-related data access
  */
+export interface ComplianceViolationFilters {
+  /** Restrict to technologies used via direct dependencies only */
+  directOnly?: boolean
+  /** Restrict to technologies used via dependencies with this scope */
+  depScope?: string
+}
+
 export class ComplianceRepository extends BaseRepository {
   /**
-   * Find all compliance violations
-   * 
+   * Find all compliance violations.
+   *
    * A compliance violation occurs when:
    * - A team uses a technology without approval (unapproved)
    * - A team uses a technology marked for elimination (eliminated)
-   * 
+   *
    * Results are ordered by system count (most impactful first).
-   * 
-   * @returns Array of compliance violations
    */
-  async findViolations(): Promise<ComplianceViolation[]> {
+  async findViolations(filters: ComplianceViolationFilters = {}): Promise<ComplianceViolation[]> {
     const query = await loadQuery('compliance/find-violations.cypher')
-    const { records } = await this.executeQuery(query)
-    
+    const { records } = await this.executeQuery(query, {
+      directOnly: filters.directOnly ?? null,
+      depScope: filters.depScope ?? null,
+    })
+
     return records.map(record => this.mapToViolation(record))
   }
 

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -11,6 +11,10 @@ export interface ComponentFilters {
   license?: string
   hasLicense?: boolean
   system?: string
+  /** When true, restrict to direct dependencies of the system (requires system to be set) */
+  directOnly?: boolean
+  /** Filter by dependency scope on the USES edge (e.g. 'runtime', 'dev', 'optional') */
+  depScope?: string
   limit?: number
   offset?: number
   sortBy?: string
@@ -67,8 +71,31 @@ export class ComponentRepository extends BaseRepository {
     }
 
     if (filters.system) {
-      componentConditions.push('EXISTS { MATCH (sys:System {name: $system})-[:USES]->(c) }')
+      if (filters.directOnly) {
+        componentConditions.push('EXISTS { MATCH (sys:System {name: $system})-[:USES {isDirect: true}]->(c) }')
+      } else if (filters.depScope) {
+        componentConditions.push('EXISTS { MATCH (sys:System {name: $system})-[:USES {scope: $depScope}]->(c) }')
+      } else {
+        componentConditions.push('EXISTS { MATCH (sys:System {name: $system})-[:USES]->(c) }')
+      }
       params.system = filters.system
+    }
+
+    if (filters.depScope && !filters.system) {
+      // scope filter without a system is not meaningful — ignore silently
+    }
+
+    if (filters.directOnly && filters.depScope && filters.system) {
+      // both directOnly and depScope: require isDirect=true AND scope matches
+      // replace the condition added above with a combined one
+      const idx = componentConditions.findLastIndex(c => c.includes('isDirect'))
+      if (idx >= 0) {
+        componentConditions[idx] = 'EXISTS { MATCH (sys:System {name: $system})-[:USES {isDirect: true, scope: $depScope}]->(c) }'
+      }
+    }
+
+    if (filters.depScope) {
+      params.depScope = filters.depScope
     }
 
     if (filters.technology) {
@@ -122,6 +149,13 @@ export class ComponentRepository extends BaseRepository {
   async findAll(filters: ComponentFilters = {}): Promise<{ data: Component[]; total: number }> {
     const baseQuery = await loadQuery('components/find-all.cypher')
     const { componentConditions, params } = this.buildFilterConditions(filters)
+
+    // $system must always be defined — the Phase 2 query uses it to look up
+    // scope/isDirect from the USES edge for the filtered system context.
+    // When no system filter is active, it resolves to null and the head() returns null.
+    if (!params.system) {
+      params.system = null
+    }
 
     const componentWhere = componentConditions.length > 0
       ? `WHERE ${componentConditions.join(' AND ')}`
@@ -185,7 +219,8 @@ export class ComponentRepository extends BaseRepository {
       bomRef: record.get('bomRef'),
       type: record.get('type'),
       group: record.get('group'),
-      scope: record.get('scope'),
+      scope: record.get('scope') ?? null,
+      isDirect: record.get('isDirect') ?? null,
       hashes: (record.get('hashes') ?? []).filter((h: { algorithm?: string; value?: string }) => h.algorithm),
       licenses: (record.get('licenses') ?? []).filter((l: { id?: string; name?: string }) => l.id || l.name),
       copyright: record.get('copyright'),

--- a/server/repositories/license.repository.ts
+++ b/server/repositories/license.repository.ts
@@ -54,6 +54,10 @@ export interface LicenseFilters {
 
 export interface LicenseViolationFilters {
   search?: string
+  /** Restrict to direct dependencies only (USES {isDirect: true}) */
+  directOnly?: boolean
+  /** Restrict to a specific dependency scope on the USES edge */
+  depScope?: string
   limit?: number
   offset?: number
   sortBy?: string
@@ -488,25 +492,32 @@ export class LicenseRepository extends BaseRepository {
    * Find components using disallowed licenses
    */
   async findViolations(filters: LicenseViolationFilters = {}): Promise<{ data: LicenseViolation[], total: number }> {
-    const conditions: string[] = ['license.allowed = false']
-    const params: Record<string, unknown> = {}
+    const conditions: string[] = []
+    const params: Record<string, unknown> = {
+      directOnly: filters.directOnly ?? null,
+      depScope: filters.depScope ?? null,
+    }
 
     if (filters.search) {
       conditions.push('(toLower(comp.name) CONTAINS toLower($search) OR toLower(license.id) CONTAINS toLower($search) OR toLower(sys.name) CONTAINS toLower($search) OR toLower(team.name) CONTAINS toLower($search))')
       params.search = filters.search
     }
 
-    const whereClause = `WHERE ${conditions.join(' AND ')}`
-    const matchClause = `MATCH (team:Team)-[:OWNS]->(sys:System)-[:USES]->(comp:Component)-[:HAS_LICENSE]->(license:License)`
+    const extraWhere = conditions.length > 0 ? `AND ${conditions.join(' AND ')}` : ''
+    const matchClause = `MATCH (team:Team)-[:OWNS]->(sys:System)-[u:USES]->(comp:Component)-[:HAS_LICENSE]->(license:License)`
+    const baseWhere = `WHERE license.allowed = false
+      AND ($directOnly IS NULL OR $directOnly = false OR u.isDirect = true)
+      AND ($depScope IS NULL OR u.scope = $depScope)
+      ${extraWhere}`
 
     // Count query
-    const countCypher = `${matchClause} ${whereClause} RETURN count(*) as total`
+    const countCypher = `${matchClause} ${baseWhere} RETURN count(*) as total`
     const { records: countRecords } = await this.executeQuery(countCypher, params)
     const total = countRecords[0]?.get('total').toNumber() || 0
 
     // Data query
     let dataCypher = `${matchClause}
-      ${whereClause}
+      ${baseWhere}
       RETURN team.name as teamName,
              sys.name as systemName,
              sys.businessCriticality as systemBusinessCriticality,

--- a/server/repositories/version-constraint.repository.ts
+++ b/server/repositories/version-constraint.repository.ts
@@ -7,6 +7,10 @@ export interface ViolationFilters {
   team?: string
   technology?: string
   system?: string
+  /** Restrict to direct dependencies only (USES {isDirect: true}) */
+  directOnly?: boolean
+  /** Restrict to a specific dependency scope on the USES edge */
+  depScope?: string
   limit?: number
   offset?: number
   sortBy?: string
@@ -163,7 +167,10 @@ export class VersionConstraintRepository extends BaseRepository {
   async findViolations(filters: ViolationFilters): Promise<Violation[]> {
     const query = await loadQuery('version-constraints/find-violations.cypher')
 
-    const params: Record<string, string> = {}
+    const params: Record<string, unknown> = {
+      directOnly: filters.directOnly ?? null,
+      depScope: filters.depScope ?? null,
+    }
     const conditions: string[] = []
 
     if (filters.severity) {

--- a/server/services/compliance.service.ts
+++ b/server/services/compliance.service.ts
@@ -1,4 +1,4 @@
-import { ComplianceRepository, type ComplianceViolation } from '../repositories/compliance.repository'
+import { ComplianceRepository, type ComplianceViolation, type ComplianceViolationFilters } from '../repositories/compliance.repository'
 
 interface TeamSummary {
   team: string
@@ -40,10 +40,10 @@ export class ComplianceService {
    * 
    * @returns Violations with summary statistics
    */
-  async findViolations(): Promise<ViolationResult> {
-    const violations = await this.complianceRepo.findViolations()
+  async findViolations(filters: ComplianceViolationFilters = {}): Promise<ViolationResult> {
+    const violations = await this.complianceRepo.findViolations(filters)
     const summary = this.calculateSummary(violations)
-    
+
     return {
       violations,
       summary

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -59,7 +59,8 @@ export interface Component {
   // === CLASSIFICATION ===
   type: ComponentType | null     // library, framework, application, etc.
   group: string | null           // Maven groupId, npm scope, etc.
-  scope: DependencyScope | null  // required, optional, dev, test, etc.
+  scope: DependencyScope | null  // runtime, required, optional, dev, excluded — from USES edge (null when no system context)
+  isDirect: boolean | null       // true = direct dep of the queried system; null when no system context
   
   // === HASHES ===
   hashes: Hash[]                 // Multiple hashes with algorithms


### PR DESCRIPTION
## Description

Exposes the `isDirect` and `scope` edge properties (set during SBOM ingestion by PR #587) as query parameters across the component list and all violation endpoints. Enables queries like:

```
GET /components?system=karla&direct=true
GET /components?system=karla&depScope=runtime
GET /licenses/violations?direct=true
GET /version-constraints/violations?direct=true&depScope=runtime
GET /compliance/violations?direct=true
```

Also fixes a stale `c.scope` reference in `components/find-all.cypher` — scope was removed from Component nodes by migration `20260522_080000` and was silently returning `null` for all components.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #579

## Changes Made

- **`GET /components`** — `?direct=true` filters to `USES {isDirect: true}`; `?depScope=<value>` filters to `USES {scope: $depScope}`. Both can be combined. Response now includes `scope` and `isDirect` per component, sourced from the `USES` edge for the queried system. `null` when no `system` parameter is provided.

- **`GET /licenses/violations`** — `?direct=true` and `?depScope=` applied on the `USES` edge in the query. Filters added to `LicenseViolationFilters` and `findViolations()`.

- **`GET /version-constraints/violations`** — same filters added to `ViolationFilters` and `findViolations()`. The `{{AND_CONDITIONS}}` placeholder pattern is used to compose with existing severity/team/technology conditions.

- **`GET /compliance/violations`** — operates at the Technology level; `direct=true` means "only flag technologies used via at least one direct component dependency". `ComplianceViolationFilters` added to repository and service.

- **`types/api.d.ts`** — `Component.isDirect: boolean | null` added. Additive change; existing consumers see `null` when no system context is provided.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

**`depScope` without `system` on `/components`** — silently ignored. Scope is an edge property with no meaning outside a system context.

**Dependency on PR #587** — this PR requires the `isDirect` and `scope` properties to be present on `USES` edges. These are set by the BFS propagation introduced in #587 and backfilled by migration `20260522_120000`. If merged before #587, all `direct=true` queries will return empty results until the migration runs.
