### PR TITLE
Integrate dependency controls on component detail

### DIFF
--- a/app/components/ComponentDependencyTree.vue
+++ b/app/components/ComponentDependencyTree.vue
@@ -1,14 +1,6 @@
 <template>
   <div class="space-y-4">
     <DependencyFilters v-if="systemName" v-model="selectedScopes" />
-    <UAlert
-      v-else
-      color="neutral"
-      variant="subtle"
-      icon="i-lucide-info"
-      title="Global dependency view"
-      description="Scope filters require a system context because dependency scope is system-specific."
-    />
 
     <USkeleton v-if="pending" class="h-32 w-full" />
 
@@ -42,7 +34,7 @@
 
       <div v-if="dependencies.length === 0" class="rounded-md border border-dashed border-(--ui-border) p-6 text-center">
         <UIcon name="i-lucide-package-open" class="mx-auto mb-2 size-8 text-(--ui-text-muted)" />
-        <p class="font-medium">{{ selectedScopes.length > 0 ? 'No dependencies match the selected filters.' : 'No dependencies found.' }}</p>
+        <p class="font-medium">{{ selectedScopes.length > 0 ? 'No dependencies match the selected filters.' : 'This component has no dependencies.' }}</p>
       </div>
 
       <ul v-else class="space-y-1" role="tree" aria-label="Component dependencies">
@@ -93,6 +85,7 @@ const dependencyCache = new Map<string, DependencyNode[]>()
 const loadedKeys = computed(() => [...loadedNodeKeys.value])
 const loadingKeys = computed(() => [...loadingNodeKeys.value])
 const filterSignature = computed(() => selectedScopes.value.toSorted().join(','))
+let loadRootRequestId = 0
 
 watch(
   () => [props.componentKey, props.systemName ?? '', filterSignature.value],
@@ -101,8 +94,6 @@ watch(
   },
   { immediate: true }
 )
