### PR TITLE
Add component dependency tree API

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -271,6 +271,115 @@
           }
         }
       },
+      "DependencyNode": {
+        "type": "object",
+        "required": [
+          "name",
+          "version",
+          "isDirect",
+          "depth"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Dependency component name"
+          },
+          "group": {
+            "type": "string",
+            "nullable": true,
+            "description": "Package group or scope"
+          },
+          "version": {
+            "type": "string",
+            "description": "Dependency component version"
+          },
+          "packageManager": {
+            "type": "string",
+            "nullable": true,
+            "description": "Package manager"
+          },
+          "purl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Package URL"
+          },
+          "scope": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "required",
+              "optional",
+              "excluded",
+              "dev",
+              "test",
+              "runtime",
+              "provided"
+            ],
+            "description": "Dependency scope from the system USES edge when a system filter is active"
+          },
+          "isDirect": {
+            "type": "boolean",
+            "description": "True when this dependency is a direct child of the queried component"
+          },
+          "depth": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Depth from the queried component"
+          },
+          "children": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DependencyNode"
+            }
+          },
+          "isCircular": {
+            "type": "boolean",
+            "description": "True when this node repeats an ancestor in the dependency path"
+          }
+        }
+      },
+      "DependencyTreeResponse": {
+        "type": "object",
+        "required": [
+          "componentKey",
+          "dependencies",
+          "totalCount",
+          "hasCircularDependencies",
+          "truncated",
+          "maxDepth"
+        ],
+        "properties": {
+          "componentKey": {
+            "type": "string",
+            "description": "Encoded component identity key"
+          },
+          "dependencies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DependencyNode"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Unique dependency nodes returned"
+          },
+          "hasCircularDependencies": {
+            "type": "boolean",
+            "description": "Whether any returned path contains a circular dependency"
+          },
+          "truncated": {
+            "type": "boolean",
+            "description": "Whether the result was truncated by the node limit"
+          },
+          "maxDepth": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "description": "Maximum traversal depth used"
+          }
+        }
+      },
       "Component": {
         "type": "object",
         "required": [
@@ -4294,6 +4403,94 @@
           },
           "404": {
             "description": "Component not found"
+          }
+        }
+      }
+    },
+    "/components/{key}/dependencies": {
+      "get": {
+        "tags": [
+          "Components"
+        ],
+        "summary": "Get component dependency tree",
+        "description": "Retrieves direct and transitive dependencies for a component. Scope filtering requires a system context because dependency scope is stored on System USES Component relationships.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Encoded component identity from the components list."
+          },
+          {
+            "in": "query",
+            "name": "system",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Restrict dependencies to components used by this system."
+          },
+          {
+            "in": "query",
+            "name": "scope",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated dependency scopes. Requires system."
+          },
+          {
+            "in": "query",
+            "name": "maxDepth",
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 10
+            },
+            "description": "Maximum DEPENDS_ON traversal depth."
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 500,
+              "minimum": 1,
+              "maximum": 500
+            },
+            "description": "Maximum unique dependency nodes returned."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dependency tree retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiSingleResourceResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/DependencyTreeResponse"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Component key or query parameters are invalid"
+          },
+          "404": {
+            "description": "Component or system not found"
           }
         }
       }

