### PR TITLE
Group components by version

### DIFF
--- a/app/components/ComponentVersionsModal.vue
+++ b/app/components/ComponentVersionsModal.vue
@@ -1,0 +1,194 @@
+<template>
+  <UModal
+    :open="open"
+    :title="componentTitle"
+    :description="modalDescription"
+    :ui="{ content: 'max-w-5xl', footer: 'justify-end' }"
+    @update:open="emit('update:open', $event)"
+  >
+    <template #body>
+      <div v-if="groupedComponent" class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-(--ui-border)">
+          <thead>
+            <tr class="text-left text-xs font-medium text-(--ui-text-muted) uppercase tracking-normal">
+              <th class="px-3 py-2">Version</th>
+              <th class="px-3 py-2">Package Manager</th>
+              <th class="px-3 py-2">License</th>
+              <th class="px-3 py-2">Type</th>
+              <th class="px-3 py-2 text-right">Systems</th>
+              <th class="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-(--ui-border)">
+            <tr v-for="version in groupedComponent.versionDetails" :key="versionKey(version)">
+              <td class="px-3 py-2 whitespace-nowrap">
+                <NuxtLink :to="componentDetailTarget(version)" class="font-medium hover:underline">
+                  <code>{{ version.version }}</code>
+                </NuxtLink>
+              </td>
+              <td class="px-3 py-2 whitespace-nowrap">
+                <span v-if="version.packageManager" class="inline-flex items-center gap-1">
+                  <UIcon :name="pmIcon(version.packageManager)" :style="{ color: pmColor(version.packageManager) }" class="size-4 flex-shrink-0" />
+                  {{ version.packageManager }}
+                </span>
+                <span v-else class="text-(--ui-text-muted)">-</span>
+              </td>
+              <td class="px-3 py-2">
+                <div v-if="version.licenses.length" class="flex flex-wrap gap-1">
+                  <UBadge
+                    v-for="license in version.licenses.slice(0, 2)"
+                    :key="license.id || license.name"
+                    color="neutral"
+                    variant="subtle"
+                  >
+                    {{ license.id || license.name || 'Unknown' }}
+                  </UBadge>
+                  <span v-if="version.licenses.length > 2" class="text-sm text-(--ui-text-muted)">
+                    +{{ version.licenses.length - 2 }}
+                  </span>
+                </div>
+                <span v-else class="text-(--ui-text-muted)">-</span>
+              </td>
+              <td class="px-3 py-2 whitespace-nowrap">
+                <UBadge v-if="version.type" color="primary" variant="subtle">
+                  {{ version.type }}
+                </UBadge>
+                <span v-else class="text-(--ui-text-muted)">-</span>
+              </td>
+              <td class="px-3 py-2 text-right tabular-nums">
+                {{ version.systemCount || 0 }}
+              </td>
+              <td class="px-3 py-2 text-right">
+                <UDropdownMenu :items="versionActions(version)" :content="{ align: 'end' }">
+                  <UButton icon="i-lucide-ellipsis-vertical" color="neutral" variant="ghost" size="sm" />
+                </UDropdownMenu>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </template>
+    <template #footer>
+      <UButton label="Close" color="neutral" variant="outline" @click="emit('update:open', false)" />
+    </template>
+  </UModal>
+</template>
+
+<script setup lang="ts">
+import type { GroupedComponent, GroupedComponentVersion } from '~~/types/api'
+import { encodeComponentKey } from '~~/utils/component-identity'
+
+const props = defineProps<{
+  open: boolean
+  groupedComponent: GroupedComponent | null
+  systemFilter?: string
+}>()
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+}>()
+
+const { status } = useAuth()
+
+const PM_COLORS: Record<string, string> = {
+  npm: '#cb3837', yarn: '#2c8ebb', maven: '#c71a36', gradle: '#02303a',
+  pypi: '#3572a5', cargo: '#dea584', nuget: '#004880', gem: '#cc342d',
+  go: '#00add8', composer: '#885630', unknown: '#6b7280',
+}
+
+const PM_ICONS: Record<string, string> = {
+  npm:      'i-simple-icons-npm',
+  yarn:     'i-simple-icons-yarn',
+  maven:    'i-simple-icons-apachemaven',
+  gradle:   'i-simple-icons-gradle',
+  pypi:     'i-simple-icons-pypi',
+  cargo:    'i-simple-icons-rust',
+  nuget:    'i-simple-icons-nuget',
+  gem:      'i-simple-icons-rubygems',
+  go:       'i-simple-icons-go',
+  composer: 'i-simple-icons-composer',
+}
+
+const componentTitle = computed(() => {
+  if (!props.groupedComponent) return 'Component Versions'
+  return props.groupedComponent.group
+    ? `${props.groupedComponent.group}/${props.groupedComponent.name}`
+    : props.groupedComponent.name
+})
+
+const modalDescription = computed(() => {
+  const count = props.groupedComponent?.versionDetails.length ?? 0
+  return `${count} ${count === 1 ? 'version' : 'versions'}`
+})
+
+function pmIcon(pm: string | null | undefined): string {
+  return PM_ICONS[(pm ?? 'unknown').toLowerCase()] ?? 'i-lucide-package'
+}
+
+function pmColor(pm: string | null | undefined): string {
+  return PM_COLORS[(pm ?? 'unknown').toLowerCase()] ?? PM_COLORS.unknown
+}
+
+function componentDetailTarget(component: GroupedComponentVersion) {
+  const path = `/components/${encodeComponentKey(component)}`
+  return props.systemFilter
+    ? { path, query: { fromSystem: props.systemFilter } }
+    : path
+}
+
+function versionKey(component: GroupedComponentVersion) {
+  return component.purl ?? `${component.packageManager ?? 'unknown'}:${component.group ?? ''}:${component.name}@${component.version}`
+}
+
+function versionActions(component: GroupedComponentVersion) {
+  const group: { label: string, icon: string, onSelect: () => void }[] = [{
+    label: 'View Details',
+    icon: 'i-lucide-eye',
+    onSelect: () => navigateTo(componentDetailTarget(component))
+  }]
+
+  if (component.purl) {
+    group.push({
+      label: 'Copy PURL',
+      icon: 'i-lucide-copy',
+      onSelect: () => navigator.clipboard.writeText(component.purl!)
+    })
+  }
+
+  if (component.homepage) {
+    group.push({
+      label: 'Visit Homepage',
+      icon: 'i-lucide-external-link',
+      onSelect: () => window.open(component.homepage!, '_blank')
+    })
+  }
+
+  if (component.technologyName) {
+    group.push({
+      label: 'View Technology',
+      icon: 'i-lucide-cpu',
+      onSelect: () => navigateTo(`/technologies/${encodeURIComponent(component.technologyName!)}`)
+    })
+  }
+
+  const groups = [group]
+
+  if (!component.technologyName && status.value === 'authenticated') {
+    const query: Record<string, string> = {
+      name: component.name,
+      componentName: component.name
+    }
+    if (component.group) query.componentGroup = component.group
+    if (component.packageManager) query.componentPackageManager = component.packageManager
+    if (component.type) query.componentType = component.type
+
+    groups.push([{
+      label: 'Create Technology',
+      icon: 'i-lucide-plus',
+      onSelect: () => navigateTo({ path: '/technologies/new', query })
+    }])
+  }
+
+  return groups
+}
+</script>