-
-let loadRootRequestId = 0
 
 async function loadRoot() {
   const requestId = ++loadRootRequestId

--- a/app/components/ComponentDependencyTree.vue
+++ b/app/components/ComponentDependencyTree.vue
@@ -89,7 +89,12 @@ let loadRootRequestId = 0
 
 watch(
   () => [props.componentKey, props.systemName ?? '', filterSignature.value],
-  async () => {
+  async ([, systemName]) => {
+    if (!systemName && selectedScopes.value.length > 0) {
+      selectedScopes.value = []
+      return
+    }
+
     await loadRoot()
   },
   { immediate: true }

--- a/app/pages/components/[key].vue
+++ b/app/pages/components/[key].vue
@@ -328,32 +328,42 @@
         <template #header>
           <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
-              <h2 class="text-lg font-semibold">Dependency Tree</h2>
-              <p class="text-sm text-(--ui-text-muted)">Explore direct and transitive dependencies.</p>
+              <h2 class="text-lg font-semibold">Dependencies</h2>
+              <p class="text-sm text-(--ui-text-muted)">
+                {{ directDependencyCount }} {{ directDependencyCount === 1 ? 'direct dependency' : 'direct dependencies' }}
+              </p>
             </div>
-            <label v-if="component.systems.length > 0" class="flex items-center gap-2 text-sm">
-              <span class="text-(--ui-text-muted)">System context</span>
-              <select
-                v-model="selectedDependencySystem"
-                class="rounded-md border border-(--ui-border) bg-(--ui-bg) px-2 py-1 text-(--ui-text)"
-                aria-label="Dependency tree system context"
-              >
-                <option value="">Global</option>
-                <option
-                  v-for="system in component.systems"
-                  :key="system.name"
-                  :value="system.name"
-                >
-                  {{ system.name }}
-                </option>
-              </select>
-            </label>
+            <div v-if="dependencySystemContext" class="flex flex-wrap items-center gap-2">
+              <UButton
+                label="All Dependencies"
+                icon="i-lucide-globe"
+                size="sm"
+                :variant="dependencyView === 'global' ? 'solid' : 'outline'"
+                :color="dependencyView === 'global' ? 'primary' : 'neutral'"
+                @click="setDependencyView('global')"
+              />
+              <UButton
+                :label="`Dependencies in ${dependencySystemContext}`"
+                icon="i-lucide-boxes"
+                size="sm"
+                :variant="dependencyView === 'system' ? 'solid' : 'outline'"
+                :color="dependencyView === 'system' ? 'primary' : 'neutral'"
+                @click="setDependencyView('system')"
+              />
+            </div>
+            <UBadge
+              v-else
+              color="neutral"
+              variant="subtle"
+            >
+              Global view
+            </UBadge>
           </div>
         </template>
 
         <ComponentDependencyTree
           :component-key="route.params.key as string"
-          :system-name="selectedDependencySystem || undefined"
+          :system-name="activeDependencySystem"
         />
       </UCard>
 
@@ -417,7 +427,9 @@
 import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, PackageMetadataStatus } from '~~/types/api'
 
 const route = useRoute()
-const selectedDependencySystem = ref('')
+const router = useRouter()
+
+type DependencyView = 'global' | 'system'
 
 interface ComponentDetailResponse {
   success: boolean
@@ -435,6 +447,19 @@ const displayName = computed(() => {
     ? `${component.value.group}/${component.value.name}`
     : component.value.name
 })
+const directDependencyCount = computed(() => {
+  const directDependencies = component.value?.directDependencies
+  return Array.isArray(directDependencies) ? directDependencies.length : 0
+})
+const dependencySystemContext = computed(() => firstQueryValue(route.query.fromSystem))
+const dependencyView = computed<DependencyView>(() => {
+  const requestedView = firstQueryValue(route.query.dependencyView)
+  if (requestedView === 'global' || requestedView === 'system') return requestedView
+  return dependencySystemContext.value ? 'system' : 'global'
+})
+const activeDependencySystem = computed(() => (
+  dependencyView.value === 'system' ? dependencySystemContext.value : undefined
+))
 
 function getEolColor(status?: EOLStatusValue): 'success' | 'warning' | 'error' | 'neutral' {
   const colors: Record<EOLStatusValue, 'success' | 'warning' | 'error' | 'neutral'> = {
@@ -497,6 +522,24 @@ function formatSystemUsage(system: ComponentSystemUsage): string {
   if (system.isDirect === true) labels.push('direct')
   if (system.isDirect === false) labels.push('transitive')
   return labels.join(', ')
+}
+
+function firstQueryValue(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim()) return value
+  if (Array.isArray(value)) {
+    const first = value.find(item => typeof item === 'string' && item.trim())
+    return typeof first === 'string' ? first : undefined
+  }
+  return undefined
+}
+
+async function setDependencyView(view: DependencyView) {
+  await router.replace({
+    query: {
+      ...route.query,
+      dependencyView: view
+    }
+  })
 }
 
 useHead({

--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -142,7 +142,7 @@ const ComponentNameCell = defineComponent({
         },
         {
           default: () => h(NuxtLink, {
-            to: `/components/${encodeComponentKey(props.component)}`,
+            to: componentDetailTarget(props.component),
             class: 'font-semibold hover:underline'
           }, () => displayName),
           content: () => tooltipContent()
@@ -221,7 +221,7 @@ const columns: TableColumn<Component>[] = [
       const group: { label: string, icon: string, onSelect: () => void }[] = [{
         label: 'View Details',
         icon: 'i-lucide-eye',
-        onSelect: () => navigateTo(`/components/${encodeComponentKey(component)}`)
+        onSelect: () => navigateTo(componentDetailTarget(component))
       }]
 
       if (component.purl) {
@@ -281,6 +281,13 @@ const sorting = ref([])
 const route = useRoute()
 const licenseFilter = computed(() => route.query.license as string | undefined)
 const systemFilter = computed(() => route.query.system as string | undefined)
+
+function componentDetailTarget(component: Component) {
+  const path = `/components/${encodeComponentKey(component)}`
+  return systemFilter.value
+    ? { path, query: { fromSystem: systemFilter.value } }
+    : path
+}
 
 const page = ref(1)
 const pageSize = 20

--- a/test/app/components/ComponentDependencyTree.test.ts
+++ b/test/app/components/ComponentDependencyTree.test.ts
@@ -154,6 +154,25 @@ describe('ComponentDependencyTree', () => {
     expect(fetchMock.mock.calls[1][0]).toContain('scope=runtime')
   })
 
+  it('clears selected scopes before loading global dependencies', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(treeResponse({ dependencies: [rootA], totalCount: 1 }))
+      .mockResolvedValueOnce(treeResponse({ dependencies: [rootA], totalCount: 1 }))
+      .mockResolvedValueOnce(treeResponse({ dependencies: [rootB], totalCount: 1 }))
+
+    const wrapper = await mountTree(fetchMock, { systemName: 'catalog' })
+    await wrapper.get('input[value="runtime"]').setValue(true)
+    await flushPromises()
+    await wrapper.setProps({ systemName: undefined })
+    await flushPromises()
+
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[2][0]).not.toContain('system=')
+    expect(fetchMock.mock.calls[2][0]).not.toContain('scope=')
+    expect(wrapper.text()).toContain('beta')
+    expect(wrapper.text()).not.toContain('No dependencies match the selected filters.')
+  })
+
   it('renders empty and circular states', async () => {
     const circularNode: DependencyNode = {
       ...rootA,

--- a/test/app/components/ComponentDependencyTree.test.ts
+++ b/test/app/components/ComponentDependencyTree.test.ts
@@ -177,6 +177,6 @@ describe('ComponentDependencyTree', () => {
 
     const wrapper = await mountTree(fetchMock)
 
-    expect(wrapper.text()).toContain('No dependencies found.')
+    expect(wrapper.text()).toContain('This component has no dependencies.')
   })
 })

--- a/test/app/pages/components/key.test.ts
+++ b/test/app/pages/components/key.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment happy-dom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { computed, defineComponent, reactive, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ComponentDetailPage from '../../../../app/pages/components/[key].vue'
+import type { ComponentDetail } from '../../../../types/api'
+
+const baseComponent: ComponentDetail = {
+  name: 'node',
+  version: '24.16.0',
+  packageManager: 'npm',
+  purl: 'pkg:npm/node@24.16.0',
+  cpe: null,
+  bomRef: null,
+  type: 'library',
+  group: null,
+  scope: null,
+  isDirect: null,
+  hashes: [],
+  licenses: [],
+  copyright: null,
+  supplier: null,
+  author: null,
+  publisher: null,
+  description: null,
+  homepage: null,
+  externalReferences: [],
+  releaseDate: null,
+  publishedDate: null,
+  modifiedDate: null,
+  technologyName: 'Node.js',
+  systemCount: 1,
+  systems: [{ name: 'catalog', scope: 'runtime', isDirect: true }],
+  directDependencies: [
+    {
+      name: 'semver',
+      group: null,
+      version: '7.6.3',
+      packageManager: 'npm',
+      purl: 'pkg:npm/semver@7.6.3',
+      scope: 'runtime',
+      isDirect: true
+    }
+  ],
+  eol: null,
+  packageMetadata: null
+}
+
+function mountPage(options: {
+  query?: Record<string, string>
+  component?: Partial<ComponentDetail> & Record<string, unknown>
+} = {}) {
+  const route = reactive({
+    params: { key: 'component-key' },
+    query: { ...(options.query ?? {}) }
+  })
+  const replace = vi.fn(async ({ query }: { query: Record<string, string> }) => {
+    route.query = { ...query }
+  })
+  const component = {
+    ...baseComponent,
+    ...(options.component ?? {})
+  } as ComponentDetail
+
+  vi.stubGlobal('computed', computed)
+  vi.stubGlobal('ref', ref)
+  vi.stubGlobal('useRoute', () => route)
+  vi.stubGlobal('useRouter', () => ({ replace }))
+  vi.stubGlobal('useFetch', vi.fn(async () => ({
+    data: ref({ success: true, data: component }),
+    pending: ref(false),
+    error: ref(null)
+  })))
+  vi.stubGlobal('useHead', vi.fn())
+
+  const wrapper = mount(defineComponent({
+    components: { ComponentDetailPage },
+    template: '<Suspense><ComponentDetailPage /></Suspense>'
+  }), {
+    global: {
+      stubs: {
+        ComponentDependencyTree: {
+          props: ['componentKey', 'systemName'],
+          template: '<div data-test="dependency-tree" :data-component-key="componentKey" :data-system-name="systemName || \'\'" />'
+        },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        UAlert: { props: ['title', 'description'], template: '<div><strong>{{ title }}</strong><span>{{ description }}</span><slot name="actions" /></div>' },
+        UBadge: { props: ['label'], template: '<span>{{ label }}<slot /></span>' },
+        UButton: {
+          props: ['label'],
+          emits: ['click'],
+          template: '<button type="button" @click="$emit(\'click\')">{{ label }}<slot /><slot name="trailing" /></button>'
+        },
+        UCard: { template: '<section><slot name="header" /><slot /></section>' },
+        UPageHeader: { props: ['title', 'description'], template: '<header><h1>{{ title }}</h1><p>{{ description }}</p></header>' },
+        USkeleton: { template: '<div />' }
+      }
+    }
+  })
+
+  return { wrapper, route, replace }
+}
+
+describe('component detail dependencies section', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('defaults to system dependency view when fromSystem is present', async () => {
+    const { wrapper } = mountPage({ query: { fromSystem: 'catalog' } })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Dependencies')
+    expect(wrapper.text()).toContain('1 direct dependency')
+    expect(wrapper.text()).toContain('All Dependencies')
+    expect(wrapper.text()).toContain('Dependencies in catalog')
+    expect(wrapper.get('[data-test="dependency-tree"]').attributes('data-system-name')).toBe('catalog')
+  })
+
+  it('persists global dependency view in the URL', async () => {
+    const { wrapper, route, replace } = mountPage({ query: { fromSystem: 'catalog' } })
+    await flushPromises()
+
+    const globalToggle = wrapper.findAll('button').find(button => button.text() === 'All Dependencies')
+    expect(globalToggle).toBeTruthy()
+
+    await globalToggle!.trigger('click')
+    await flushPromises()
+
+    expect(replace).toHaveBeenCalledWith({
+      query: {
+        fromSystem: 'catalog',
+        dependencyView: 'global'
+      }
+    })
+    expect(route.query.dependencyView).toBe('global')
+    expect(wrapper.get('[data-test="dependency-tree"]').attributes('data-system-name')).toBe('')
+  })
+
+  it('uses global dependency view when there is no system context', async () => {
+    const { wrapper } = mountPage()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Global view')
+    expect(wrapper.text()).not.toContain('All Dependencies')
+    expect(wrapper.get('[data-test="dependency-tree"]').attributes('data-system-name')).toBe('')
+  })
+
+  it('handles missing direct dependency data as zero dependencies', async () => {
+    const { wrapper } = mountPage({
+      component: {
+        directDependencies: undefined
+      }
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('0 direct dependencies')
+  })
+})


### PR DESCRIPTION
## Description

Integrates dependency exploration controls into the component detail page and preserves system context when navigating from filtered component lists.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Fixes #618
Relates to #618

## Changes Made

- Renamed the component detail dependency card to Dependencies and added the direct dependency count.
- Added URL-backed global/system dependency view state using `dependencyView=global|system` and `fromSystem` context.
- Preserved system context when navigating from `/components?system=...` to component detail pages.
- Hid scope filters in global dependency view and retained them for system-scoped dependency views.
- Added page coverage for dependency view defaults, URL persistence, and missing direct dependency data.

## Screenshots

Not included; behavior is covered by automated tests.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

Verification run locally:

- `npm run test`
- `npm run lint`
- `npm run mdlint`