--- a/server/api/components/[key]/dependencies.get.ts
+++ b/server/api/components/[key]/dependencies.get.ts
@@ -1,0 +1,195 @@
+import { decodeComponentKey } from '../../../../utils/component-identity'
+import type { DependencyScope, DependencyTreeResponse } from '~~/types/api'
+import { componentService } from '../../../services/singletons'
+
+const ALLOWED_SCOPES = new Set<DependencyScope>([
+  'required',
+  'optional',
+  'excluded',
+  'dev',
+  'test',
+  'runtime',
+  'provided'
+])
+
+const DEFAULT_MAX_DEPTH = 10
+const MAX_DEPTH = 10
+const DEFAULT_LIMIT = 500
+const MAX_LIMIT = 500
+
+/**
+ * @openapi
+ * /components/{key}/dependencies:
+ *   get:
+ *     tags:
+ *       - Components
+ *     summary: Get component dependency tree
+ *     description: Retrieves direct and transitive dependencies for a component. Scope filtering requires a system context because dependency scope is stored on System USES Component relationships.
+ *     parameters:
+ *       - in: path
+ *         name: key
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Encoded component identity from the components list.
+ *       - in: query
+ *         name: system
+ *         schema:
+ *           type: string
+ *         description: Restrict dependencies to components used by this system.
+ *       - in: query
+ *         name: scope
+ *         schema:
+ *           type: string
+ *         description: Comma-separated dependency scopes. Requires system.
+ *       - in: query
+ *         name: maxDepth
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *           minimum: 1
+ *           maximum: 10
+ *         description: Maximum DEPENDS_ON traversal depth.
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 500
+ *           minimum: 1
+ *           maximum: 500
+ *         description: Maximum unique dependency nodes returned.
+ *     responses:
+ *       200:
+ *         description: Dependency tree retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiSingleResourceResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/DependencyTreeResponse'
+ *       400:
+ *         description: Component key or query parameters are invalid
+ *       404:
+ *         description: Component or system not found
+ */
+export default defineEventHandler(async (event) => {
+  const key = getRouterParam(event, 'key')
+  if (!key) {
+    throw createError({
+      statusCode: 400,
+      message: 'Component key is required'
+    })
+  }
+
+  const identity = decodeComponentKey(key)
+  if (!identity) {
+    throw createError({
+      statusCode: 400,
+      message: 'Component key is invalid'
+    })
+  }
+
+  const query = getQuery(event)
+  const system = typeof query.system === 'string' && query.system.trim()
+    ? query.system.trim()
+    : undefined
+  const scopes = parseScopes(query.scope)
+
+  if (scopes.length > 0 && !system) {
+    throw createError({
+      statusCode: 400,
+      message: 'scope filter requires system query parameter'
+    })
+  }
+
+  const maxDepth = parseBoundedInteger(query.maxDepth, 'maxDepth', DEFAULT_MAX_DEPTH, MAX_DEPTH)
+  const limit = parseBoundedInteger(query.limit, 'limit', DEFAULT_LIMIT, MAX_LIMIT)
+
+  const dependencyTree = await componentService.findDependencies(identity, {
+    system,
+    scopes,
+    maxDepth,
+    limit
+  })
+
+  if (!dependencyTree) {
+    throw createError({
+      statusCode: 404,
+      message: 'Component not found'
+    })
+  }
+
+  if (!dependencyTree.systemExists) {
+    throw createError({
+      statusCode: 404,
+      message: `System '${system}' not found`
+    })
+  }
+
+  const data: DependencyTreeResponse = {
+    componentKey: key,
+    dependencies: dependencyTree.dependencies,
+    totalCount: dependencyTree.totalCount,
+    hasCircularDependencies: dependencyTree.hasCircularDependencies,
+    truncated: dependencyTree.truncated,
+    maxDepth: dependencyTree.maxDepth
+  }
+
+  return {
+    success: true,
+    data
+  }
+})
+
+function parseScopes(value: unknown): DependencyScope[] {
+  if (value === undefined || value === null || value === '') return []
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: 'scope must be a comma-separated string'
+    })
+  }
+
+  const scopes = value.split(',')
+    .map(scope => scope.trim())
+    .filter(Boolean)
+
+  for (const scope of scopes) {
+    if (!ALLOWED_SCOPES.has(scope as DependencyScope)) {
+      throw createError({
+        statusCode: 400,
+        message: `Invalid scope '${scope}'`
+      })
+    }
+  }
+
+  return [...new Set(scopes)] as DependencyScope[]
+}
+
+function parseBoundedInteger(
+  value: unknown,
+  name: string,
+  defaultValue: number,
+  maxValue: number
+): number {
+  if (value === undefined || value === null || value === '') return defaultValue
+  if (typeof value !== 'string') {
+    throw createError({
+      statusCode: 400,
+      message: `${name} must be an integer`
+    })
+  }
+
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isInteger(parsed) || String(parsed) !== value || parsed < 1) {
+    throw createError({
+      statusCode: 400,
+      message: `${name} must be a positive integer`
+    })
+  }
+
+  return Math.min(parsed, maxValue)
+}