--- a/app/composables/useComponentDescription.ts
+++ b/app/composables/useComponentDescription.ts
@@ -15,7 +15,9 @@ const clientCache = new Map<string, string | null>()
 // reuse the existing request instead of firing duplicate network requests.
 const inFlightRequests = new Map<string, Promise<void>>()
 
-function cacheKey(component: Component): string {
+type ComponentDescriptionIdentity = Pick<Component, 'packageManager' | 'name' | 'group' | 'description'>
+
+function cacheKey(component: ComponentDescriptionIdentity): string {
   const { packageManager, name, group } = component
   const pm = packageManager ?? 'unknown'
   return group ? `${pm}:${group}/${name}` : `${pm}:${name}`
@@ -28,7 +30,7 @@ function cacheKey(component: Component): string {
  * immediately. Otherwise, `fetch()` triggers a server-side registry lookup on
  * first call and caches the result for the lifetime of the page session.
  */
-export function useComponentDescription(component: Component) {
+export function useComponentDescription(component: ComponentDescriptionIdentity) {
   const key = cacheKey(component)
 
   const state = ref<DescriptionState>({

--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -46,6 +46,7 @@
           :columns="columns"
           :loading="pending"
           :manual-sorting="true"
+          :on-select="openGroupedComponent"
           class="flex-1"
         >
           <template #empty>
@@ -65,6 +66,12 @@
           />
         </div>
       </UCard>
+
+      <ComponentVersionsModal
+        v-model:open="versionsModalOpen"
+        :grouped-component="selectedComponent"
+        :system-filter="systemFilter"
+      />
     </template>
   </div>
 </template>
@@ -72,9 +79,8 @@
 <script setup lang="ts">
 import { h, resolveComponent, defineComponent, ref } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
-import type { TableColumn } from '@nuxt/ui'
-import type { ApiResponse, Component } from '~~/types/api'
-import { encodeComponentKey } from '~~/utils/component-identity'
+import type { TableColumn, TableRow } from '@nuxt/ui'
+import type { ApiResponse, GroupedComponent } from '~~/types/api'
 
 const PM_COLORS: Record<string, string> = {
   npm: '#cb3837', yarn: '#2c8ebb', maven: '#c71a36', gradle: '#02303a',
@@ -103,19 +109,16 @@ function pmColor(pm: string | null | undefined): string {
   return PM_COLORS[(pm ?? 'unknown').toLowerCase()] ?? PM_COLORS.unknown
 }
 
-const { status } = useAuth()
 const { getSortableHeader } = useSortableTable()
 
 const UBadge = resolveComponent('UBadge')
 const UButton = resolveComponent('UButton')
-const UDropdownMenu = resolveComponent('UDropdownMenu')
 const UTooltip = resolveComponent('UTooltip')
-const NuxtLink = resolveComponent('NuxtLink')
 
 // Inline component so each row gets its own reactive description state.
 const ComponentNameCell = defineComponent({
   props: {
-    component: { type: Object as () => Component, required: true }
+    component: { type: Object as () => GroupedComponent, required: true }
   },
   setup(props) {
     const { state, fetch } = useComponentDescription(props.component)
@@ -141,10 +144,11 @@ const ComponentNameCell = defineComponent({
           ui: { content: 'max-w-xs h-auto whitespace-normal bg-inverted text-inverted rounded px-3 py-2 text-xs shadow-md' }
         },
         {
-          default: () => h(NuxtLink, {
-            to: componentDetailTarget(props.component),
-            class: 'font-semibold hover:underline'
-          }, () => displayName),
+          default: () => h('button', {
+            type: 'button',
+            class: 'font-semibold hover:underline text-left',
+            onClick: () => openGroupedComponent(null, { original: props.component } as TableRow<GroupedComponent>)
+          }, displayName),
           content: () => tooltipContent()
         }
       )
@@ -152,16 +156,25 @@ const ComponentNameCell = defineComponent({
   }
 })
 
-const columns: TableColumn<Component>[] = [
+const columns: TableColumn<GroupedComponent>[] = [
   {
     accessorKey: 'name',
     header: ({ column }) => getSortableHeader(column, 'Name'),
     cell: ({ row }) => h(ComponentNameCell, { component: row.original })
   },
   {
-    accessorKey: 'version',
-    header: ({ column }) => getSortableHeader(column, 'Version'),
-    cell: ({ row }) => h('code', {}, row.getValue('version') as string)
+    accessorKey: 'versionRange',
+    header: 'Versions',
+    enableSorting: false,
+    cell: ({ row }) => {
+      const versionCount = row.original.versions.length
+      return h('div', { class: 'flex items-center gap-2' }, [
+        h('code', {}, row.original.versionRange ?? '-'),
+        versionCount > 1
+          ? h(UBadge, { color: 'neutral', variant: 'subtle' }, () => `${versionCount}`)
+          : null
+      ])
+    }
   },
   {
     accessorKey: 'packageManager',
@@ -198,12 +211,18 @@ const columns: TableColumn<Component>[] = [
     }
   },
   {
-    accessorKey: 'type',
+    accessorKey: 'primaryType',
     header: ({ column }) => getSortableHeader(column, 'Type'),
     cell: ({ row }) => {
-      const type = row.getValue('type') as string | undefined
+      const type = row.original.primaryType
       if (!type) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
-      return h(UBadge, { color: 'primary', variant: 'subtle' }, () => type)
+      const extraCount = Math.max(0, row.original.types.length - 1)
+      return h('div', { class: 'flex items-center gap-1' }, [
+        h(UBadge, { color: 'primary', variant: 'subtle' }, () => type),
+        extraCount > 0
+          ? h('span', { class: 'text-(--ui-text-muted) text-sm' }, `+${extraCount}`)
+          : null
+      ])
     }
   },
   {
@@ -212,67 +231,17 @@ const columns: TableColumn<Component>[] = [
     cell: ({ row }) => row.original.systemCount || 0
   },
   {
-    id: 'actions',
+    id: 'open',
     header: '',
     meta: { class: { th: 'w-10', td: 'text-right' } },
-    cell: ({ row }) => {
-      const component = row.original
-      const items: { label: string, icon: string, onSelect: () => void }[][] = []
-      const group: { label: string, icon: string, onSelect: () => void }[] = [{
-        label: 'View Details',
-        icon: 'i-lucide-eye',
-        onSelect: () => navigateTo(componentDetailTarget(component))
-      }]
-
-      if (component.purl) {
-        group.push({
-          label: 'Copy PURL',
-          icon: 'i-lucide-copy',
-          onSelect: () => navigator.clipboard.writeText(component.purl!)
-        })
-      }
-
-      if (component.homepage) {
-        group.push({
-          label: 'Visit Homepage',
-          icon: 'i-lucide-external-link',
-          onSelect: () => window.open(component.homepage!, '_blank')
-        })
-      }
-
-      if (component.technologyName) {
-        group.push({
-          label: 'View Technology',
-          icon: 'i-lucide-cpu',
-          onSelect: () => navigateTo(`/technologies/${encodeURIComponent(component.technologyName!)}`)
-        })
-      }
-
-      if (group.length > 0) {
-        items.push(group)
-      }
-
-      if (!component.technologyName && status.value === 'authenticated') {
-        const query: Record<string, string> = {
-          name: component.name,
-          componentName: component.name
-        }
-        if (component.group) query.componentGroup = component.group
-        if (component.packageManager) query.componentPackageManager = component.packageManager
-        if (component.type) query.componentType = component.type
-        items.push([{
-          label: 'Create Technology',
-          icon: 'i-lucide-plus',
-          onSelect: () => navigateTo({ path: '/technologies/new', query })
-        }])
-      }
-
-      if (items.length === 0) return null
-
-      return h(UDropdownMenu, { items, content: { align: 'end' as const } }, {
-        default: () => h(UButton, { icon: 'i-lucide-ellipsis-vertical', color: 'neutral', variant: 'ghost', size: 'sm' })
-      })
-    }
+    cell: ({ row }) => h(UButton, {
+      icon: 'i-lucide-list',
+      color: 'neutral',
+      variant: 'ghost',
+      size: 'sm',
+      'aria-label': 'View versions',
+      onClick: () => openGroupedComponent(null, row)
+    })
   }
 ]
 
@@ -282,11 +251,12 @@ const route = useRoute()
 const licenseFilter = computed(() => route.query.license as string | undefined)
 const systemFilter = computed(() => route.query.system as string | undefined)
 
-function componentDetailTarget(component: Component) {
-  const path = `/components/${encodeComponentKey(component)}`
-  return systemFilter.value
-    ? { path, query: { fromSystem: systemFilter.value } }
-    : path
+const selectedComponent = ref<GroupedComponent | null>(null)
+const versionsModalOpen = ref(false)
+
+function openGroupedComponent(_event: Event | null, row: TableRow<GroupedComponent>) {
+  selectedComponent.value = row.original
+  versionsModalOpen.value = true
 }
 
 const page = ref(1)
@@ -308,7 +278,7 @@ const offset = computed(() => (page.value - 1) * pageSize)
 // Pass individual refs/computeds as query values so Nuxt tracks each one
 // as a reactive dependency for the fetch key — passing a computed object
 // does not work because reactive() unwraps it at setup time.
-const { data, pending, error } = await useFetch<ApiResponse<Component>>('/api/components', {
+const { data, pending, error } = await useFetch<ApiResponse<GroupedComponent>>('/api/components/grouped', {
   query: {
     limit: pageSize,
     offset,

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -536,6 +536,210 @@
           }
         }
       },
+      "GroupedComponentVersion": {
+        "type": "object",
+        "required": [
+          "name",
+          "version"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "version": {
+            "type": "string"
+          },
+          "packageManager": {
+            "type": "string",
+            "nullable": true
+          },
+          "purl": {
+            "type": "string",
+            "nullable": true
+          },
+          "cpe": {
+            "type": "string",
+            "nullable": true
+          },
+          "bomRef": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "application",
+              "framework",
+              "library",
+              "container",
+              "platform",
+              "operating-system",
+              "device",
+              "device-driver",
+              "firmware",
+              "file",
+              "machine-learning-model",
+              "data"
+            ]
+          },
+          "group": {
+            "type": "string",
+            "nullable": true
+          },
+          "scope": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "required",
+              "optional",
+              "excluded",
+              "dev",
+              "test",
+              "runtime",
+              "provided"
+            ]
+          },
+          "isDirect": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "licenses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/License"
+            }
+          },
+          "homepage": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalReferences": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExternalReference"
+            }
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "publishedDate": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "modifiedDate": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "technologyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "systemCount": {
+            "type": "integer"
+          }
+        }
+      },
+      "GroupedComponent": {
+        "type": "object",
+        "required": [
+          "name",
+          "versions",
+          "versionDetails"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "group": {
+            "type": "string",
+            "nullable": true
+          },
+          "packageManager": {
+            "type": "string",
+            "nullable": true
+          },
+          "versions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "versionDetails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupedComponentVersion"
+            }
+          },
+          "versionRange": {
+            "type": "string",
+            "nullable": true
+          },
+          "systemCount": {
+            "type": "integer"
+          },
+          "licenses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/License"
+            }
+          },
+          "types": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "application",
+                "framework",
+                "library",
+                "container",
+                "platform",
+                "operating-system",
+                "device",
+                "device-driver",
+                "firmware",
+                "file",
+                "machine-learning-model",
+                "data"
+              ]
+            }
+          },
+          "primaryType": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "application",
+              "framework",
+              "library",
+              "container",
+              "platform",
+              "operating-system",
+              "device",
+              "device-driver",
+              "firmware",
+              "file",
+              "machine-learning-model",
+              "data"
+            ]
+          },
+          "purl": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
       "Technology": {
         "type": "object",
         "properties": {
@@ -4181,6 +4385,192 @@
         "responses": {
           "200": {
             "description": "Components retrieved successfully"
+          }
+        }
+      }
+    },
+    "/components/grouped": {
+      "get": {
+        "tags": [
+          "Components"
+        ],
+        "summary": "List grouped components",
+        "description": "Retrieves components grouped by package manager, group, and name. Each group includes ordered version details for version-specific actions.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Search by component name, group, or package URL (case-insensitive)"
+          },
+          {
+            "in": "query",
+            "name": "packageManager",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by package manager"
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by component type"
+          },
+          {
+            "in": "query",
+            "name": "technology",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by mapped technology name"
+          },
+          {
+            "in": "query",
+            "name": "license",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by license SPDX ID"
+          },
+          {
+            "in": "query",
+            "name": "hasLicense",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Filter by license presence (ignored when license is also specified)"
+          },
+          {
+            "in": "query",
+            "name": "system",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter to groups where any version is used by this system"
+          },
+          {
+            "in": "query",
+            "name": "direct",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "When true, restrict matching to direct dependencies of the system (requires system)"
+          },
+          {
+            "in": "query",
+            "name": "depScope",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "runtime",
+                "required",
+                "dev",
+                "optional",
+                "excluded"
+              ]
+            },
+            "description": "Filter matching by dependency scope on the USES edge (requires system)"
+          },
+          {
+            "in": "query",
+            "name": "sortBy",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "packageManager",
+                "type",
+                "systemCount"
+              ]
+            },
+            "description": "Field to sort grouped components by"
+          },
+          {
+            "in": "query",
+            "name": "sortOrder",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "description": "Sort direction"
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 200
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved grouped components",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiSuccessResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/GroupedComponent"
+                          }
+                        },
+                        "total": {
+                          "type": "integer",
+                          "description": "Total count of unique component groups matching filters"
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to fetch grouped components",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/server/api/components/grouped.get.ts
+++ b/server/api/components/grouped.get.ts
@@ -1,0 +1,163 @@
+import type { ApiResponse, GroupedComponent } from '~~/types/api'
+import { componentService } from '../../services/singletons'
+
+/**
+ * @openapi
+ * /components/grouped:
+ *   get:
+ *     tags:
+ *       - Components
+ *     summary: List grouped components
+ *     description: Retrieves components grouped by package manager, group, and name. Each group includes ordered version details for version-specific actions.
+ *     parameters:
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Search by component name, group, or package URL (case-insensitive)
+ *       - in: query
+ *         name: packageManager
+ *         schema:
+ *           type: string
+ *         description: Filter by package manager
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *         description: Filter by component type
+ *       - in: query
+ *         name: technology
+ *         schema:
+ *           type: string
+ *         description: Filter by mapped technology name
+ *       - in: query
+ *         name: license
+ *         schema:
+ *           type: string
+ *         description: Filter by license SPDX ID
+ *       - in: query
+ *         name: hasLicense
+ *         schema:
+ *           type: boolean
+ *         description: Filter by license presence (ignored when license is also specified)
+ *       - in: query
+ *         name: system
+ *         schema:
+ *           type: string
+ *         description: Filter to groups where any version is used by this system
+ *       - in: query
+ *         name: direct
+ *         schema:
+ *           type: boolean
+ *         description: When true, restrict matching to direct dependencies of the system (requires system)
+ *       - in: query
+ *         name: depScope
+ *         schema:
+ *           type: string
+ *           enum: [runtime, required, dev, optional, excluded]
+ *         description: Filter matching by dependency scope on the USES edge (requires system)
+ *       - in: query
+ *         name: sortBy
+ *         schema:
+ *           type: string
+ *           enum: [name, packageManager, type, systemCount]
+ *         description: Field to sort grouped components by
+ *       - in: query
+ *         name: sortOrder
+ *         schema:
+ *           type: string
+ *           enum: [asc, desc]
+ *         description: Sort direction
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *           minimum: 1
+ *           maximum: 200
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *           minimum: 0
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved grouped components
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiSuccessResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/GroupedComponent'
+ *                     total:
+ *                       type: integer
+ *                       description: Total count of unique component groups matching filters
+ *       400:
+ *         description: Invalid query parameters
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ *       500:
+ *         description: Failed to fetch grouped components
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ */
+export default defineEventHandler(async (event): Promise<ApiResponse<GroupedComponent>> => {
+  try {
+    const query = getQuery(event)
+
+    const rawLimit = query.limit ? parseInt(query.limit as string, 10) : 50
+    const rawOffset = query.offset ? parseInt(query.offset as string, 10) : 0
+
+    if (Number.isNaN(rawLimit) || Number.isNaN(rawOffset)) {
+      setResponseStatus(event, 400)
+      return { success: false, error: 'limit and offset must be valid integers', data: [] }
+    }
+
+    const limit = Math.min(Math.max(1, rawLimit), 200)
+    const offset = Math.max(0, rawOffset)
+    const sortBy = ['name', 'packageManager', 'type', 'systemCount'].includes(query.sortBy as string)
+      ? query.sortBy as string
+      : undefined
+
+    const result = await componentService.findAllGrouped({
+      search: query.search as string | undefined,
+      packageManager: query.packageManager as string | undefined,
+      type: query.type as string | undefined,
+      technology: query.technology as string | undefined,
+      license: query.license as string | undefined,
+      hasLicense: query.hasLicense === 'true' ? true : query.hasLicense === 'false' ? false : undefined,
+      system: query.system as string | undefined,
+      directOnly: query.direct === 'true' ? true : undefined,
+      depScope: query.depScope as string | undefined,
+      limit,
+      offset,
+      sortBy,
+      sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
+    })
+
+    return {
+      success: true,
+      data: result.data,
+      count: result.count,
+      total: result.total
+    }
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : 'Failed to fetch grouped components'
+    setResponseStatus(event, 500)
+    return {
+      success: false,
+      error: errorMessage,
+      data: []
+    }
+  }
+})

--- a/server/database/queries/components/find-all-grouped.cypher
+++ b/server/database/queries/components/find-all-grouped.cypher
@@ -1,0 +1,79 @@
+// Phase 1: filter candidate components, reduce them to group identities,
+// compute group-level aggregates across all versions, then paginate groups.
+MATCH (candidate:Component)
+{{COMPONENT_WHERE}}
+WITH DISTINCT
+     coalesce(candidate.packageManager, 'unknown') as packageManagerKey,
+     coalesce(candidate.group, '') as groupKey,
+     candidate.name as name
+MATCH (groupComponent:Component { name: name })
+WHERE coalesce(groupComponent.packageManager, 'unknown') = packageManagerKey
+  AND coalesce(groupComponent.group, '') = groupKey
+OPTIONAL MATCH (groupSystem:System)-[:USES]->(groupComponent)
+WITH packageManagerKey,
+     groupKey,
+     name,
+     collect(DISTINCT groupComponent) as groupComponents,
+     count(DISTINCT groupSystem) as groupSystemCount,
+     [type IN collect(DISTINCT groupComponent.type) WHERE type IS NOT NULL | type] as groupTypes,
+     min(groupComponent.type) as primaryType
+WITH collect({
+       packageManagerKey: packageManagerKey,
+       groupKey: groupKey,
+       name: name,
+       components: groupComponents,
+       systemCount: groupSystemCount,
+       types: groupTypes,
+       primaryType: primaryType
+     }) as allGroups,
+     count(*) as total
+UNWIND allGroups as group
+WITH group, total
+ORDER BY {{ORDER_BY}}
+{{PAGINATION}}
+
+// Phase 2: fetch related version-level data only for the paginated groups.
+UNWIND group.components as c
+OPTIONAL MATCH (versionSystem:System)-[u:USES]->(c)
+WITH group, total, c,
+     count(DISTINCT versionSystem) as versionSystemCount,
+     head([x IN collect(DISTINCT {scope: u.scope, isDirect: u.isDirect, sysName: versionSystem.name}) WHERE x.sysName = $system | x.scope]) as scope,
+     head([x IN collect(DISTINCT {scope: u.scope, isDirect: u.isDirect, sysName: versionSystem.name}) WHERE x.sysName = $system | x.isDirect]) as isDirect
+OPTIONAL MATCH (c)-[:HAS_LICENSE]->(l:License)
+WITH group, total, c, versionSystemCount, scope, isDirect,
+     collect(DISTINCT {id: l.id, name: l.name, url: l.url, text: l.text}) as licenses
+OPTIONAL MATCH (c)-[:HAS_REFERENCE]->(ref:ExternalReference)
+WITH group, total, c, versionSystemCount, scope, isDirect, licenses,
+     collect(DISTINCT {type: ref.type, url: ref.url}) as externalReferences
+OPTIONAL MATCH (c)-[:IS_VERSION_OF]->(tech:Technology)
+WITH group, total,
+     collect({
+       name: c.name,
+       version: c.version,
+       packageManager: c.packageManager,
+       purl: c.purl,
+       cpe: c.cpe,
+       bomRef: c.bomRef,
+       type: c.type,
+       group: c.group,
+       scope: scope,
+       isDirect: isDirect,
+       licenses: [lic IN licenses WHERE lic.id IS NOT NULL OR lic.name IS NOT NULL | lic],
+       homepage: c.homepage,
+       externalReferences: [er IN externalReferences WHERE er.type IS NOT NULL | er],
+       description: c.description,
+       releaseDate: c.releaseDate,
+       publishedDate: c.publishedDate,
+       modifiedDate: c.modifiedDate,
+       technologyName: tech.name,
+       systemCount: versionSystemCount
+     }) as versionDetails
+RETURN group.name as name,
+       CASE group.groupKey WHEN '' THEN null ELSE group.groupKey END as `group`,
+       group.packageManagerKey as packageManager,
+       group.systemCount as systemCount,
+       group.types as types,
+       group.primaryType as primaryType,
+       versionDetails,
+       total
+ORDER BY {{ORDER_BY}}

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -467,6 +467,82 @@ This API implements **RMM Level 2** with proper use of HTTP methods and status c
             }
           }
         },
