### PR TITLE
Fix Watchtower socket proxy permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -152,6 +152,8 @@ jobs:
                 environment:
                   CONTAINERS: 1
                   IMAGES: 1
+                  NETWORKS: 1
+                  VOLUMES: 1
                   POST: 1
                   ALLOW_STOP: 1
                   ALLOW_RESTARTS: 1

--- a/app/pages/api-reference.vue
+++ b/app/pages/api-reference.vue
@@ -30,7 +30,28 @@
         <template #header>
           <h2 class="text-lg font-semibold">Overview</h2>
         </template>
-        <div class="prose-content" v-html="renderMarkdown(spec.info?.description || '')" />
+        <div class="prose-content space-y-3">
+          <template v-for="(block, index) in overviewBlocks" :key="index">
+            <h1 v-if="block.type === 'heading' && block.level === 1">
+              <MarkdownInline :segments="block.content" />
+            </h1>
+            <h2 v-else-if="block.type === 'heading' && block.level === 2">
+              <MarkdownInline :segments="block.content" />
+            </h2>
+            <h3 v-else-if="block.type === 'heading'">
+              <MarkdownInline :segments="block.content" />
+            </h3>
+            <ul v-else-if="block.type === 'list'">
+              <li v-for="(item, itemIndex) in block.items" :key="itemIndex">
+                <MarkdownInline :segments="item" />
+              </li>
+            </ul>
+            <pre v-else-if="block.type === 'code'"><code>{{ block.text }}</code></pre>
+            <p v-else>
+              <MarkdownInline :segments="block.content" />
+            </p>
+          </template>
+        </div>
       </UCard>
 
       <UCard v-for="tag in spec.tags" :key="tag.name">
