### PR TITLE
Add direct dependencies to component detail API

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Polaris API",
-    "version": "0.5.46",
+    "version": "0.5.49",
     "description": "# Polaris Technology Catalog API\n\nThe Polaris API provides programmatic access to the technology catalog, enabling automation, integration, and custom tooling.\n\n## Key Features\n\n- **RESTful Design** - Resource-based URLs with proper HTTP methods\n- **Comprehensive Coverage** - Systems, Teams, Technologies, Components, Policies, and more\n- **Developer-Friendly** - Clear error messages and consistent response structure\n\n## Authentication\n\nMost endpoints require authentication using session-based authentication integrated with the web application.\n\n**Authorization Levels:**\n- **Public** - No authentication required\n- **Authenticated** - Valid user session required  \n- **Team Member** - User must belong to a team\n- **Team Owner** - User must belong to team that owns the resource\n- **Superuser** - User must have superuser role\n\n## Response Format\n\nAll successful responses follow this structure:\n```json\n{\n  \"success\": true,\n  \"data\": [...],\n  \"count\": 10\n}\n```\n\nAll errors follow this structure:\n```json\n{\n  \"statusCode\": 404,\n  \"message\": \"Resource 'example' not found\"\n}\n```\n\n## Richardson Maturity Model\n\nThis API implements **RMM Level 2** with proper use of HTTP methods and status codes.",
     "license": {
       "name": "MIT",
@@ -214,6 +214,60 @@
             "type": "string",
             "description": "Reference URL",
             "example": "https://github.com/facebook/react"
+          }
+        }
+      },
+      "ComponentDirectDependency": {
+        "type": "object",
+        "required": [
+          "name",
+          "version",
+          "isDirect"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Direct dependency component name"
+          },
+          "group": {
+            "type": "string",
+            "nullable": true,
+            "description": "Package group or scope"
+          },
+          "version": {
+            "type": "string",
+            "description": "Direct dependency component version"
+          },
+          "packageManager": {
+            "type": "string",
+            "nullable": true,
+            "description": "Package manager"
+          },
+          "purl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Package URL"
+          },
+          "scope": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "required",
+              "optional",
+              "excluded",
+              "dev",
+              "test",
+              "runtime",
+              "provided"
+            ],
+            "description": "Dependency scope when unambiguous across known system usage"
+          },
+          "isDirect": {
+            "type": "boolean",
+            "enum": [
+              true
+            ],
+            "description": "Always true for direct dependencies returned by component detail"
           }
         }
       },