+        GroupedComponentVersion: {
+          type: 'object',
+          required: ['name', 'version'],
+          properties: {
+            name: { type: 'string' },
+            version: { type: 'string' },
+            packageManager: { type: 'string', nullable: true },
+            purl: { type: 'string', nullable: true },
+            cpe: { type: 'string', nullable: true },
+            bomRef: { type: 'string', nullable: true },
+            type: {
+              type: 'string',
+              nullable: true,
+              enum: ['application', 'framework', 'library', 'container', 'platform', 'operating-system', 'device', 'device-driver', 'firmware', 'file', 'machine-learning-model', 'data']
+            },
+            group: { type: 'string', nullable: true },
+            scope: {
+              type: 'string',
+              nullable: true,
+              enum: ['required', 'optional', 'excluded', 'dev', 'test', 'runtime', 'provided']
+            },
+            isDirect: { type: 'boolean', nullable: true },
+            licenses: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/License' }
+            },
+            homepage: { type: 'string', nullable: true },
+            externalReferences: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/ExternalReference' }
+            },
+            description: { type: 'string', nullable: true },
+            releaseDate: { type: 'string', nullable: true, format: 'date-time' },
+            publishedDate: { type: 'string', nullable: true, format: 'date-time' },
+            modifiedDate: { type: 'string', nullable: true, format: 'date-time' },
+            technologyName: { type: 'string', nullable: true },
+            systemCount: { type: 'integer' }
+          }
+        },
+        GroupedComponent: {
+          type: 'object',
+          required: ['name', 'versions', 'versionDetails'],
+          properties: {
+            name: { type: 'string' },
+            group: { type: 'string', nullable: true },
+            packageManager: { type: 'string', nullable: true },
+            versions: {
+              type: 'array',
+              items: { type: 'string' }
+            },
+            versionDetails: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/GroupedComponentVersion' }
+            },
+            versionRange: { type: 'string', nullable: true },
+            systemCount: { type: 'integer' },
+            licenses: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/License' }
+            },
+            types: {
+              type: 'array',
+              items: {
+                type: 'string',
+                enum: ['application', 'framework', 'library', 'container', 'platform', 'operating-system', 'device', 'device-driver', 'firmware', 'file', 'machine-learning-model', 'data']
+              }
+            },
+            primaryType: {
+              type: 'string',
+              nullable: true,
+              enum: ['application', 'framework', 'library', 'container', 'platform', 'operating-system', 'device', 'device-driver', 'firmware', 'file', 'machine-learning-model', 'data']
+            },
+            purl: { type: 'string', nullable: true },
+            description: { type: 'string', nullable: true }
+          }
+        },
         Technology: {
           type: 'object',
           properties: {

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -1,8 +1,9 @@
 import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
-import type { Component, ComponentDetail, DependencyNode, DependencyScope } from '~~/types/api'
+import type { Component, ComponentDetail, DependencyNode, DependencyScope, GroupedComponent, GroupedComponentVersion, License } from '~~/types/api'
 import type { ComponentIdentity } from '~~/utils/component-identity'
 import { buildOrderByClause, type SortConfig } from '../utils/sorting'
+import semver from 'semver'
 
 export interface ComponentFilters {
   search?: string
@@ -66,6 +67,16 @@ const componentSortConfig: SortConfig = {
     technologyName: 'tech.name'
   },
   defaultOrderBy: 'c.packageManager ASC, c.name ASC, c.version ASC'
+}
+
+const groupedComponentSortConfig: SortConfig = {
+  allowedFields: {
+    name: 'group.name',
+    packageManager: 'group.packageManagerKey',
+    type: 'group.primaryType',
+    systemCount: 'group.systemCount'
+  },
+  defaultOrderBy: 'group.packageManagerKey ASC, group.name ASC'
 }
 
 // Fields computed after aggregation (Phase 2) — cannot be used in Phase 1 ORDER BY
@@ -241,6 +252,48 @@ export class ComponentRepository extends BaseRepository {
     }
   }
 
+  async findAllGrouped(filters: ComponentFilters = {}): Promise<{ data: GroupedComponent[]; total: number }> {
+    const baseQuery = await loadQuery('components/find-all-grouped.cypher')
+    const { componentConditions, params } = this.buildFilterConditions(filters)
+
+    if (!params.system) {
+      params.system = null
+    }
+
+    const groupedComponentConditions = componentConditions.map(condition =>
+      condition.replace(/\bc\b/g, 'candidate')
+    )
+
+    const componentWhere = groupedComponentConditions.length > 0
+      ? `WHERE ${groupedComponentConditions.join(' AND ')}`
+      : ''
+
+    let pagination = ''
+    if (filters.limit !== undefined) {
+      pagination = 'SKIP toInteger($offset) LIMIT toInteger($limit)'
+      params.offset = filters.offset || 0
+      params.limit = filters.limit
+    }
+
+    const orderBy = buildOrderByClause(
+      { sortBy: filters.sortBy, sortOrder: filters.sortOrder },
+      groupedComponentSortConfig
+    )
+
+    const cypher = this.injectPlaceholders(baseQuery, {
+      '{{COMPONENT_WHERE}}': componentWhere,
+      '{{ORDER_BY}}': orderBy,
+      '{{PAGINATION}}': pagination
+    })
+
+    const { records } = await this.executeQuery(cypher, params)
+    const total = records.length > 0 ? records[0].get('total').toNumber() : 0
+    return {
+      data: records.map(record => this.mapToGroupedComponent(record)),
+      total
+    }
+  }
+
   async findByIdentity(identity: ComponentIdentity): Promise<ComponentDetail | null> {
     const query = await loadQuery('components/find-by-identity.cypher')
     const params = {
@@ -403,6 +456,56 @@ export class ComponentRepository extends BaseRepository {
     }
   }
 
+  private mapToGroupedComponent(record: Neo4jRecord): GroupedComponent {
+    const versionDetails = ((record.get('versionDetails') ?? []) as Record<string, unknown>[])
+      .map(version => this.mapToGroupedComponentVersion(version))
+      .sort(compareGroupedVersions)
+
+    const versions = versionDetails.map(version => version.version)
+    const licenses = dedupeLicenses(versionDetails.flatMap(version => version.licenses))
+    const description = versionDetails.find(version => version.description)?.description ?? null
+    const purl = stripPurlVersion(versionDetails.find(version => version.purl)?.purl ?? null)
+
+    return {
+      name: record.get('name'),
+      group: record.get('group'),
+      packageManager: record.get('packageManager'),
+      versions,
+      versionDetails,
+      versionRange: formatVersionRange(versions),
+      systemCount: record.get('systemCount').toNumber(),
+      licenses,
+      types: (record.get('types') ?? []).filter(Boolean),
+      primaryType: record.get('primaryType'),
+      purl,
+      description
+    }
+  }
+
+  private mapToGroupedComponentVersion(version: Record<string, unknown>): GroupedComponentVersion {
+    return {
+      name: version.name as string,
+      version: version.version as string,
+      packageManager: version.packageManager as string | null,
+      purl: version.purl as string | null,
+      cpe: version.cpe as string | null,
+      bomRef: version.bomRef as string | null,
+      type: version.type as GroupedComponentVersion['type'],
+      group: version.group as string | null,
+      scope: (version.scope ?? null) as DependencyScope | null,
+      isDirect: (version.isDirect ?? null) as boolean | null,
+      licenses: ((version.licenses ?? []) as License[]).filter(license => license.id || license.name),
+      homepage: version.homepage as string | null,
+      externalReferences: ((version.externalReferences ?? []) as GroupedComponentVersion['externalReferences']).filter(ref => ref.type),
+      description: version.description as string | null,
+      releaseDate: version.releaseDate?.toString() ?? null,
+      publishedDate: version.publishedDate?.toString() ?? null,
+      modifiedDate: version.modifiedDate?.toString() ?? null,
+      technologyName: version.technologyName as string | null,
+      systemCount: toNumber(version.systemCount)
+    }
+  }
+
   private mapToComponentDetail(record: Neo4jRecord): ComponentDetail {
     return {
       ...this.mapToComponent(record),
@@ -437,4 +540,53 @@ export class ComponentRepository extends BaseRepository {
     }
   }
 
+}
+
+function compareGroupedVersions(a: GroupedComponentVersion, b: GroupedComponentVersion): number {
+  const semverA = semver.valid(a.version)
+  const semverB = semver.valid(b.version)
+
+  if (semverA && semverB) {
+    return semver.compare(semverA, semverB)
+  }
+
+  const dateA = Date.parse(a.publishedDate ?? a.releaseDate ?? '')
+  const dateB = Date.parse(b.publishedDate ?? b.releaseDate ?? '')
+  if (!Number.isNaN(dateA) && !Number.isNaN(dateB) && dateA !== dateB) {
+    return dateA - dateB
+  }
+
+  return a.version.localeCompare(b.version, undefined, { numeric: true, sensitivity: 'base' })
+}
+
+function formatVersionRange(versions: string[]): string | null {
+  if (versions.length === 0) return null
+  if (versions.length === 1) return versions[0]!
+  if (versions.length <= 3) return versions.join(', ')
+  return `${versions[0]} - ${versions[versions.length - 1]}`
+}
+
+function dedupeLicenses(licenses: License[]): License[] {
+  const deduped = new Map<string, License>()
+  for (const license of licenses) {
+    const key = license.id || license.name
+    if (!key || deduped.has(key)) continue
+    deduped.set(key, license)
+  }
+  return [...deduped.values()]
+}
+
+function stripPurlVersion(purl: string | null): string | null {
+  if (!purl) return null
+  const lastSlash = purl.lastIndexOf('/')
+  const lastAt = purl.lastIndexOf('@')
+  return lastAt > lastSlash ? purl.slice(0, lastAt) : purl
+}
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number') return value
+  if (value && typeof value === 'object' && 'toNumber' in value && typeof value.toNumber === 'function') {
+    return value.toNumber()
+  }
+  return 0
 }

--- a/server/services/component.service.ts
+++ b/server/services/component.service.ts
@@ -1,6 +1,6 @@
 import { ComponentRepository } from '../repositories/component.repository'
 import type { ComponentDependencyFilters, ComponentDependencyTree, ComponentFilters } from '../repositories/component.repository'
-import type { Component, ComponentDetail } from '~~/types/api'
+import type { Component, ComponentDetail, GroupedComponent } from '~~/types/api'
 import type { ComponentIdentity } from '~~/utils/component-identity'
 
 export type { ComponentFilters }
@@ -36,6 +36,29 @@ export class ComponentService {
     
     const { data, total } = await this.componentRepo.findAll(filtersWithPagination)
     
+    return {
+      data,
+      count: data.length,
+      total
+    }
+  }
+
+  async findAllGrouped(filters: ComponentFilters = {}): Promise<{
+    data: GroupedComponent[]
+    count: number
+    total: number
+  }> {
+    const limit = filters.limit !== undefined ? filters.limit : 50
+    const offset = filters.offset || 0
+
+    const filtersWithPagination = {
+      ...filters,
+      limit,
+      offset
+    }
+
+    const { data, total } = await this.componentRepo.findAllGrouped(filtersWithPagination)
+
     return {
       data,
       count: data.length,

--- a/test/server/api/components-grouped.spec.ts
+++ b/test/server/api/components-grouped.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import handler from '../../../server/api/components/grouped.get'
+import { componentService } from '../../../server/services/singletons'
+
+vi.mock('../../../server/services/singletons', () => ({
+  componentService: { findAllGrouped: vi.fn() }
+}))
+
+const mockGroupedComponent = {
+  name: 'react',
+  group: null,
+  packageManager: 'npm',
+  versions: ['18.2.0', '19.0.0'],
+  versionRange: '18.2.0, 19.0.0',
+  versionDetails: [],
+  systemCount: 2,
+  licenses: [],
+  types: ['library'],
+  primaryType: 'library',
+  purl: 'pkg:npm/react',
+  description: null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/components/grouped', () => {
+  it('should return grouped components with count and total', async () => {
+    vi.mocked(componentService.findAllGrouped).mockResolvedValue({ data: [mockGroupedComponent], count: 1, total: 1 })
+
+    const result = await handler(mockEvent())
+
+    expect(result).toMatchObject({ success: true, count: 1, total: 1 })
+    expect(result.data).toHaveLength(1)
+  })
+
+  it('should return 400 on non-numeric limit', async () => {
+    const result = await handler(mockEvent({ query: { limit: 'abc' } }))
+
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining('limit') })
+  })
+
+  it('should clamp limit to 200 maximum', async () => {
+    vi.mocked(componentService.findAllGrouped).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await handler(mockEvent({ query: { limit: '999' } }))
+
+    expect(componentService.findAllGrouped).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }))
+  })
+
+  it('should pass the existing component filter surface to the service', async () => {
+    vi.mocked(componentService.findAllGrouped).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await handler(mockEvent({
+      query: {
+        search: 'react',
+        packageManager: 'npm',
+        type: 'library',
+        technology: 'React',
+        license: 'MIT',
+        hasLicense: 'true',
+        system: 'frontend',
+        direct: 'true',
+        depScope: 'runtime',
+        sortBy: 'systemCount',
+        sortOrder: 'desc'
+      }
+    }))
+
+    expect(componentService.findAllGrouped).toHaveBeenCalledWith(expect.objectContaining({
+      search: 'react',
+      packageManager: 'npm',
+      type: 'library',
+      technology: 'React',
+      license: 'MIT',
+      hasLicense: true,
+      system: 'frontend',
+      directOnly: true,
+      depScope: 'runtime',
+      sortBy: 'systemCount',
+      sortOrder: 'desc'
+    }))
+  })
+
+  it('should drop unsupported grouped sort fields', async () => {
+    vi.mocked(componentService.findAllGrouped).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await handler(mockEvent({ query: { sortBy: 'version' } }))
+
+    expect(componentService.findAllGrouped).toHaveBeenCalledWith(expect.objectContaining({ sortBy: undefined }))
+  })
+})

