### PR TITLE
Add deps.dev package metadata overlay

### DIFF
--- a/app/pages/components/[key].vue
+++ b/app/pages/components/[key].vue
@@ -163,6 +163,122 @@
             />
           </div>
         </UCard>
+
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between gap-3">
+              <h2 class="text-lg font-semibold">Package Information</h2>
+              <UBadge :color="getPackageMetadataColor(component.packageMetadata?.status)" variant="subtle">
+                {{ getPackageMetadataLabel(component.packageMetadata?.status) }}
+              </UBadge>
+            </div>
+          </template>
+
+          <div class="space-y-4">
+            <p class="text-sm text-(--ui-text-muted)">
+              Package data is provided by deps.dev. Polaris displays this third-party information for visibility and does not store package registry metadata.
+            </p>
+
+            <UAlert
+              v-if="!component.packageMetadata || component.packageMetadata.status === 'unavailable'"
+              color="neutral"
+              variant="subtle"
+              icon="i-lucide-circle-help"
+              title="No package metadata available"
+              :description="getPackageMetadataUnavailableDescription(component.packageMetadata?.reason)"
+            />
+
+            <template v-else>
+              <UAlert
+                v-if="component.packageMetadata.isDeprecated"
+                color="warning"
+                variant="subtle"
+                icon="i-lucide-triangle-alert"
+                title="Package version is deprecated"
+                :description="component.packageMetadata.deprecatedReason || 'deps.dev reports this package version as deprecated.'"
+              />
+
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Package</span>
+                  <p class="font-medium break-all">{{ component.packageMetadata.packageName || '—' }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Ecosystem</span>
+                  <p class="font-medium">{{ component.packageMetadata.system || '—' }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Current Version</span>
+                  <p class="font-medium break-all">{{ component.packageMetadata.currentVersion || '—' }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Latest Version</span>
+                  <p class="font-medium break-all">{{ component.packageMetadata.latestVersion || '—' }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Default Version</span>
+                  <p class="font-medium break-all">{{ component.packageMetadata.defaultVersion || '—' }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Published</span>
+                  <p class="font-medium">{{ component.packageMetadata.publishedAt ? formatDate(component.packageMetadata.publishedAt) : '—' }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Recent Releases</span>
+                  <p class="font-medium">{{ component.packageMetadata.recentReleases ?? '—' }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Advisories</span>
+                  <p class="font-medium">{{ component.packageMetadata.advisoryCount ?? '—' }}</p>
+                </div>
+              </div>
+
+              <div>
+                <span class="text-sm text-(--ui-text-muted)">Licenses</span>
+                <div v-if="component.packageMetadata.licenses.length > 0" class="mt-2 flex flex-wrap gap-2">
+                  <UBadge
+                    v-for="license in component.packageMetadata.licenses"
+                    :key="license"
+                    color="neutral"
+                    variant="subtle"
+                  >
+                    {{ license }}
+                  </UBadge>
+                </div>
+                <p v-else class="font-medium">—</p>
+              </div>
+
+              <div v-if="component.packageMetadata.advisories.length > 0">
+                <span class="text-sm text-(--ui-text-muted)">Advisory Links</span>
+                <div class="mt-2 flex flex-wrap gap-2">
+                  <UButton
+                    v-for="advisory in component.packageMetadata.advisories"
+                    :key="advisory.id"
+                    :to="advisory.url || undefined"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    :label="advisory.id"
+                    icon="i-lucide-shield-alert"
+                    variant="outline"
+                    color="warning"
+                    size="sm"
+                  />
+                </div>
+              </div>
+            </template>
+
+            <UButton
+              v-if="component.packageMetadata?.source.url"
+              :to="component.packageMetadata.source.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              label="View Source"
+              icon="i-lucide-external-link"
+              variant="outline"
+              size="sm"
+            />
+          </div>
+        </UCard>
       </div>
 
       <UCard v-if="component.purl || component.cpe || component.bomRef">
@@ -265,7 +381,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage } from '~~/types/api'
+import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, PackageMetadataStatus } from '~~/types/api'
 
 const route = useRoute()
 
@@ -314,6 +430,26 @@ function getEolUnknownDescription(reason?: string): string {
     fetch_failed: 'The third-party lifecycle source could not be reached.'
   }
   return descriptions[reason || ''] || 'No lifecycle data is available from the configured third-party source.'
+}
+
+function getPackageMetadataColor(status?: PackageMetadataStatus): 'success' | 'neutral' {
+  return status === 'available' ? 'success' : 'neutral'
+}
+
+function getPackageMetadataLabel(status?: PackageMetadataStatus): string {
+  return status === 'available' ? 'Available' : 'Unavailable'
+}
+
+function getPackageMetadataUnavailableDescription(reason?: string): string {
+  const descriptions: Record<string, string> = {
+    missing_purl: 'This component does not have a package URL to look up in deps.dev.',
+    malformed_purl: 'The package URL could not be parsed for deps.dev lookup.',
+    unsupported_ecosystem: 'deps.dev package metadata is not available for this package ecosystem.',
+    package_not_found: 'deps.dev did not find this package.',
+    version_not_found: 'deps.dev found the package, but not this component version.',
+    fetch_failed: 'The third-party package metadata source could not be reached.'
+  }
+  return descriptions[reason || ''] || 'No package metadata is available from the configured third-party source.'
 }
 
 function formatDate(dateString: string): string {

--- a/server/api/components/[key].get.ts
+++ b/server/api/components/[key].get.ts
@@ -1,5 +1,6 @@
 import { decodeComponentKey } from '../../../utils/component-identity'
-import { componentService, eolService } from '../../services/singletons'
+import type { PackageMetadata } from '~~/types/api'
+import { componentService, eolService, packageMetadataService } from '../../services/singletons'
 
 /**
  * @openapi
@@ -49,13 +50,36 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const eol = await eolService.getEOLStatus(component)
+  const [eol, packageMetadata] = await Promise.all([
+    eolService.getEOLStatus(component),
+    packageMetadataService.getMetadata(component).catch((): PackageMetadata => ({
+      status: 'unavailable',
+      reason: 'fetch_failed',
+      system: null,
+      packageName: null,
+      currentVersion: component.version,
+      latestVersion: null,
+      defaultVersion: null,
+      publishedAt: null,
+      isDeprecated: null,
+      deprecatedReason: null,
+      licenses: [],
+      advisoryCount: null,
+      advisories: [],
+      recentReleases: null,
+      source: {
+        name: 'deps.dev',
+        url: null
+      }
+    }))
+  ])
 
   return {
     success: true,
     data: {
       ...component,
-      eol
+      eol,
+      packageMetadata
     }
   }
 })

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -264,7 +264,8 @@ export class ComponentRepository extends BaseRepository {
           scope: system.scope ?? null,
           isDirect: system.isDirect ?? null
         })),
-      eol: null
+      eol: null,
+      packageMetadata: null
     }
   }
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -12,6 +12,7 @@ export { UserService } from './user.service'
 export { AuditLogService } from './audit-log.service'
 export { GitHubImportService } from './github-import.service'
 export { EOLService } from './eol.service'
+export { PackageMetadataService } from './package-metadata.service'
 export {
   complianceService,
   componentService,
@@ -26,7 +27,8 @@ export {
   userService,
   auditLogService,
   gitHubImportService,
-  eolService
+  eolService,
+  packageMetadataService
 } from './singletons'
 export type { ViolationResult as VersionConstraintViolationResult } from './version-constraint.service'
 export type { ViolationResult as ComplianceViolationResult } from './compliance.service'

--- a/server/services/package-metadata.service.ts
+++ b/server/services/package-metadata.service.ts
@@ -1,0 +1,294 @@
+import type { Component, PackageAdvisory, PackageMetadata, PackageMetadataUnavailableReason } from '~~/types/api'
+
+interface CacheEntry<T> {
+  expiresAt: number
+  value: T
+}
+
+interface CacheStorage {
+  getItem<T>(key: string): Promise<T | null>
+  setItem<T>(key: string, value: T): Promise<void>
+}
+
+type JsonFetcher = <T>(url: string) => Promise<T>
+
+interface DepsPackageResponse {
+  versions?: DepsVersionSummary[]
+}
+
+interface DepsVersionSummary {
+  versionKey?: {
+    version?: string
+  }
+  publishedAt?: string
+  isDefault?: boolean
+  isDeprecated?: boolean
+  deprecatedReason?: string
+}
+
+interface DepsVersionResponse {
+  publishedAt?: string
+  isDeprecated?: boolean
+  deprecatedReason?: string
+  licenses?: string[]
+  advisoryKeys?: Array<{ id?: string }>
+  links?: Array<{ label?: string; url?: string }>
+}
+
+export interface ParsedPackagePurl {
+  system: string
+  packageName: string
+  version: string | null
+}
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000
+const RECENT_RELEASE_WINDOW_MS = 365 * 24 * 60 * 60 * 1000
+const DEPS_DEV_API_BASE = 'https://api.deps.dev/v3'
+const DEPS_DEV_WEB_BASE = 'https://deps.dev'
+
+const SYSTEM_MAP: Record<string, string> = {
+  npm: 'npm',
+  pypi: 'pypi',
+  maven: 'maven',
+  cargo: 'cargo',
+  golang: 'go',
+  go: 'go'
+}
+
+export class PackageMetadataService {
+  constructor(
+    private readonly fetcher: JsonFetcher = fetchJson,
+    private readonly storageFactory: () => CacheStorage = () => useStorage('cache:api') as CacheStorage
+  ) {}
+
+  async getMetadata(component: Pick<Component, 'purl' | 'version'>): Promise<PackageMetadata> {
+    if (!component.purl) {
+      return this.unavailable('missing_purl', null, null, component.version || null)
+    }
+
+    const parsed = this.parsePurl(component.purl)
+    if (!parsed) {
+      return this.unavailable('malformed_purl', null, null, component.version || null)
+    }
+
+    if (parsed.reason) {
+      return this.unavailable(parsed.reason, null, null, parsed.version || component.version || null)
+    }
+
+    const currentVersion = parsed.version || component.version || null
+
+    let packageData: DepsPackageResponse
+    try {
+      packageData = await this.getPackage(parsed.system, parsed.packageName)
+    } catch (error) {
+      return this.unavailable(this.isNotFound(error) ? 'package_not_found' : 'fetch_failed', parsed.system, parsed.packageName, currentVersion)
+    }
+
+    try {
+      const versionData = currentVersion
+        ? await this.getVersion(parsed.system, parsed.packageName, currentVersion)
+        : null
+      return this.available(parsed.system, parsed.packageName, currentVersion, packageData, versionData)
+    } catch (error) {
+      return this.unavailable(this.isNotFound(error) ? 'version_not_found' : 'fetch_failed', parsed.system, parsed.packageName, currentVersion)
+    }
+  }
+
+  parsePurl(purl: string): (ParsedPackagePurl & { reason?: never }) | { reason: PackageMetadataUnavailableReason; version: string | null } | null {
+    const match = /^pkg:([^/]+)\/(.+)$/.exec(purl.trim())
+    if (!match) return null
+
+    const type = this.safeDecode(match[1]).toLowerCase()
+    const system = SYSTEM_MAP[type]
+    const pathWithVersion = match[2].split(/[?#]/, 1)[0]
+    if (!pathWithVersion) return null
+
+    const versionIndex = pathWithVersion.lastIndexOf('@')
+    const rawPackagePath = versionIndex > 0 ? pathWithVersion.slice(0, versionIndex) : pathWithVersion
+    const version = versionIndex > 0 ? this.safeDecode(pathWithVersion.slice(versionIndex + 1)) : null
+    const packagePath = this.safeDecode(rawPackagePath)
+
+    if (!system) return { reason: 'unsupported_ecosystem', version }
+    if (!packagePath || (versionIndex > 0 && !version)) return null
+
+    const packageName = this.toDepsPackageName(system, packagePath)
+    if (!packageName) return null
+
+    return {
+      system,
+      packageName,
+      version
+    }
+  }
+
+  private async getPackage(system: string, packageName: string): Promise<DepsPackageResponse> {
+    const key = `package-metadata:v2:package:${system}:${encodeURIComponent(packageName)}`
+    return await this.cached(key, () => this.fetcher<DepsPackageResponse>(this.packageApiUrl(system, packageName)))
+  }
+
+  private async getVersion(system: string, packageName: string, version: string): Promise<DepsVersionResponse> {
+    const key = `package-metadata:v2:version:${system}:${encodeURIComponent(packageName)}:${encodeURIComponent(version)}`
+    return await this.cached(key, () => this.fetcher<DepsVersionResponse>(this.versionApiUrl(system, packageName, version)))
+  }
+
+  private async cached<T>(key: string, producer: () => Promise<T>): Promise<T> {
+    const storage = this.storageFactory()
+    const cached = await storage.getItem<CacheEntry<T>>(key)
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value
+    }
+
+    const value = await producer()
+    await storage.setItem(key, {
+      expiresAt: Date.now() + CACHE_TTL_MS,
+      value
+    })
+    return value
+  }
+
+  private available(
+    system: string,
+    packageName: string,
+    currentVersion: string | null,
+    packageData: DepsPackageResponse,
+    versionData: DepsVersionResponse | null
+  ): PackageMetadata {
+    const versions = packageData.versions || []
+    const latest = this.latestVersion(versions)
+    const defaultVersion = versions.find(version => version.isDefault)?.versionKey?.version || null
+    const recentReleases = this.recentReleaseCount(versions)
+    const advisories = this.advisories(versionData?.advisoryKeys || [])
+
+    return {
+      status: 'available',
+      system,
+      packageName,
+      currentVersion,
+      latestVersion: latest?.versionKey?.version || null,
+      defaultVersion,
+      publishedAt: versionData?.publishedAt || versions.find(version => version.versionKey?.version === currentVersion)?.publishedAt || null,
+      isDeprecated: versionData?.isDeprecated ?? versions.find(version => version.versionKey?.version === currentVersion)?.isDeprecated ?? null,
+      deprecatedReason: versionData?.deprecatedReason || versions.find(version => version.versionKey?.version === currentVersion)?.deprecatedReason || null,
+      licenses: versionData?.licenses || [],
+      advisoryCount: advisories.length,
+      advisories,
+      recentReleases,
+      source: {
+        name: 'deps.dev',
+        url: this.webUrl(system, packageName, currentVersion)
+      }
+    }
+  }
+
+  private unavailable(
+    reason: PackageMetadataUnavailableReason,
+    system: string | null,
+    packageName: string | null,
+    currentVersion: string | null
+  ): PackageMetadata {
+    return {
+      status: 'unavailable',
+      reason,
+      system,
+      packageName,
+      currentVersion,
+      latestVersion: null,
+      defaultVersion: null,
+      publishedAt: null,
+      isDeprecated: null,
+      deprecatedReason: null,
+      licenses: [],
+      advisoryCount: null,
+      advisories: [],
+      recentReleases: null,
+      source: {
+        name: 'deps.dev',
+        url: system && packageName ? this.webUrl(system, packageName, currentVersion) : null
+      }
+    }
+  }
+
+  private latestVersion(versions: DepsVersionSummary[]): DepsVersionSummary | null {
+    return versions.reduce<DepsVersionSummary | null>((latest, version) => {
+      const publishedAt = Date.parse(version.publishedAt || '')
+      if (Number.isNaN(publishedAt)) return latest
+      if (!latest) return version
+
+      const latestPublishedAt = Date.parse(latest.publishedAt || '')
+      return Number.isNaN(latestPublishedAt) || publishedAt > latestPublishedAt ? version : latest
+    }, null)
+  }
+
+  private recentReleaseCount(versions: DepsVersionSummary[]): number {
+    const cutoff = Date.now() - RECENT_RELEASE_WINDOW_MS
+    return versions.filter((version) => {
+      const publishedAt = Date.parse(version.publishedAt || '')
+      return !Number.isNaN(publishedAt) && publishedAt >= cutoff
+    }).length
+  }
+
+  private advisories(advisoryKeys: Array<{ id?: string }>): PackageAdvisory[] {
+    return advisoryKeys
+      .map(advisory => advisory.id)
+      .filter((id): id is string => Boolean(id))
+      .map(id => ({
+        id,
+        url: `https://osv.dev/vulnerability/${encodeURIComponent(id)}`
+      }))
+  }
+
+  private toDepsPackageName(system: string, packagePath: string): string | null {
+    const parts = packagePath.split('/').filter(Boolean)
+    if (parts.length === 0) return null
+
+    if (system === 'maven') {
+      if (parts.length < 2) return null
+      return `${parts.slice(0, -1).join('.')}:${parts.at(-1)}`
+    }
+
+    return packagePath
+  }
+
+  private isNotFound(error: unknown): boolean {
+    const statusCode = typeof error === 'object' && error && 'statusCode' in error
+      ? Number((error as { statusCode?: unknown }).statusCode)
+      : null
+
+    return statusCode === 404
+  }
+
+  private packageApiUrl(system: string, packageName: string): string {
+    return `${DEPS_DEV_API_BASE}/systems/${system}/packages/${encodeURIComponent(packageName)}`
+  }
+
+  private versionApiUrl(system: string, packageName: string, version: string): string {
+    return `${this.packageApiUrl(system, packageName)}/versions/${encodeURIComponent(version)}`
+  }
+
+  private webUrl(system: string, packageName: string, version: string | null): string {
+    const packageUrl = `${DEPS_DEV_WEB_BASE}/${system}/${encodeURIComponent(packageName)}`
+    return version ? `${packageUrl}/${encodeURIComponent(version)}` : packageUrl
+  }
+
+  private safeDecode(value: string): string {
+    try {
+      return decodeURIComponent(value)
+    } catch {
+      return value
+    }
+  }
+}
+
+class FetchJsonError extends Error {
+  constructor(message: string, readonly statusCode: number) {
+    super(message)
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new FetchJsonError(`Request failed with status ${response.status}`, response.status)
+  }
+  return await response.json() as T
+}

--- a/server/services/singletons.ts
+++ b/server/services/singletons.ts
@@ -24,6 +24,7 @@ import { SourceRepositoryService } from './source-repository.service'
 import { AuditLogService } from './audit-log.service'
 import { GitHubImportService } from './github-import.service'
 import { EOLService } from './eol.service'
+import { PackageMetadataService } from './package-metadata.service'
 
 export const technologyService = new TechnologyService()
 export const teamService = new TeamService()
@@ -39,3 +40,4 @@ export const sourceRepositoryService = new SourceRepositoryService()
 export const auditLogService = new AuditLogService()
 export const gitHubImportService = new GitHubImportService()
 export const eolService = new EOLService()
+export const packageMetadataService = new PackageMetadataService()

--- a/test/server/api/component-detail.spec.ts
+++ b/test/server/api/component-detail.spec.ts
@@ -3,11 +3,12 @@ import { mockEvent } from '../../fixtures/h3-event'
 import { encodeComponentKey } from '../../../utils/component-identity'
 import handler from '../../../server/api/components/[key].get'
 import eolHandler from '../../../server/api/components/eol.get'
-import { componentService, eolService } from '../../../server/services/singletons'
+import { componentService, eolService, packageMetadataService } from '../../../server/services/singletons'
 
 vi.mock('../../../server/services/singletons', () => ({
   componentService: { findByIdentity: vi.fn() },
-  eolService: { getEOLStatus: vi.fn() }
+  eolService: { getEOLStatus: vi.fn() },
+  packageMetadataService: { getMetadata: vi.fn() }
 }))
 
 const mockComponent = {
@@ -36,7 +37,8 @@ const mockComponent = {
   technologyName: 'Node.js',
   systemCount: 1,
   systems: [{ name: 'catalog', scope: 'runtime', isDirect: true }],
-  eol: null
+  eol: null,
+  packageMetadata: null
 }
 
 const mockEol = {
@@ -52,25 +54,45 @@ const mockEol = {
   source: { name: 'endoflife.date' as const, url: 'https://endoflife.date/nodejs' }
 }
 
+const mockPackageMetadata = {
+  status: 'available' as const,
+  system: 'npm',
+  packageName: 'node',
+  currentVersion: '24.16.0',
+  latestVersion: '24.17.0',
+  defaultVersion: '24.17.0',
+  publishedAt: '2026-05-21T00:00:00Z',
+  isDeprecated: false,
+  deprecatedReason: null,
+  licenses: ['MIT'],
+  advisoryCount: 0,
+  advisories: [],
+  recentReleases: 3,
+  source: { name: 'deps.dev' as const, url: 'https://deps.dev/npm/node/24.16.0' }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
 describe('GET /api/components/{key}', () => {
-  it('returns component details with read-only EOL visibility', async () => {
+  it('returns component details with read-only enrichment', async () => {
     vi.mocked(componentService.findByIdentity).mockResolvedValue(mockComponent)
     vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
+    vi.mocked(packageMetadataService.getMetadata).mockResolvedValue(mockPackageMetadata)
 
     const key = encodeComponentKey(mockComponent)
     const result = await handler(mockEvent({ params: { key } }))
 
     expect(componentService.findByIdentity).toHaveBeenCalledWith({ purl: 'pkg:npm/node@24.16.0' })
     expect(eolService.getEOLStatus).toHaveBeenCalledWith(mockComponent)
+    expect(packageMetadataService.getMetadata).toHaveBeenCalledWith(mockComponent)
     expect(result).toMatchObject({
       success: true,
       data: {
         name: 'node',
-        eol: mockEol
+        eol: mockEol,
+        packageMetadata: mockPackageMetadata
       }
     })
   })
@@ -78,6 +100,28 @@ describe('GET /api/components/{key}', () => {
   it('rejects malformed component keys', async () => {
     await expect(handler(mockEvent({ params: { key: 'invalid' } }))).rejects.toMatchObject({
       statusCode: 400
+    })
+  })
+
+  it('does not fail component details when package metadata enrichment throws', async () => {
+    vi.mocked(componentService.findByIdentity).mockResolvedValue(mockComponent)
+    vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
+    vi.mocked(packageMetadataService.getMetadata).mockRejectedValue(new Error('deps.dev unavailable'))
+
+    const key = encodeComponentKey(mockComponent)
+    const result = await handler(mockEvent({ params: { key } }))
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        name: 'node',
+        eol: mockEol,
+        packageMetadata: {
+          status: 'unavailable',
+          reason: 'fetch_failed',
+          currentVersion: '24.16.0'
+        }
+      }
     })
   })
 })

--- a/test/server/services/package-metadata.service.spec.ts
+++ b/test/server/services/package-metadata.service.spec.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { PackageMetadataService } from '../../../server/services/package-metadata.service'
+
+function createStorage() {
+  const cache = new Map<string, unknown>()
+  return {
+    getItem: vi.fn(async (key: string) => cache.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value)
+    })
+  }
+}
+
+const packageResponse = {
+  versions: [
+    {
+      versionKey: { version: '1.0.0' },
+      publishedAt: '2024-01-01T00:00:00Z',
+      isDefault: false,
+      isDeprecated: false,
+      deprecatedReason: ''
+    },
+    {
+      versionKey: { version: '1.2.0' },
+      publishedAt: '2025-09-23T12:05:06Z',
+      isDefault: false,
+      isDeprecated: false,
+      deprecatedReason: ''
+    },
+    {
+      versionKey: { version: '2.0.0' },
+      publishedAt: '2026-05-21T00:00:00Z',
+      isDefault: true,
+      isDeprecated: false,
+      deprecatedReason: ''
+    }
+  ]
+}
+
+const versionResponse = {
+  publishedAt: '2025-09-23T12:05:06Z',
+  isDeprecated: true,
+  deprecatedReason: 'Use 2.x instead.',
+  licenses: ['MIT', 'Apache-2.0'],
+  advisoryKeys: [{ id: 'GHSA-29mw-wpgm-hmr9' }, { id: 'GHSA-f23m-r3pf-42rh' }]
+}
+
+function notFound() {
+  return Object.assign(new Error('not found'), { statusCode: 404 })
+}
+
+describe('PackageMetadataService', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-06-02T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('parses supported package URLs into deps.dev system and package names', () => {
+    const service = new PackageMetadataService()
+
+    expect(service.parsePurl('pkg:npm/react@18.2.0')).toEqual({
+      system: 'npm',
+      packageName: 'react',
+      version: '18.2.0'
+    })
+    expect(service.parsePurl('pkg:npm/@nuxt/ui@4.0.0')).toEqual({
+      system: 'npm',
+      packageName: '@nuxt/ui',
+      version: '4.0.0'
+    })
+    expect(service.parsePurl('pkg:pypi/Django@5.0.1')).toEqual({
+      system: 'pypi',
+      packageName: 'Django',
+      version: '5.0.1'
+    })
+    expect(service.parsePurl('pkg:maven/org.springframework/spring-core@6.1.0')).toEqual({
+      system: 'maven',
+      packageName: 'org.springframework:spring-core',
+      version: '6.1.0'
+    })
+    expect(service.parsePurl('pkg:cargo/serde@1.0.203')).toEqual({
+      system: 'cargo',
+      packageName: 'serde',
+      version: '1.0.203'
+    })
+    expect(service.parsePurl('pkg:golang/github.com/gorilla/mux@v1.8.1')).toEqual({
+      system: 'go',
+      packageName: 'github.com/gorilla/mux',
+      version: 'v1.8.1'
+    })
+  })
+
+  it('returns parser failures for unsupported and malformed purls', () => {
+    const service = new PackageMetadataService()
+
+    expect(service.parsePurl('pkg:gem/rails@7.1.0')).toEqual({
+      reason: 'unsupported_ecosystem',
+      version: '7.1.0'
+    })
+    expect(service.parsePurl('not-a-purl')).toBeNull()
+    expect(service.parsePurl('pkg:maven/spring-core@6.1.0')).toBeNull()
+  })
+
+  it('fetches package and version data and maps a stable Polaris response', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(packageResponse)
+      .mockResolvedValueOnce(versionResponse)
+    const service = new PackageMetadataService(fetcher as never, () => storage)
+
+    const metadata = await service.getMetadata({
+      purl: 'pkg:npm/@nuxt/ui@1.2.0',
+      version: '1.2.0'
+    })
+
+    expect(fetcher).toHaveBeenNthCalledWith(1, 'https://api.deps.dev/v3/systems/npm/packages/%40nuxt%2Fui')
+    expect(fetcher).toHaveBeenNthCalledWith(2, 'https://api.deps.dev/v3/systems/npm/packages/%40nuxt%2Fui/versions/1.2.0')
+    expect(metadata).toMatchObject({
+      status: 'available',
+      system: 'npm',
+      packageName: '@nuxt/ui',
+      currentVersion: '1.2.0',
+      latestVersion: '2.0.0',
+      defaultVersion: '2.0.0',
+      publishedAt: '2025-09-23T12:05:06Z',
+      isDeprecated: true,
+      deprecatedReason: 'Use 2.x instead.',
+      licenses: ['MIT', 'Apache-2.0'],
+      advisoryCount: 2,
+      recentReleases: 2,
+      source: {
+        name: 'deps.dev',
+        url: 'https://deps.dev/npm/%40nuxt%2Fui/1.2.0'
+      }
+    })
+    expect(metadata.advisories).toEqual([
+      { id: 'GHSA-29mw-wpgm-hmr9', url: 'https://osv.dev/vulnerability/GHSA-29mw-wpgm-hmr9' },
+      { id: 'GHSA-f23m-r3pf-42rh', url: 'https://osv.dev/vulnerability/GHSA-f23m-r3pf-42rh' }
+    ])
+  })
+
+  it('caches package and version responses for repeated lookups', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(packageResponse)
+      .mockResolvedValueOnce(versionResponse)
+    const service = new PackageMetadataService(fetcher as never, () => storage)
+
+    await service.getMetadata({ purl: 'pkg:npm/react@1.2.0', version: '1.2.0' })
+    await service.getMetadata({ purl: 'pkg:npm/react@1.2.0', version: '1.2.0' })
+
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it('builds canonical deps.dev web links for ordinary npm packages', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(packageResponse)
+      .mockResolvedValueOnce({ ...versionResponse, isDeprecated: false, deprecatedReason: '' })
+    const service = new PackageMetadataService(fetcher as never, () => storage)
+
+    const metadata = await service.getMetadata({
+      purl: 'pkg:npm/nuxt@4.4.6',
+      version: '4.4.6'
+    })
+
+    expect(metadata).toMatchObject({
+      status: 'available',
+      system: 'npm',
+      packageName: 'nuxt',
+      currentVersion: '4.4.6',
+      source: {
+        name: 'deps.dev',
+        url: 'https://deps.dev/npm/nuxt/4.4.6'
+      }
+    })
+    expect(storage.setItem).toHaveBeenNthCalledWith(1, 'package-metadata:v2:package:npm:nuxt', expect.any(Object))
+    expect(storage.setItem).toHaveBeenNthCalledWith(2, 'package-metadata:v2:version:npm:nuxt:4.4.6', expect.any(Object))
+  })
+
+  it('returns unavailable when package metadata cannot be looked up', async () => {
+    const storage = createStorage()
+    const service = new PackageMetadataService(vi.fn(async () => {
+      throw notFound()
+    }) as never, () => storage)
+
+    const metadata = await service.getMetadata({ purl: 'pkg:npm/missing@1.0.0', version: '1.0.0' })
+
+    expect(metadata).toMatchObject({
+      status: 'unavailable',
+      reason: 'package_not_found',
+      system: 'npm',
+      packageName: 'missing',
+      currentVersion: '1.0.0'
+    })
+  })
+
+  it('returns unavailable when selected version metadata cannot be looked up', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(packageResponse)
+      .mockRejectedValueOnce(notFound())
+    const service = new PackageMetadataService(fetcher as never, () => storage)
+
+    const metadata = await service.getMetadata({ purl: 'pkg:npm/react@9.9.9', version: '9.9.9' })
+
+    expect(metadata).toMatchObject({
+      status: 'unavailable',
+      reason: 'version_not_found',
+      system: 'npm',
+      packageName: 'react',
+      currentVersion: '9.9.9'
+    })
+  })
+
+  it('returns unavailable for missing purl, unsupported ecosystem, and upstream failures', async () => {
+    const storage = createStorage()
+    const service = new PackageMetadataService(vi.fn(async () => {
+      throw new Error('network unavailable')
+    }) as never, () => storage)
+
+    await expect(service.getMetadata({ purl: null, version: '1.0.0' })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'missing_purl'
+    })
+    await expect(service.getMetadata({ purl: 'pkg:gem/rails@7.1.0', version: '7.1.0' })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'unsupported_ecosystem'
+    })
+    await expect(service.getMetadata({ purl: 'pkg:npm/react@18.2.0', version: '18.2.0' })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'fetch_failed'
+    })
+  })
+})

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -114,9 +114,46 @@ export interface EOLStatus {
   reason?: 'no_mapping' | 'no_data' | 'no_matching_cycle' | 'fetch_failed'
 }
 
+export type PackageMetadataStatus = 'available' | 'unavailable'
+
+export type PackageMetadataUnavailableReason =
+  | 'missing_purl'
+  | 'malformed_purl'
+  | 'unsupported_ecosystem'
+  | 'package_not_found'
+  | 'version_not_found'
+  | 'fetch_failed'
+
+export interface PackageAdvisory {
+  id: string
+  url: string | null
+}
+
+export interface PackageMetadata {
+  status: PackageMetadataStatus
+  reason?: PackageMetadataUnavailableReason
+  system: string | null
+  packageName: string | null
+  currentVersion: string | null
+  latestVersion: string | null
+  defaultVersion: string | null
+  publishedAt: string | null
+  isDeprecated: boolean | null
+  deprecatedReason: string | null
+  licenses: string[]
+  advisoryCount: number | null
+  advisories: PackageAdvisory[]
+  recentReleases: number | null
+  source: {
+    name: 'deps.dev'
+    url: string | null
+  }
+}
+
 export interface ComponentDetail extends Component {
   systems: ComponentSystemUsage[]
   eol: EOLStatus | null
+  packageMetadata: PackageMetadata | null
 }
 
 export type TechnologyDomain =


### PR DESCRIPTION
## Summary

- Add a deps.dev-backed `PackageMetadataService` with 24-hour Nitro `cache:api` storage and tested PURL parsing for supported ecosystems.
- Return `packageMetadata` inline from component detail responses with typed unavailable states instead of failing the whole page.
- Add a component detail Package Information card showing version context, recent releases, deprecation, licenses, advisories, and source links.
- Fix deps.dev web links to the canonical `/{version}` shape and avoid filesystem cache key collisions between package and version entries.

## Verification

- `npm test -- --run test/server/services/package-metadata.service.spec.ts test/server/api/component-detail.spec.ts`
- `npm run lint`
- `NODE_OPTIONS=--max-old-space-size=4096 npm run build`

## Notes

The standard `npm run build` reached Node's default heap limit during Nitro packaging in this workspace. Re-running the same build with a larger Node heap completed successfully.