--- a/server/database/queries/components/find-dependencies-recursive.cypher
+++ b/server/database/queries/components/find-dependencies-recursive.cypher
@@ -1,0 +1,59 @@
+MATCH (root:Component)
+WHERE (
+  $purl IS NOT NULL
+  AND root.purl = $purl
+) OR (
+  $purl IS NULL
+  AND root.name = $name
+  AND root.version = $version
+  AND coalesce(root.packageManager, '') = coalesce($packageManager, '')
+  AND coalesce(root.`group`, '') = coalesce($group, '')
+)
+OPTIONAL MATCH (systemContext:System {name: $system})
+WITH root, systemContext
+CALL {
+  WITH root, systemContext
+  MATCH path = (root)-[:DEPENDS_ON*1..{{MAX_DEPTH}}]->(:Component)
+  WHERE (
+    $system IS NULL OR (
+      systemContext IS NOT NULL
+      AND EXISTS { MATCH (systemContext)-[:USES]->(root) }
+      AND all(pathNode IN nodes(path)[1..] WHERE EXISTS { MATCH (systemContext)-[:USES]->(pathNode) })
+    )
+  )
+  AND (
+    size($scopes) = 0 OR all(pathNode IN nodes(path)[1..] WHERE EXISTS {
+      MATCH (systemContext)-[scopeUse:USES]->(pathNode)
+      WHERE scopeUse.scope IN $scopes
+    })
+  )
+  WITH path
+  ORDER BY length(path)
+  LIMIT toInteger($pathLimit)
+  RETURN collect({
+    nodes: [pathNode IN nodes(path)[1..] | {
+      elementId: elementId(pathNode),
+      name: pathNode.name,
+      group: pathNode.`group`,
+      version: pathNode.version,
+      packageManager: pathNode.packageManager,
+      purl: pathNode.purl,
+      scope: CASE
+        WHEN $system IS NULL THEN null
+        ELSE head([(systemContext)-[nodeUse:USES]->(pathNode) | nodeUse.scope])
+      END
+    }]
+  }) as paths,
+  count(path) as pathCount
+}
+RETURN {
+  elementId: elementId(root),
+  name: root.name,
+  group: root.`group`,
+  version: root.version,
+  packageManager: root.packageManager,
+  purl: root.purl
+} as root,
+($system IS NULL OR systemContext IS NOT NULL) as systemExists,
+paths,
+pathCount

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -252,6 +252,95 @@ This API implements **RMM Level 2** with proper use of HTTP methods and status c
             }
           }
         },