--- a/test/server/repositories/component.repository.spec.ts
+++ b/test/server/repositories/component.repository.spec.ts
@@ -197,6 +197,93 @@ describe('ComponentRepository', () => {
     })
   })
 
+  describe('findAllGrouped()', () => {
+    it('should group components by package manager, group, and name', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (:Component { name: $name, version: '1.0.0', packageManager: 'npm', purl: $p1, type: 'library' })
+        CREATE (:Component { name: $name, version: '1.1.0', packageManager: 'npm', purl: $p2, type: 'library' })
+      `, {
+        name: `${PREFIX}grouped-lib`,
+        p1: `pkg:npm/${PREFIX}grouped-lib@1.0.0`,
+        p2: `pkg:npm/${PREFIX}grouped-lib@1.1.0`
+      })
+
+      const { data } = await repo.findAllGrouped({ search: `${PREFIX}grouped-lib` })
+      const group = data.find(component => component.name === `${PREFIX}grouped-lib`)
+
+      expect(group).toBeDefined()
+      expect(group!.versions).toEqual(['1.0.0', '1.1.0'])
+      expect(group!.versionDetails).toHaveLength(2)
+    })
+
+    it('should count distinct systems across all versions', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (v1:Component { name: $name, version: '1.0.0', packageManager: 'npm', purl: $p1 })
+        CREATE (v2:Component { name: $name, version: '2.0.0', packageManager: 'npm', purl: $p2 })
+        CREATE (s:System { name: $systemName })
+        CREATE (s)-[:USES]->(v1)
+        CREATE (s)-[:USES]->(v2)
+      `, {
+        name: `${PREFIX}distinct-systems`,
+        p1: `pkg:npm/${PREFIX}distinct-systems@1.0.0`,
+        p2: `pkg:npm/${PREFIX}distinct-systems@2.0.0`,
+        systemName: `${PREFIX}shared-system`
+      })
+
+      const { data } = await repo.findAllGrouped({ search: `${PREFIX}distinct-systems` })
+      const group = data.find(component => component.name === `${PREFIX}distinct-systems`)
+
+      expect(group).toBeDefined()
+      expect(group!.systemCount).toBe(1)
+      expect(group!.versionDetails.map(version => version.systemCount)).toEqual([1, 1])
+    })
+
+    it('should sort semantic versions numerically for display', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (:Component { name: $name, version: '10.0.0', packageManager: 'npm', purl: $p10 })
+        CREATE (:Component { name: $name, version: '2.0.0', packageManager: 'npm', purl: $p2 })
+        CREATE (:Component { name: $name, version: '1.0.0', packageManager: 'npm', purl: $p1 })
+        CREATE (:Component { name: $name, version: '3.0.0', packageManager: 'npm', purl: $p3 })
+      `, {
+        name: `${PREFIX}semver-order`,
+        p10: `pkg:npm/${PREFIX}semver-order@10.0.0`,
+        p2: `pkg:npm/${PREFIX}semver-order@2.0.0`,
+        p1: `pkg:npm/${PREFIX}semver-order@1.0.0`,
+        p3: `pkg:npm/${PREFIX}semver-order@3.0.0`
+      })
+
+      const { data } = await repo.findAllGrouped({ search: `${PREFIX}semver-order` })
+      const group = data.find(component => component.name === `${PREFIX}semver-order`)
+
+      expect(group).toBeDefined()
+      expect(group!.versions).toEqual(['1.0.0', '2.0.0', '3.0.0', '10.0.0'])
+      expect(group!.versionRange).toBe('1.0.0 - 10.0.0')
+    })
+
+    it('should paginate by unique groups', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (:Component { name: $nameA, version: '1.0.0', packageManager: 'npm', purl: $pA1 })
+        CREATE (:Component { name: $nameA, version: '2.0.0', packageManager: 'npm', purl: $pA2 })
+        CREATE (:Component { name: $nameB, version: '1.0.0', packageManager: 'npm', purl: $pB1 })
+      `, {
+        nameA: `${PREFIX}page-a`,
+        nameB: `${PREFIX}page-b`,
+        pA1: `pkg:npm/${PREFIX}page-a@1.0.0`,
+        pA2: `pkg:npm/${PREFIX}page-a@2.0.0`,
+        pB1: `pkg:npm/${PREFIX}page-b@1.0.0`
+      })
+
+      const { data, total } = await repo.findAllGrouped({ search: `${PREFIX}page-`, limit: 1, offset: 0 })
+
+      expect(data).toHaveLength(1)
+      expect(total).toBe(2)
+    })
+  })
+
   describe('findByIdentity()', () => {
     it('should find component details by purl', async () => {
       if (!ctx.neo4jAvailable) return

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -89,6 +89,43 @@ export interface Component {
   systemCount: number            // Number of systems using this
 }
 
+export interface GroupedComponentVersion {
+  name: string
+  version: string
+  packageManager: string | null
+  purl: string | null
+  cpe: string | null
+  bomRef: string | null
+  type: ComponentType | null
+  group: string | null
+  scope: DependencyScope | null
+  isDirect: boolean | null
+  licenses: License[]
+  homepage: string | null
+  externalReferences: ExternalReference[]
+  description: string | null
+  releaseDate: string | null
+  publishedDate: string | null
+  modifiedDate: string | null
+  technologyName: string | null
+  systemCount: number
+}
+
+export interface GroupedComponent {
+  name: string
+  group: string | null
+  packageManager: string | null
+  versions: string[]
+  versionDetails: GroupedComponentVersion[]
+  versionRange: string | null
+  systemCount: number
+  licenses: License[]
+  types: ComponentType[]
+  primaryType: ComponentType | null
+  purl: string | null
+  description: string | null
+}
+
 export interface ComponentSystemUsage {
   name: string
   scope: DependencyScope | null


### PR DESCRIPTION
## Description

Groups duplicate component rows on `/components` by package manager, group, and name while preserving version-specific details and actions in a modal.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Configuration or build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #604
Relates to #625

## Changes Made

<!-- List the specific changes you made -->

- Added `GET /api/components/grouped` with grouped pagination, existing component filters, distinct system counts, and per-version detail rows.
- Updated `/components` to show grouped rows with version ranges/count badges and a modal for version-specific actions.
- Added grouped component API types, OpenAPI schema/output, and focused API/repository tests.

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

Not included.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

<!-- Add any additional information that reviewers should know -->

Validation run:

- `npm run test`
- `npm run lint`
- `npm run mdlint`
- `npm run build`