@@ -4163,7 +4217,77 @@
         ],
         "responses": {
           "200": {
-            "description": "Component details retrieved successfully"
+            "description": "Component details retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiSingleResourceResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "allOf": [
+                            {
+                              "$ref": "#/components/schemas/Component"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "systems": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string"
+                                      },
+                                      "scope": {
+                                        "type": "string",
+                                        "nullable": true,
+                                        "enum": [
+                                          "required",
+                                          "optional",
+                                          "excluded",
+                                          "dev",
+                                          "test",
+                                          "runtime",
+                                          "provided"
+                                        ]
+                                      },
+                                      "isDirect": {
+                                        "type": "boolean",
+                                        "nullable": true
+                                      }
+                                    }
+                                  }
+                                },
+                                "directDependencies": {
+                                  "type": "array",
+                                  "items": {
+                                    "$ref": "#/components/schemas/ComponentDirectDependency"
+                                  }
+                                },
+                                "eol": {
+                                  "type": "object",
+                                  "nullable": true
+                                },
+                                "packageMetadata": {
+                                  "type": "object",
+                                  "nullable": true
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
           },
           "400": {
             "description": "Component key is missing or invalid"

--- a/server/api/components/[key].get.ts
+++ b/server/api/components/[key].get.ts
@@ -20,6 +20,42 @@ import { componentService, eolService, packageMetadataService } from '../../serv
  *     responses:
  *       200:
  *         description: Component details retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiSingleResourceResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       allOf:
+ *                         - $ref: '#/components/schemas/Component'
+ *                         - type: object
+ *                           properties:
+ *                             systems:
+ *                               type: array
+ *                               items:
+ *                                 type: object
+ *                                 properties:
+ *                                   name:
+ *                                     type: string
+ *                                   scope:
+ *                                     type: string
+ *                                     nullable: true
+ *                                     enum: [required, optional, excluded, dev, test, runtime, provided]
+ *                                   isDirect:
+ *                                     type: boolean
+ *                                     nullable: true
+ *                             directDependencies:
+ *                               type: array
+ *                               items:
+ *                                 $ref: '#/components/schemas/ComponentDirectDependency'
+ *                             eol:
+ *                               type: object
+ *                               nullable: true
+ *                             packageMetadata:
+ *                               type: object
+ *                               nullable: true
  *       400:
  *         description: Component key is missing or invalid
  *       404:

--- a/server/database/queries/components/find-by-identity.cypher
+++ b/server/database/queries/components/find-by-identity.cypher
@@ -19,6 +19,23 @@ WITH c, tech,
      collect(DISTINCT {algorithm: h.algorithm, value: h.value}) as hashes,
      collect(DISTINCT {id: l.id, name: l.name, url: l.url, text: l.text}) as licenses,
      collect(DISTINCT {type: ref.type, url: ref.url}) as externalReferences
+OPTIONAL MATCH (c)-[:DEPENDS_ON]->(dep:Component)
+OPTIONAL MATCH (dep)<-[depUse:USES]-(:System)
+WITH c, tech, systems, hashes, licenses, externalReferences, dep,
+     [scope IN collect(DISTINCT depUse.scope) WHERE scope IS NOT NULL] as dependencyScopes
+WITH c, tech, systems, hashes, licenses, externalReferences,
+     collect(DISTINCT CASE
+       WHEN dep.name IS NULL THEN null
+       ELSE {
+         name: dep.name,
+         group: dep.`group`,
+         version: dep.version,
+         packageManager: dep.packageManager,
+         purl: dep.purl,
+         scope: CASE WHEN size(dependencyScopes) = 1 THEN head(dependencyScopes) ELSE null END,
+         isDirect: true
+       }
+     END) as directDependencies
 RETURN c.name as name,
        c.version as version,
        c.packageManager as packageManager,
@@ -43,5 +60,6 @@ RETURN c.name as name,
        c.modifiedDate as modifiedDate,
        tech.name as technologyName,
        size([system IN systems WHERE system.name IS NOT NULL | system]) as systemCount,
-       [system IN systems WHERE system.name IS NOT NULL | system] as systems
+       [system IN systems WHERE system.name IS NOT NULL | system] as systems,
+       [dep IN directDependencies WHERE dep IS NOT NULL | dep] as directDependencies
 LIMIT 1

--- a/server/database/queries/components/find-by-identity.cypher
+++ b/server/database/queries/components/find-by-identity.cypher
@@ -20,7 +20,7 @@ WITH c, tech,
      collect(DISTINCT {id: l.id, name: l.name, url: l.url, text: l.text}) as licenses,
      collect(DISTINCT {type: ref.type, url: ref.url}) as externalReferences
 OPTIONAL MATCH (c)-[:DEPENDS_ON]->(dep:Component)
-OPTIONAL MATCH (dep)<-[depUse:USES]-(:System)
+OPTIONAL MATCH (dep)<-[depUse:USES {isDirect: true}]-(:System)
 WITH c, tech, systems, hashes, licenses, externalReferences, dep,
      [scope IN collect(DISTINCT depUse.scope) WHERE scope IS NOT NULL] as dependencyScopes
 WITH c, tech, systems, hashes, licenses, externalReferences,

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -212,6 +212,46 @@ This API implements **RMM Level 2** with proper use of HTTP methods and status c
             }
           }
         },