+        DependencyNode: {
+          type: 'object',
+          required: ['name', 'version', 'isDirect', 'depth'],
+          properties: {
+            name: {
+              type: 'string',
+              description: 'Dependency component name'
+            },
+            group: {
+              type: 'string',
+              nullable: true,
+              description: 'Package group or scope'
+            },
+            version: {
+              type: 'string',
+              description: 'Dependency component version'
+            },
+            packageManager: {
+              type: 'string',
+              nullable: true,
+              description: 'Package manager'
+            },
+            purl: {
+              type: 'string',
+              nullable: true,
+              description: 'Package URL'
+            },
+            scope: {
+              type: 'string',
+              nullable: true,
+              enum: ['required', 'optional', 'excluded', 'dev', 'test', 'runtime', 'provided'],
+              description: 'Dependency scope from the system USES edge when a system filter is active'
+            },
+            isDirect: {
+              type: 'boolean',
+              description: 'True when this dependency is a direct child of the queried component'
+            },
+            depth: {
+              type: 'integer',
+              minimum: 1,
+              description: 'Depth from the queried component'
+            },
+            children: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/DependencyNode'
+              }
+            },
+            isCircular: {
+              type: 'boolean',
+              description: 'True when this node repeats an ancestor in the dependency path'
+            }
+          }
+        },
+        DependencyTreeResponse: {
+          type: 'object',
+          required: ['componentKey', 'dependencies', 'totalCount', 'hasCircularDependencies', 'truncated', 'maxDepth'],
+          properties: {
+            componentKey: {
+              type: 'string',
+              description: 'Encoded component identity key'
+            },
+            dependencies: {
+              type: 'array',
+              items: {
+                $ref: '#/components/schemas/DependencyNode'
+              }
+            },
+            totalCount: {
+              type: 'integer',
+              minimum: 0,
+              description: 'Unique dependency nodes returned'
+            },
+            hasCircularDependencies: {
+              type: 'boolean',
+              description: 'Whether any returned path contains a circular dependency'
+            },
+            truncated: {
+              type: 'boolean',
+              description: 'Whether the result was truncated by the node limit'
+            },
+            maxDepth: {
+              type: 'integer',
+              minimum: 1,
+              maximum: 10,
+              description: 'Maximum traversal depth used'
+            }
+          }
+        },
         Component: {
           type: 'object',
           required: ['name', 'version'],

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -1,6 +1,6 @@
 import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
-import type { Component, ComponentDetail } from '~~/types/api'
+import type { Component, ComponentDetail, DependencyNode, DependencyScope } from '~~/types/api'
 import type { ComponentIdentity } from '~~/utils/component-identity'
 import { buildOrderByClause, type SortConfig } from '../utils/sorting'
 
@@ -20,6 +20,40 @@ export interface ComponentFilters {
   offset?: number
   sortBy?: string
   sortOrder?: 'asc' | 'desc'
+}
+
+export interface ComponentDependencyFilters {
+  system?: string
+  scopes?: DependencyScope[]
+  maxDepth: number
+  limit: number
+}
+
+export interface ComponentDependencyTree {
+  dependencies: DependencyNode[]
+  totalCount: number
+  hasCircularDependencies: boolean
+  truncated: boolean
+  maxDepth: number
+  systemExists: boolean
+}
+
+interface DependencyPathNode {
+  elementId: string
+  name: string
+  group?: string | null
+  version: string
+  packageManager?: string | null
+  purl?: string | null
+  scope?: DependencyScope | null
+}
+
+interface DependencyPath {
+  nodes: DependencyPathNode[]
+}
+
+type MutableDependencyNode = DependencyNode & {
+  children: MutableDependencyNode[]
 }
 
 const componentSortConfig: SortConfig = {
@@ -220,6 +254,116 @@ export class ComponentRepository extends BaseRepository {
     const { records } = await this.executeQuery(query, params)
     if (records.length === 0) return null
     return this.mapToComponentDetail(records[0])
+  }
+
+  async findDependencies(
+    identity: ComponentIdentity,
+    filters: ComponentDependencyFilters
+  ): Promise<ComponentDependencyTree | null> {
+    const baseQuery = await loadQuery('components/find-dependencies-recursive.cypher')
+    const query = this.injectPlaceholders(baseQuery, {
+      '{{MAX_DEPTH}}': String(filters.maxDepth)
+    })
+    const params = {
+      purl: identity.purl || null,
+      name: identity.name || null,
+      version: identity.version || null,
+      packageManager: identity.packageManager || null,
+      group: identity.group || null,
+      system: filters.system || null,
+      scopes: filters.scopes ?? [],
+      pathLimit: Math.max(filters.limit * filters.maxDepth * 2, filters.limit)
+    }
+
+    const { records } = await this.executeQuery(query, params)
+    if (records.length === 0) return null
+
+    const record = records[0]
+    const root = record.get('root') as DependencyPathNode
+    const paths = (record.get('paths') ?? []) as DependencyPath[]
+
+    return {
+      ...this.buildDependencyTree(root, paths, filters.limit),
+      maxDepth: filters.maxDepth,
+      systemExists: record.get('systemExists') as boolean
+    }
+  }
+
+  private buildDependencyTree(
+    root: DependencyPathNode,
+    paths: DependencyPath[],
+    limit: number
+  ): Omit<ComponentDependencyTree, 'maxDepth' | 'systemExists'> {
+    const dependencies: MutableDependencyNode[] = []
+    const uniqueNodeKeys = new Set<string>()
+    const rootKey = this.getDependencyNodeKey(root)
+    let hasCircularDependencies = false
+    let truncated = false
+
+    for (const path of paths) {
+      let siblings = dependencies
+      const ancestors = new Set<string>([rootKey])
+
+      for (let index = 0; index < path.nodes.length; index += 1) {
+        const pathNode = path.nodes[index]
+        if (!pathNode.name || !pathNode.version) break
+
+        const nodeKey = this.getDependencyNodeKey(pathNode)
+        const isCircular = ancestors.has(nodeKey)
+        let treeNode = siblings.find(node => this.getDependencyNodeKey(node) === nodeKey)
+
+        if (!treeNode) {
+          if (!uniqueNodeKeys.has(nodeKey) && uniqueNodeKeys.size >= limit) {
+            truncated = true
+            break
+          }
+
+          treeNode = {
+            name: pathNode.name,
+            group: pathNode.group ?? null,
+            version: pathNode.version,
+            packageManager: pathNode.packageManager ?? null,
+            purl: pathNode.purl ?? null,
+            scope: pathNode.scope ?? null,
+            isDirect: index === 0,
+            depth: index + 1,
+            children: []
+          }
+          siblings.push(treeNode)
+        }
+
+        uniqueNodeKeys.add(nodeKey)
+
+        if (isCircular) {
+          treeNode.isCircular = true
+          hasCircularDependencies = true
+          break
+        }
+
+        ancestors.add(nodeKey)
+        siblings = treeNode.children
+      }
+    }
+
+    return {
+      dependencies,
+      totalCount: uniqueNodeKeys.size,
+      hasCircularDependencies,
+      truncated
+    }
+  }
+
+  private getDependencyNodeKey(node: {
+    elementId?: string
+    purl?: string | null
+    packageManager?: string | null
+    group?: string | null
+    name: string
+    version: string
+  }): string {
+    return node.purl
+      ?? node.elementId
+      ?? `${node.packageManager ?? ''}:${node.group ?? ''}:${node.name}@${node.version}`
   }
 
   /**

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -282,12 +282,16 @@ export class ComponentRepository extends BaseRepository {
     const root = record.get('root') as DependencyPathNode
     const paths = (record.get('paths') ?? []) as DependencyPath[]
 
+    const tree = this.buildDependencyTree(root, paths, filters.limit)
+    const pathCount = record.get('pathCount').toNumber()
+    const reachedPathLimit = pathCount >= params.pathLimit
+
     return {
-      ...this.buildDependencyTree(root, paths, filters.limit),
+      ...tree,
+      truncated: tree.truncated || reachedPathLimit,
       maxDepth: filters.maxDepth,
       systemExists: record.get('systemExists') as boolean
     }
-  }
 
   private buildDependencyTree(
     root: DependencyPathNode,

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -362,9 +362,7 @@ export class ComponentRepository extends BaseRepository {
     version: string
   }): string {
     return node.purl
-      ?? node.elementId
       ?? `${node.packageManager ?? ''}:${node.group ?? ''}:${node.name}@${node.version}`
-  }
 
   /**
    * Map Neo4j record to Component domain object

--- a/server/services/component.service.ts
+++ b/server/services/component.service.ts
@@ -1,5 +1,5 @@
 import { ComponentRepository } from '../repositories/component.repository'
-import type { ComponentFilters } from '../repositories/component.repository'
+import type { ComponentDependencyFilters, ComponentDependencyTree, ComponentFilters } from '../repositories/component.repository'
 import type { Component, ComponentDetail } from '~~/types/api'
 import type { ComponentIdentity } from '~~/utils/component-identity'
 
@@ -45,6 +45,13 @@ export class ComponentService {
 
   async findByIdentity(identity: ComponentIdentity): Promise<ComponentDetail | null> {
     return await this.componentRepo.findByIdentity(identity)
+  }
+
+  async findDependencies(
+    identity: ComponentIdentity,
+    filters: ComponentDependencyFilters
+  ): Promise<ComponentDependencyTree | null> {
+    return await this.componentRepo.findDependencies(identity, filters)
   }
 
 }

--- a/test/server/api/component-dependencies.spec.ts
+++ b/test/server/api/component-dependencies.spec.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import { encodeComponentKey } from '../../../utils/component-identity'
+import handler from '../../../server/api/components/[key]/dependencies.get'
+import { componentService } from '../../../server/services/singletons'
+
+vi.mock('../../../server/services/singletons', () => ({
+  componentService: { findDependencies: vi.fn() }
+}))
+
+const mockComponent = {
+  name: 'node',
+  version: '24.16.0',
+  packageManager: 'npm',
+  purl: 'pkg:npm/node@24.16.0',
+  group: null
+}
+
+const mockTree = {
+  dependencies: [
+    {
+      name: 'semver',
+      group: null,
+      version: '7.6.3',
+      packageManager: 'npm',
+      purl: 'pkg:npm/semver@7.6.3',
+      scope: 'runtime' as const,
+      isDirect: true,
+      depth: 1,
+      children: []
+    }
+  ],
+  totalCount: 1,
+  hasCircularDependencies: false,
+  truncated: false,
+  maxDepth: 10,
+  systemExists: true
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/components/{key}/dependencies', () => {
+  it('returns a dependency tree', async () => {
+    vi.mocked(componentService.findDependencies).mockResolvedValue(mockTree)
+
+    const key = encodeComponentKey(mockComponent)
+    const result = await handler(mockEvent({
+      params: { key },
+      query: { system: 'catalog', scope: 'runtime,dev' }
+    }))
+
+    expect(componentService.findDependencies).toHaveBeenCalledWith(
+      { purl: 'pkg:npm/node@24.16.0' },
+      {
+        system: 'catalog',
+        scopes: ['runtime', 'dev'],
+        maxDepth: 10,
+        limit: 500
+      }
+    )
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        componentKey: key,
+        dependencies: mockTree.dependencies,
+        totalCount: 1,
+        hasCircularDependencies: false,
+        truncated: false,
+        maxDepth: 10
+      }
+    })
+  })
+
+  it('rejects malformed component keys', async () => {
+    await expect(handler(mockEvent({ params: { key: 'invalid' } }))).rejects.toMatchObject({
+      statusCode: 400
+    })
+  })
+
+  it('rejects scope filtering without a system', async () => {
+    const key = encodeComponentKey(mockComponent)
+
+    await expect(handler(mockEvent({
+      params: { key },
+      query: { scope: 'runtime' }
+    }))).rejects.toMatchObject({
+      statusCode: 400,
+      message: 'scope filter requires system query parameter'
+    })
+  })
+
+  it('rejects unknown scopes', async () => {
+    const key = encodeComponentKey(mockComponent)
+
+    await expect(handler(mockEvent({
+      params: { key },
+      query: { system: 'catalog', scope: 'compile' }
+    }))).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Invalid scope 'compile'"
+    })
+  })
+
+  it('clamps maxDepth and limit to server caps', async () => {
+    vi.mocked(componentService.findDependencies).mockResolvedValue({
+      ...mockTree,
+      maxDepth: 10
+    })
+    const key = encodeComponentKey(mockComponent)
+
+    await handler(mockEvent({
+      params: { key },
+      query: { maxDepth: '99', limit: '999' }
+    }))
+
+    expect(componentService.findDependencies).toHaveBeenCalledWith(
+      { purl: 'pkg:npm/node@24.16.0' },
+      expect.objectContaining({
+        maxDepth: 10,
+        limit: 500
+      })
+    )
+  })
+
+  it('returns 404 when the component does not exist', async () => {
+    vi.mocked(componentService.findDependencies).mockResolvedValue(null)
+    const key = encodeComponentKey(mockComponent)
+
+    await expect(handler(mockEvent({ params: { key } }))).rejects.toMatchObject({
+      statusCode: 404,
+      message: 'Component not found'
+    })
+  })
+
+  it('returns 404 when a system filter references a missing system', async () => {
+    vi.mocked(componentService.findDependencies).mockResolvedValue({
+      ...mockTree,
+      dependencies: [],
+      totalCount: 0,
+      systemExists: false
+    })
+    const key = encodeComponentKey(mockComponent)
+
+    await expect(handler(mockEvent({
+      params: { key },
+      query: { system: 'missing-system' }
+    }))).rejects.toMatchObject({
+      statusCode: 404,
+      message: "System 'missing-system' not found"
+    })
+  })
+})

--- a/test/server/repositories/component.repository.spec.ts
+++ b/test/server/repositories/component.repository.spec.ts
@@ -392,4 +392,176 @@ describe('ComponentRepository', () => {
     })
   })
 
+  describe('findDependencies()', () => {
+    it('should return an empty dependency tree when a component has no dependencies', async () => {
+      if (!ctx.neo4jAvailable) return
+      const purl = `pkg:npm/${PREFIX}deps-empty@1.0.0`
+      await seed(ctx.driver, `
+        CREATE (:Component {
+          name: $name,
+          version: '1.0.0',
+          packageManager: 'npm',
+          purl: $purl
+        })
+      `, { name: `${PREFIX}deps-empty`, purl })
+
+      const result = await repo.findDependencies({ purl }, {
+        maxDepth: 10,
+        limit: 500
+      })
+
+      expect(result).toMatchObject({
+        dependencies: [],
+        totalCount: 0,
+        hasCircularDependencies: false,
+        truncated: false,
+        maxDepth: 10,
+        systemExists: true
+      })
+    })
+
+    it('should return nested transitive dependencies and flag circular branches', async () => {
+      if (!ctx.neo4jAvailable) return
+      const rootPurl = `pkg:npm/${PREFIX}deps-root@1.0.0`
+      await seed(ctx.driver, `
+        CREATE (root:Component { name: $root, version: '1.0.0', packageManager: 'npm', purl: $rootPurl })
+        CREATE (a:Component { name: $a, version: '1.0.0', packageManager: 'npm', purl: $aPurl })
+        CREATE (b:Component { name: $b, version: '1.0.0', packageManager: 'npm', purl: $bPurl })
+        CREATE (c:Component { name: $c, version: '1.0.0', packageManager: 'npm', purl: $cPurl })
+        CREATE (root)-[:DEPENDS_ON]->(a)
+        CREATE (a)-[:DEPENDS_ON]->(b)
+        CREATE (b)-[:DEPENDS_ON]->(c)
+        CREATE (c)-[:DEPENDS_ON]->(a)
+      `, {
+        root: `${PREFIX}deps-root`,
+        rootPurl,
+        a: `${PREFIX}deps-a`,
+        aPurl: `pkg:npm/${PREFIX}deps-a@1.0.0`,
+        b: `${PREFIX}deps-b`,
+        bPurl: `pkg:npm/${PREFIX}deps-b@1.0.0`,
+        c: `${PREFIX}deps-c`,
+        cPurl: `pkg:npm/${PREFIX}deps-c@1.0.0`
+      })
+
+      const result = await repo.findDependencies({ purl: rootPurl }, {
+        maxDepth: 5,
+        limit: 500
+      })
+
+      expect(result).toBeDefined()
+      expect(result!.hasCircularDependencies).toBe(true)
+      expect(result!.totalCount).toBe(3)
+      expect(result!.dependencies).toMatchObject([
+        {
+          name: `${PREFIX}deps-a`,
+          isDirect: true,
+          depth: 1,
+          children: [
+            {
+              name: `${PREFIX}deps-b`,
+              isDirect: false,
+              depth: 2,
+              children: [
+                {
+                  name: `${PREFIX}deps-c`,
+                  isDirect: false,
+                  depth: 3,
+                  children: [
+                    {
+                      name: `${PREFIX}deps-a`,
+                      isCircular: true,
+                      depth: 4
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ])
+    })
+
+    it('should apply system boundaries and scope filtering', async () => {
+      if (!ctx.neo4jAvailable) return
+      const rootPurl = `pkg:npm/${PREFIX}scoped-root@1.0.0`
+      await seed(ctx.driver, `
+        CREATE (root:Component { name: $root, version: '1.0.0', packageManager: 'npm', purl: $rootPurl })
+        CREATE (runtimeDep:Component { name: $runtimeDep, version: '1.0.0', packageManager: 'npm', purl: $runtimeDepPurl })
+        CREATE (runtimeTransitive:Component { name: $runtimeTransitive, version: '1.0.0', packageManager: 'npm', purl: $runtimeTransitivePurl })
+        CREATE (devDep:Component { name: $devDep, version: '1.0.0', packageManager: 'npm', purl: $devDepPurl })
+        CREATE (outsideDep:Component { name: $outsideDep, version: '1.0.0', packageManager: 'npm', purl: $outsideDepPurl })
+        CREATE (system:System { name: $system })
+        CREATE (system)-[:USES { scope: 'runtime', isDirect: true }]->(root)
+        CREATE (system)-[:USES { scope: 'runtime', isDirect: true }]->(runtimeDep)
+        CREATE (system)-[:USES { scope: 'runtime', isDirect: false }]->(runtimeTransitive)
+        CREATE (system)-[:USES { scope: 'dev', isDirect: true }]->(devDep)
+        CREATE (root)-[:DEPENDS_ON]->(runtimeDep)
+        CREATE (runtimeDep)-[:DEPENDS_ON]->(runtimeTransitive)
+        CREATE (root)-[:DEPENDS_ON]->(devDep)
+        CREATE (root)-[:DEPENDS_ON]->(outsideDep)
+      `, {
+        root: `${PREFIX}scoped-root`,
+        rootPurl,
+        runtimeDep: `${PREFIX}runtime-dep`,
+        runtimeDepPurl: `pkg:npm/${PREFIX}runtime-dep@1.0.0`,
+        runtimeTransitive: `${PREFIX}runtime-transitive`,
+        runtimeTransitivePurl: `pkg:npm/${PREFIX}runtime-transitive@1.0.0`,
+        devDep: `${PREFIX}dev-dep`,
+        devDepPurl: `pkg:npm/${PREFIX}dev-dep@1.0.0`,
+        outsideDep: `${PREFIX}outside-dep`,
+        outsideDepPurl: `pkg:npm/${PREFIX}outside-dep@1.0.0`,
+        system: `${PREFIX}scope-system`
+      })
+
+      const result = await repo.findDependencies({ purl: rootPurl }, {
+        system: `${PREFIX}scope-system`,
+        scopes: ['runtime'],
+        maxDepth: 10,
+        limit: 500
+      })
+
+      expect(result).toBeDefined()
+      expect(result!.systemExists).toBe(true)
+      expect(result!.dependencies).toMatchObject([
+        {
+          name: `${PREFIX}runtime-dep`,
+          scope: 'runtime',
+          isDirect: true,
+          depth: 1,
+          children: [
+            {
+              name: `${PREFIX}runtime-transitive`,
+              scope: 'runtime',
+              isDirect: false,
+              depth: 2
+            }
+          ]
+        }
+      ])
+    })
+
+    it('should report a missing system separately from a missing component', async () => {
+      if (!ctx.neo4jAvailable) return
+      const purl = `pkg:npm/${PREFIX}deps-system-missing@1.0.0`
+      await seed(ctx.driver, `
+        CREATE (:Component {
+          name: $name,
+          version: '1.0.0',
+          packageManager: 'npm',
+          purl: $purl
+        })
+      `, { name: `${PREFIX}deps-system-missing`, purl })
+
+      const result = await repo.findDependencies({ purl }, {
+        system: `${PREFIX}missing-system`,
+        maxDepth: 10,
+        limit: 500
+      })
+
+      expect(result).toBeDefined()
+      expect(result!.systemExists).toBe(false)
+      expect(result!.dependencies).toEqual([])
+    })
+  })
+
 })

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -105,6 +105,28 @@ export interface ComponentDirectDependency {
   isDirect: boolean
 }
 
+export interface DependencyNode {
+  name: string
+  group: string | null
+  version: string
+  packageManager: string | null
+  purl: string | null
+  scope: DependencyScope | null
+  isDirect: boolean
+  depth: number
+  children?: DependencyNode[]
+  isCircular?: boolean
+}
+
+export interface DependencyTreeResponse {
+  componentKey: string
+  dependencies: DependencyNode[]
+  totalCount: number
+  hasCircularDependencies: boolean
+  truncated: boolean
+  maxDepth: number
+}
+
 export type EOLStatusValue = 'active' | 'approaching_eol' | 'unsupported' | 'unknown'
 
 export interface EOLStatus {


### PR DESCRIPTION
## Description

Adds `GET /api/components/{key}/dependencies` to return a bounded dependency tree for a component, including direct and transitive dependencies, depth metadata, cycle flags, truncation metadata, and optional system-scoped scope filtering.

The endpoint requires `system` when `scope` is provided because dependency scope is stored on `System -[:USES]-> Component` relationships rather than on `DEPENDS_ON` edges.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Fixes #616
Relates to #616

## Changes Made

- Added a recursive, bounded `DEPENDS_ON` query for component dependency trees.
- Added repository, service, and API endpoint support for dependency tree responses.
- Added API types and OpenAPI schemas for `DependencyNode` and `DependencyTreeResponse`.
- Added tests for tree generation, cycle detection, system/scope filtering, validation, and empty/missing states.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

Verification run locally:

- `npm run test`
- `npm run lint`
- `npm run mdlint`
- `npm run docs:api`