@@ -120,7 +141,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, defineComponent, h, type PropType } from 'vue'
 
 useHead({
   title: 'API Reference - Polaris'
@@ -147,10 +168,41 @@ interface Endpoint extends EndpointDetail {
   method: string
 }
 
+type InlineSegmentType = 'text' | 'strong' | 'em' | 'code'
+
+interface InlineSegment {
+  type: InlineSegmentType
+  text: string
+}
+
+type MarkdownBlock =
+  | { type: 'heading', level: 1 | 2 | 3, content: InlineSegment[] }
+  | { type: 'paragraph', content: InlineSegment[] }
+  | { type: 'list', items: InlineSegment[][] }
+  | { type: 'code', text: string }
+
 const expandedEndpoints = ref(new Set<string>())
 
 const { data: spec, status, error } = await useFetch<OpenAPISpec>('/api/openapi.json')
 const loading = computed(() => status.value === 'pending')
+const overviewBlocks = computed(() => parseMarkdown(spec.value?.info?.description || ''))
+
+const MarkdownInline = defineComponent({
+  props: {
+    segments: {
+      type: Array as PropType<InlineSegment[]>,
+      required: true
+    }
+  },
+  setup(props) {
+    return () => props.segments.map((segment) => {
+      if (segment.type === 'strong') return h('strong', segment.text)
+      if (segment.type === 'em') return h('em', segment.text)
+      if (segment.type === 'code') return h('code', segment.text)
+      return segment.text
+    })
+  }
+})
 
 function getMethodColor(method: string): 'success' | 'primary' | 'warning' | 'error' | 'neutral' {
   const colors: Record<string, 'success' | 'primary' | 'warning' | 'error' | 'neutral'> = {
@@ -200,16 +252,108 @@ function getResponseSchema(endpoint: Endpoint): unknown | null {
   return jsonContent?.schema || null
 }
 
-function renderMarkdown(text: string): string {
-  return text
-    .replace(/### (.*)/g, '<h3>$1</h3>')
-    .replace(/## (.*)/g, '<h2>$1</h2>')
-    .replace(/# (.*)/g, '<h1>$1</h1>')
-    .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-    .replace(/\*(.*?)\*/g, '<em>$1</em>')
-    .replace(/`(.*?)`/g, '<code>$1</code>')
-    .replace(/\n\n/g, '</p><p>')
-    .replace(/\n- (.*)/g, '<li>$1</li>')
+function parseMarkdown(text: string): MarkdownBlock[] {
+  const blocks: MarkdownBlock[] = []
+  const paragraphLines: string[] = []
+  let listItems: InlineSegment[][] = []
+  let codeLines: string[] = []
+  let inCodeBlock = false
+
+  const flushParagraph = () => {
+    if (!paragraphLines.length) return
+    blocks.push({ type: 'paragraph', content: parseInlineMarkdown(paragraphLines.join(' ')) })
+    paragraphLines.length = 0
+  }
+
+  const flushList = () => {
+    if (!listItems.length) return
+    blocks.push({ type: 'list', items: listItems })
+    listItems = []
+  }
+
+  const flushCode = () => {
+    blocks.push({ type: 'code', text: codeLines.join('\n') })
+    codeLines = []
+  }
+
+  for (const line of text.split('\n')) {
+    if (line.startsWith('```')) {
+      if (inCodeBlock) {
+        flushCode()
+        inCodeBlock = false
+      }
+      else {
+        flushParagraph()
+        flushList()
+        inCodeBlock = true
+      }
+      continue
+    }
+
+    if (inCodeBlock) {
+      codeLines.push(line)
+      continue
+    }
+
+    if (!line.trim()) {
+      flushParagraph()
+      flushList()
+      continue
+    }
+
+    const heading = /^(#{1,3})\s+(.+)$/.exec(line)
+    if (heading) {
+      flushParagraph()
+      flushList()
+      blocks.push({
+        type: 'heading',
+        level: heading[1].length as 1 | 2 | 3,
+        content: parseInlineMarkdown(heading[2])
+      })
+      continue
+    }
+
+    const listItem = /^-\s+(.+)$/.exec(line)
+    if (listItem) {
+      flushParagraph()
+      listItems.push(parseInlineMarkdown(listItem[1]))
+      continue
+    }
+
+    flushList()
+    paragraphLines.push(line.trim())
+  }
+
+  if (inCodeBlock) flushCode()
+  flushParagraph()
+  flushList()
+
+  return blocks
+}
+
+function parseInlineMarkdown(text: string): InlineSegment[] {
+  const segments: InlineSegment[] = []
+  const pattern = /(\*\*([^*]+)\*\*|`([^`]+)`|\*([^*]+)\*)/g
+  let lastIndex = 0
+  let match: RegExpExecArray | null
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ type: 'text', text: text.slice(lastIndex, match.index) })
+    }
+
+    if (match[2]) segments.push({ type: 'strong', text: match[2] })
+    else if (match[3]) segments.push({ type: 'code', text: match[3] })
+    else if (match[4]) segments.push({ type: 'em', text: match[4] })
+
+    lastIndex = pattern.lastIndex
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ type: 'text', text: text.slice(lastIndex) })
+  }
+
+  return segments
 }
 
 function downloadSpec() {
@@ -226,29 +370,42 @@ function downloadSpec() {
 </script>
 
 <style scoped>
-.prose-content :deep(h3) {
+.prose-content h1 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.prose-content h2 {
+  font-size: 1.25rem;
+  font-weight: 650;
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.prose-content h3 {
   font-size: 1.1rem;
   font-weight: 600;
   margin-top: 1.5rem;
   margin-bottom: 0.5rem;
 }
 
-.prose-content :deep(p) {
+.prose-content p {
   margin: 0.5rem 0;
   color: var(--ui-text-muted);
 }
 
-.prose-content :deep(ul) {
+.prose-content ul {
   list-style: disc;
   padding-left: 1.5rem;
   margin: 0.5rem 0;
 }
 
-.prose-content :deep(li) {
+.prose-content li {
   margin: 0.25rem 0;
 }
 
-.prose-content :deep(code) {
+.prose-content code {
   font-family: ui-monospace, monospace;
   background: var(--ui-bg-elevated);
   padding: 0.125rem 0.25rem;
@@ -256,7 +413,19 @@ function downloadSpec() {
   font-size: 0.875em;
 }
 
-.prose-content :deep(strong) {
+.prose-content pre {
+  overflow-x: auto;
+  background: var(--ui-bg-elevated);
+  border-radius: 0.375rem;
+  padding: 1rem;
+}
+
+.prose-content pre code {
+  background: transparent;
+  padding: 0;
+}
+
+.prose-content strong {
   font-weight: 600;
 }
 </style>

--- a/infra/ansible/templates/docker-compose.yml.j2
+++ b/infra/ansible/templates/docker-compose.yml.j2
@@ -105,6 +105,8 @@ services:
     environment:
       CONTAINERS: 1
       IMAGES: 1
+      NETWORKS: 1
+      VOLUMES: 1
       POST: 1
       ALLOW_STOP: 1
       ALLOW_RESTARTS: 1

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -116,6 +116,8 @@ services:
     environment:
       CONTAINERS: 1
       IMAGES: 1
+      NETWORKS: 1
+      VOLUMES: 1
       POST: 1
       ALLOW_STOP: 1
       ALLOW_RESTARTS: 1


### PR DESCRIPTION
## Description

Fixes Watchtower updates for Compose-managed infrastructure containers by allowing the Docker socket proxy to expose the Docker network and volume API sections needed during container recreation. Also removes the existing API reference `v-html` lint warning by rendering the OpenAPI description through structured Vue nodes instead of injected HTML.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Fixes #
Relates to #

## Changes Made

- Added `NETWORKS: 1` and `VOLUMES: 1` to `socket-proxy` permissions in the production Compose file, Ansible template, and deploy workflow inline Compose.
- Replaced raw `v-html` Markdown rendering on the API reference page with a small structured Markdown renderer.
- Verified the requested checks pass locally.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed

## Additional Notes

Checks run:

- `npm run test`
- `npm run lint`
- `npm run mdlint`