+        ComponentDirectDependency: {
+          type: 'object',
+          required: ['name', 'version', 'isDirect'],
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Direct dependency component name'
+            },
+            group: {
+              type: 'string',
+              nullable: true,
+              description: 'Package group or scope'
+            },
+            version: {
+              type: 'string',
+              description: 'Direct dependency component version'
+            },
+            packageManager: {
+              type: 'string',
+              nullable: true,
+              description: 'Package manager'
+            },
+            purl: {
+              type: 'string',
+              nullable: true,
+              description: 'Package URL'
+            },
+            scope: {
+              type: 'string',
+              nullable: true,
+              enum: ['required', 'optional', 'excluded', 'dev', 'test', 'runtime', 'provided'],
+              description: 'Dependency scope when unambiguous across known system usage'
+            },
+            isDirect: {
+              type: 'boolean',
+              enum: [true],
+              description: 'Always true for direct dependencies returned by component detail'
+            }
+          }
+        },
         Component: {
           type: 'object',
           required: ['name', 'version'],

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -281,7 +281,7 @@ export class ComponentRepository extends BaseRepository {
           packageManager: dependency.packageManager ?? null,
           purl: dependency.purl ?? null,
           scope: dependency.scope ?? null,
-          isDirect: dependency.isDirect ?? true
+          isDirect: true
         })),
       eol: null,
       packageMetadata: null

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -265,7 +265,7 @@ export class ComponentRepository extends BaseRepository {
           isDirect: system.isDirect ?? null
         })),
       directDependencies: (record.get('directDependencies') ?? [])
-        .filter((dependency: { name?: string }) => dependency.name)
+        .filter((dependency: { name?: string; version?: string | null }) => dependency.name && dependency.version)
         .map((dependency: {
           name: string
           group?: string | null

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -264,6 +264,25 @@ export class ComponentRepository extends BaseRepository {
           scope: system.scope ?? null,
           isDirect: system.isDirect ?? null
         })),
+      directDependencies: (record.get('directDependencies') ?? [])
+        .filter((dependency: { name?: string }) => dependency.name)
+        .map((dependency: {
+          name: string
+          group?: string | null
+          version: string
+          packageManager?: string | null
+          purl?: string | null
+          scope?: string | null
+          isDirect?: boolean
+        }) => ({
+          name: dependency.name,
+          group: dependency.group ?? null,
+          version: dependency.version,
+          packageManager: dependency.packageManager ?? null,
+          purl: dependency.purl ?? null,
+          scope: dependency.scope ?? null,
+          isDirect: dependency.isDirect ?? true
+        })),
       eol: null,
       packageMetadata: null
     }

--- a/test/server/api/component-detail.spec.ts
+++ b/test/server/api/component-detail.spec.ts
@@ -37,6 +37,17 @@ const mockComponent = {
   technologyName: 'Node.js',
   systemCount: 1,
   systems: [{ name: 'catalog', scope: 'runtime', isDirect: true }],
+  directDependencies: [
+    {
+      name: 'semver',
+      group: null,
+      version: '7.6.3',
+      packageManager: 'npm',
+      purl: 'pkg:npm/semver@7.6.3',
+      scope: 'runtime',
+      isDirect: true
+    }
+  ],
   eol: null,
   packageMetadata: null
 }
@@ -91,6 +102,7 @@ describe('GET /api/components/{key}', () => {
       success: true,
       data: {
         name: 'node',
+        directDependencies: mockComponent.directDependencies,
         eol: mockEol,
         packageMetadata: mockPackageMetadata
       }

--- a/test/server/repositories/component.repository.spec.ts
+++ b/test/server/repositories/component.repository.spec.ts
@@ -222,6 +222,7 @@ describe('ComponentRepository', () => {
         type: 'library',
         description: 'Component fetched by purl',
         systems: [],
+        directDependencies: [],
         eol: null
       })
     })
@@ -304,6 +305,76 @@ describe('ComponentRepository', () => {
       ])
       expect(component!.externalReferences).toEqual([
         { type: 'vcs', url: 'https://example.com/repo.git' }
+      ])
+    })
+
+    it('should include direct component dependencies without duplicates', async () => {
+      if (!ctx.neo4jAvailable) return
+      const purl = `pkg:npm/${PREFIX}detail-root@1.0.0`
+      await seed(ctx.driver, `
+        CREATE (root:Component {
+          name: $name,
+          version: '1.0.0',
+          packageManager: 'npm',
+          purl: $purl
+        })
+        CREATE (runtimeDep:Component {
+          name: $runtimeDep,
+          version: '2.0.0',
+          packageManager: 'npm',
+          purl: $runtimePurl
+        })
+        CREATE (ambiguousDep:Component {
+          name: $ambiguousDep,
+          version: '3.0.0',
+          packageManager: 'npm',
+          purl: $ambiguousPurl
+        })
+        CREATE (root)-[:DEPENDS_ON]->(runtimeDep)
+        CREATE (root)-[:DEPENDS_ON]->(ambiguousDep)
+        CREATE (runtimeSystemA:System { name: $runtimeSystemA })
+        CREATE (runtimeSystemB:System { name: $runtimeSystemB })
+        CREATE (ambiguousSystemA:System { name: $ambiguousSystemA })
+        CREATE (ambiguousSystemB:System { name: $ambiguousSystemB })
+        CREATE (runtimeSystemA)-[:USES { scope: 'runtime', isDirect: true }]->(runtimeDep)
+        CREATE (runtimeSystemB)-[:USES { scope: 'runtime', isDirect: true }]->(runtimeDep)
+        CREATE (ambiguousSystemA)-[:USES { scope: 'runtime', isDirect: true }]->(ambiguousDep)
+        CREATE (ambiguousSystemB)-[:USES { scope: 'dev', isDirect: true }]->(ambiguousDep)
+      `, {
+        name: `${PREFIX}detail-root`,
+        purl,
+        runtimeDep: `${PREFIX}runtime-dep`,
+        runtimePurl: `pkg:npm/${PREFIX}runtime-dep@2.0.0`,
+        ambiguousDep: `${PREFIX}ambiguous-dep`,
+        ambiguousPurl: `pkg:npm/${PREFIX}ambiguous-dep@3.0.0`,
+        runtimeSystemA: `${PREFIX}runtime-system-a`,
+        runtimeSystemB: `${PREFIX}runtime-system-b`,
+        ambiguousSystemA: `${PREFIX}ambiguous-system-a`,
+        ambiguousSystemB: `${PREFIX}ambiguous-system-b`
+      })
+
+      const component = await repo.findByIdentity({ purl })
+
+      expect(component).toBeDefined()
+      expect(component!.directDependencies.toSorted((a, b) => a.name.localeCompare(b.name))).toEqual([
+        {
+          name: `${PREFIX}ambiguous-dep`,
+          group: null,
+          version: '3.0.0',
+          packageManager: 'npm',
+          purl: `pkg:npm/${PREFIX}ambiguous-dep@3.0.0`,
+          scope: null,
+          isDirect: true
+        },
+        {
+          name: `${PREFIX}runtime-dep`,
+          group: null,
+          version: '2.0.0',
+          packageManager: 'npm',
+          purl: `pkg:npm/${PREFIX}runtime-dep@2.0.0`,
+          scope: 'runtime',
+          isDirect: true
+        }
       ])
     })
 

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -95,6 +95,16 @@ export interface ComponentSystemUsage {
   isDirect: boolean | null
 }
 
+export interface ComponentDirectDependency {
+  name: string
+  group: string | null
+  version: string
+  packageManager: string | null
+  purl: string | null
+  scope: DependencyScope | null
+  isDirect: boolean
+}
+
 export type EOLStatusValue = 'active' | 'approaching_eol' | 'unsupported' | 'unknown'
 
 export interface EOLStatus {
@@ -152,6 +162,7 @@ export interface PackageMetadata {
 
 export interface ComponentDetail extends Component {
   systems: ComponentSystemUsage[]
+  directDependencies: ComponentDirectDependency[]
   eol: EOLStatus | null
   packageMetadata: PackageMetadata | null
 }


### PR DESCRIPTION
## Description

Adds direct component dependencies to the component detail API response by exposing outgoing `DEPENDS_ON` relationships from Neo4j as `directDependencies` on `GET /api/components/{key}`.

Scope is returned only when known `USES.scope` values for the dependency are unambiguous across system usage; otherwise it is returned as `null` to avoid inventing system-specific context on a component-global endpoint.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Fixes #615
Relates to #615

## Changes Made

- Added `directDependencies` to the component detail repository query and mapper.
- Added public API typing and OpenAPI schema/docs for direct dependencies.
- Added repository and API tests covering direct dependencies, empty arrays, deduplication, and enrichment preservation.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

Verification run locally:

- `npm run test`
- `npm run lint`
- `npm run mdlint`
- `npm run docs:api`