### PR TITLE
Filter components by direct dependency scope

### DIFF
--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -6,7 +6,7 @@
       >
         <template #description>
           <template v-if="systemFilter">
-            Components in system: <strong>{{ systemFilter }}</strong>
+            Direct components in system: <strong>{{ systemFilter }}</strong>
             <NuxtLink to="/components" class="ml-2">(clear filter)</NuxtLink>
           </template>
           <template v-else-if="licenseFilter">
@@ -14,7 +14,7 @@
             <NuxtLink to="/components" class="ml-2">(clear filter)</NuxtLink>
           </template>
           <template v-else>
-            SBOM entries across all systems
+            Direct SBOM entries across all systems
           </template>
         </template>
       </UPageHeader>
@@ -31,12 +31,17 @@
 
     <template v-else>
       <UCard>
-        <div class="flex items-center gap-2 pb-4 border-b border-(--ui-border) mb-4">
+        <div class="flex flex-wrap items-center justify-between gap-3 pb-4 border-b border-(--ui-border) mb-4">
           <UInput
             v-model="searchInput"
             placeholder="Filter by name..."
             icon="i-lucide-search"
             class="max-w-sm"
+          />
+          <USwitch
+            v-model="showDevDependencies"
+            label="Show dev dependencies"
+            size="sm"
           />
         </div>
 
@@ -250,6 +255,14 @@ const sorting = ref([])
 const route = useRoute()
 const licenseFilter = computed(() => route.query.license as string | undefined)
 const systemFilter = computed(() => route.query.system as string | undefined)
+const showDevDependenciesCookie = useCookie<'true' | 'false'>('polaris-components-show-dev-dependencies', {
+  default: () => 'true',
+  sameSite: 'lax'
+})
+const showDevDependencies = computed({
+  get: () => showDevDependenciesCookie.value !== 'false',
+  set: value => { showDevDependenciesCookie.value = value ? 'true' : 'false' }
+})
 
 const selectedComponent = ref<GroupedComponent | null>(null)
 const versionsModalOpen = ref(false)
@@ -266,13 +279,14 @@ const searchInput = ref('')
 const debouncedSearch = ref('')
 
 // Reset page when any filter changes
-watch([debouncedSearch, licenseFilter, systemFilter, sorting], () => { page.value = 1 })
+watch([debouncedSearch, licenseFilter, systemFilter, showDevDependencies, sorting], () => { page.value = 1 })
 
 const updateSearch = useDebounceFn((value: string) => { debouncedSearch.value = value }, 300)
 watch(searchInput, updateSearch)
 
 const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
 const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
+const includeDev = computed(() => showDevDependencies.value ? undefined : 'false')
 const offset = computed(() => (page.value - 1) * pageSize)
 
 // Pass individual refs/computeds as query values so Nuxt tracks each one
@@ -285,6 +299,8 @@ const { data, pending, error } = await useFetch<ApiResponse<GroupedComponent>>('
     search: debouncedSearch,
     license: licenseFilter,
     system: systemFilter,
+    direct: 'true',
+    includeDev,
     sortBy,
     sortOrder,
   },

--- a/server/api/components.get.ts
+++ b/server/api/components.get.ts
@@ -49,7 +49,12 @@ import { componentService } from '../services/singletons'
  *         name: direct
  *         schema:
  *           type: boolean
- *         description: When true, restrict to direct dependencies of the system (requires system)
+ *         description: When true, restrict to direct dependencies. With system, applies to that system; otherwise applies across all systems.
+ *       - in: query
+ *         name: includeDev
+ *         schema:
+ *           type: boolean
+ *         description: When false, hide dependencies whose matching USES edge is dev-scoped.
  *       - in: query
  *         name: depScope
  *         schema:
@@ -126,6 +131,7 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Component>>
       hasLicense: query.hasLicense === 'true' ? true : query.hasLicense === 'false' ? false : undefined,
       system: query.system as string | undefined,
       directOnly: query.direct === 'true' ? true : undefined,
+      includeDev: query.includeDev === 'false' ? false : undefined,
       depScope: query.depScope as string | undefined,
       limit,
       offset,

--- a/server/api/components/grouped.get.ts
+++ b/server/api/components/grouped.get.ts
@@ -49,7 +49,12 @@ import { componentService } from '../../services/singletons'
  *         name: direct
  *         schema:
  *           type: boolean
- *         description: When true, restrict matching to direct dependencies of the system (requires system)
+ *         description: When true, restrict matching to direct dependencies. With system, applies to that system; otherwise applies across all systems.
+ *       - in: query
+ *         name: includeDev
+ *         schema:
+ *           type: boolean
+ *         description: When false, hide dependencies whose matching USES edge is dev-scoped.
  *       - in: query
  *         name: depScope
  *         schema:
@@ -138,6 +143,7 @@ export default defineEventHandler(async (event): Promise<ApiResponse<GroupedComp
       hasLicense: query.hasLicense === 'true' ? true : query.hasLicense === 'false' ? false : undefined,
       system: query.system as string | undefined,
       directOnly: query.direct === 'true' ? true : undefined,
+      includeDev: query.includeDev === 'false' ? false : undefined,
       depScope: query.depScope as string | undefined,
       limit,
       offset,

--- a/server/database/queries/components/find-all-grouped.cypher
+++ b/server/database/queries/components/find-all-grouped.cypher
@@ -9,6 +9,7 @@ WITH DISTINCT
 MATCH (groupComponent:Component { name: name })
 WHERE coalesce(groupComponent.packageManager, 'unknown') = packageManagerKey
   AND coalesce(groupComponent.group, '') = groupKey
+{{GROUP_COMPONENT_WHERE}}
 OPTIONAL MATCH (groupSystem:System)-[:USES]->(groupComponent)
 WITH packageManagerKey,
      groupKey,

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -13,8 +13,10 @@ export interface ComponentFilters {
   license?: string
   hasLicense?: boolean
   system?: string
-  /** When true, restrict to direct dependencies of the system (requires system to be set) */
+  /** When true, restrict to direct dependencies. With system, applies to that system; otherwise across all systems. */
   directOnly?: boolean
+  /** When false, exclude dependencies whose matching USES edge is dev-scoped */
+  includeDev?: boolean
   /** Filter by dependency scope on the USES edge (e.g. 'runtime', 'dev', 'optional') */
   depScope?: string
   limit?: number
@@ -116,28 +118,29 @@ export class ComponentRepository extends BaseRepository {
       params.type = filters.type
     }
 
+    const usagePredicates: string[] = []
+    if (filters.directOnly) {
+      usagePredicates.push('u.isDirect = true')
+    }
+    if (filters.system && filters.depScope) {
+      usagePredicates.push('u.scope = $depScope')
+    }
+    if (filters.includeDev === false) {
+      usagePredicates.push('(u.scope IS NULL OR u.scope <> "dev")')
+    }
+
+    if (filters.system || filters.directOnly || filters.includeDev === false) {
+      const usageWhere = usagePredicates.length > 0 ? ` WHERE ${usagePredicates.join(' AND ')}` : ''
+      const systemPattern = filters.system ? '(sys:System {name: $system})' : '(:System)'
+      componentConditions.push(`EXISTS { MATCH ${systemPattern}-[u:USES]->(c)${usageWhere} }`)
+    }
+
     if (filters.system) {
-      if (filters.directOnly) {
-        componentConditions.push('EXISTS { MATCH (sys:System {name: $system})-[:USES {isDirect: true}]->(c) }')
-      } else if (filters.depScope) {
-        componentConditions.push('EXISTS { MATCH (sys:System {name: $system})-[:USES {scope: $depScope}]->(c) }')
-      } else {
-        componentConditions.push('EXISTS { MATCH (sys:System {name: $system})-[:USES]->(c) }')
-      }
       params.system = filters.system
     }
 
     if (filters.depScope && !filters.system) {
       // scope filter without a system is not meaningful — ignore silently
-    }
-
-    if (filters.directOnly && filters.depScope && filters.system) {
-      // both directOnly and depScope: require isDirect=true AND scope matches
-      // replace the condition added above with a combined one
-      const idx = componentConditions.findLastIndex(c => c.includes('isDirect'))
-      if (idx >= 0) {
-        componentConditions[idx] = 'EXISTS { MATCH (sys:System {name: $system})-[:USES {isDirect: true, scope: $depScope}]->(c) }'
-      }
     }
 
     if (filters.depScope) {
@@ -263,9 +266,15 @@ export class ComponentRepository extends BaseRepository {
     const groupedComponentConditions = componentConditions.map(condition =>
       condition.replace(/\bc\b/g, 'candidate')
     )
+    const expandedGroupComponentConditions = componentConditions.map(condition =>
+      condition.replace(/\bc\b/g, 'groupComponent')
+    )
 
     const componentWhere = groupedComponentConditions.length > 0
       ? `WHERE ${groupedComponentConditions.join(' AND ')}`
+      : ''
+    const groupComponentWhere = expandedGroupComponentConditions.length > 0
+      ? `  AND ${expandedGroupComponentConditions.join('\n  AND ')}`
       : ''
 
     let pagination = ''
@@ -282,6 +291,7 @@ export class ComponentRepository extends BaseRepository {
 
     const cypher = this.injectPlaceholders(baseQuery, {
       '{{COMPONENT_WHERE}}': componentWhere,
+      '{{GROUP_COMPONENT_WHERE}}': groupComponentWhere,
       '{{ORDER_BY}}': orderBy,
       '{{PAGINATION}}': pagination
     })

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -123,10 +123,8 @@ export class ComponentRepository extends BaseRepository {
       usagePredicates.push('u.isDirect = true')
     }
     if (filters.system && filters.depScope) {
-      usagePredicates.push('u.scope = $depScope')
-    }
     if (filters.includeDev === false) {
-      usagePredicates.push('(u.scope IS NULL OR u.scope <> "dev")')
+      usagePredicates.push('(u.scope IS NULL OR (u.scope <> "dev" AND u.scope <> "test"))')
     }
 
     if (filters.system || filters.directOnly || filters.includeDev === false) {

--- a/test/server/api/components-grouped.spec.ts
+++ b/test/server/api/components-grouped.spec.ts
@@ -63,6 +63,7 @@ describe('GET /api/components/grouped', () => {
         hasLicense: 'true',
         system: 'frontend',
         direct: 'true',
+        includeDev: 'false',
         depScope: 'runtime',
         sortBy: 'systemCount',
         sortOrder: 'desc'
@@ -78,6 +79,7 @@ describe('GET /api/components/grouped', () => {
       hasLicense: true,
       system: 'frontend',
       directOnly: true,
+      includeDev: false,
       depScope: 'runtime',
       sortBy: 'systemCount',
       sortOrder: 'desc'

--- a/test/server/api/components.spec.ts
+++ b/test/server/api/components.spec.ts
@@ -78,6 +78,14 @@ describe('GET /api/components', () => {
     expect(componentService.findAll).toHaveBeenCalledWith(expect.objectContaining({ hasLicense: true }))
   })
 
+  it('should pass includeDev=false to the service', async () => {
+    vi.mocked(componentService.findAll).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await handler(mockEvent({ query: { includeDev: 'false' } }))
+
+    expect(componentService.findAll).toHaveBeenCalledWith(expect.objectContaining({ includeDev: false }))
+  })
+
   it('should return error response on service failure', async () => {
     vi.mocked(componentService.findAll).mockRejectedValue(new Error('Database connection failed'))
 

--- a/test/server/repositories/component.repository.spec.ts
+++ b/test/server/repositories/component.repository.spec.ts
@@ -195,6 +195,76 @@ describe('ComponentRepository', () => {
       expect(data.map(component => component.name)).not.toContain(`${PREFIX}runtime-transitive`)
       expect(data.map(component => component.name)).not.toContain(`${PREFIX}dev-direct`)
     })
+
+    it('should filter to direct dependencies across all systems without a system filter', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (direct:Component { name: $directName, version: '1.0.0', purl: $directPurl })
+        CREATE (transitive:Component { name: $transitiveName, version: '1.0.0', purl: $transitivePurl })
+        CREATE (unused:Component { name: $unusedName, version: '1.0.0', purl: $unusedPurl })
+        CREATE (system:System { name: $systemName })
+        CREATE (system)-[:USES { scope: 'runtime', isDirect: true }]->(direct)
+        CREATE (system)-[:USES { scope: 'runtime', isDirect: false }]->(transitive)
+      `, {
+        directName: `${PREFIX}global-direct`,
+        directPurl: `pkg:npm/${PREFIX}global-direct@1.0.0`,
+        transitiveName: `${PREFIX}global-transitive`,
+        transitivePurl: `pkg:npm/${PREFIX}global-transitive@1.0.0`,
+        unusedName: `${PREFIX}global-unused`,
+        unusedPurl: `pkg:npm/${PREFIX}global-unused@1.0.0`,
+        systemName: `${PREFIX}global-filter-system`
+      })
+
+      const { data } = await repo.findAll({
+        search: `${PREFIX}global-`,
+        directOnly: true
+      })
+
+      expect(data.map(component => component.name)).toContain(`${PREFIX}global-direct`)
+      expect(data.map(component => component.name)).not.toContain(`${PREFIX}global-transitive`)
+      expect(data.map(component => component.name)).not.toContain(`${PREFIX}global-unused`)
+    })
+
+    it('should hide only dev-only direct dependencies across all systems', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (normal:Component { name: $normalName, version: '1.0.0', purl: $normalPurl })
+        CREATE (devOnly:Component { name: $devOnlyName, version: '1.0.0', purl: $devOnlyPurl })
+        CREATE (mixed:Component { name: $mixedName, version: '1.0.0', purl: $mixedPurl })
+        CREATE (devDirectTransitiveNormal:Component { name: $devDirectTransitiveNormalName, version: '1.0.0', purl: $devDirectTransitiveNormalPurl })
+        CREATE (runtimeSystem:System { name: $runtimeSystemName })
+        CREATE (devSystem:System { name: $devSystemName })
+        CREATE (runtimeSystem)-[:USES { scope: 'runtime', isDirect: true }]->(normal)
+        CREATE (devSystem)-[:USES { scope: 'dev', isDirect: true }]->(devOnly)
+        CREATE (devSystem)-[:USES { scope: 'dev', isDirect: true }]->(mixed)
+        CREATE (runtimeSystem)-[:USES { scope: 'runtime', isDirect: true }]->(mixed)
+        CREATE (devSystem)-[:USES { scope: 'dev', isDirect: true }]->(devDirectTransitiveNormal)
+        CREATE (runtimeSystem)-[:USES { scope: 'runtime', isDirect: false }]->(devDirectTransitiveNormal)
+      `, {
+        normalName: `${PREFIX}hide-dev-normal`,
+        normalPurl: `pkg:npm/${PREFIX}hide-dev-normal@1.0.0`,
+        devOnlyName: `${PREFIX}hide-dev-only`,
+        devOnlyPurl: `pkg:npm/${PREFIX}hide-dev-only@1.0.0`,
+        mixedName: `${PREFIX}hide-dev-mixed`,
+        mixedPurl: `pkg:npm/${PREFIX}hide-dev-mixed@1.0.0`,
+        devDirectTransitiveNormalName: `${PREFIX}hide-dev-transitive-normal`,
+        devDirectTransitiveNormalPurl: `pkg:npm/${PREFIX}hide-dev-transitive-normal@1.0.0`,
+        runtimeSystemName: `${PREFIX}hide-dev-runtime-system`,
+        devSystemName: `${PREFIX}hide-dev-dev-system`
+      })
+
+      const { data } = await repo.findAll({
+        search: `${PREFIX}hide-dev-`,
+        directOnly: true,
+        includeDev: false
+      })
+      const names = data.map(component => component.name)
+
+      expect(names).toContain(`${PREFIX}hide-dev-normal`)
+      expect(names).toContain(`${PREFIX}hide-dev-mixed`)
+      expect(names).not.toContain(`${PREFIX}hide-dev-only`)
+      expect(names).not.toContain(`${PREFIX}hide-dev-transitive-normal`)
+    })
   })
 
   describe('findAllGrouped()', () => {
@@ -281,6 +351,90 @@ describe('ComponentRepository', () => {
 
       expect(data).toHaveLength(1)
       expect(total).toBe(2)
+    })
+
+    it('should filter grouped results to direct dependencies across all systems', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (direct:Component { name: $directName, version: '1.0.0', packageManager: 'npm', purl: $directPurl })
+        CREATE (transitive:Component { name: $transitiveName, version: '1.0.0', packageManager: 'npm', purl: $transitivePurl })
+        CREATE (system:System { name: $systemName })
+        CREATE (system)-[:USES { scope: 'runtime', isDirect: true }]->(direct)
+        CREATE (system)-[:USES { scope: 'runtime', isDirect: false }]->(transitive)
+      `, {
+        directName: `${PREFIX}grouped-global-direct`,
+        directPurl: `pkg:npm/${PREFIX}grouped-global-direct@1.0.0`,
+        transitiveName: `${PREFIX}grouped-global-transitive`,
+        transitivePurl: `pkg:npm/${PREFIX}grouped-global-transitive@1.0.0`,
+        systemName: `${PREFIX}grouped-global-filter-system`
+      })
+
+      const { data } = await repo.findAllGrouped({
+        search: `${PREFIX}grouped-global-`,
+        directOnly: true
+      })
+
+      expect(data.map(component => component.name)).toContain(`${PREFIX}grouped-global-direct`)
+      expect(data.map(component => component.name)).not.toContain(`${PREFIX}grouped-global-transitive`)
+    })
+
+    it('should keep grouped components with normal usage when hiding dev dependencies', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (devOnly:Component { name: $devOnlyName, version: '1.0.0', packageManager: 'npm', purl: $devOnlyPurl })
+        CREATE (mixed:Component { name: $mixedName, version: '1.0.0', packageManager: 'npm', purl: $mixedPurl })
+        CREATE (runtimeSystem:System { name: $runtimeSystemName })
+        CREATE (devSystem:System { name: $devSystemName })
+        CREATE (devSystem)-[:USES { scope: 'dev', isDirect: true }]->(devOnly)
+        CREATE (devSystem)-[:USES { scope: 'dev', isDirect: true }]->(mixed)
+        CREATE (runtimeSystem)-[:USES { scope: 'runtime', isDirect: true }]->(mixed)
+      `, {
+        devOnlyName: `${PREFIX}grouped-hide-dev-only`,
+        devOnlyPurl: `pkg:npm/${PREFIX}grouped-hide-dev-only@1.0.0`,
+        mixedName: `${PREFIX}grouped-hide-dev-mixed`,
+        mixedPurl: `pkg:npm/${PREFIX}grouped-hide-dev-mixed@1.0.0`,
+        runtimeSystemName: `${PREFIX}grouped-hide-dev-runtime-system`,
+        devSystemName: `${PREFIX}grouped-hide-dev-dev-system`
+      })
+
+      const { data } = await repo.findAllGrouped({
+        search: `${PREFIX}grouped-hide-dev-`,
+        directOnly: true,
+        includeDev: false
+      })
+      const names = data.map(component => component.name)
+
+      expect(names).toContain(`${PREFIX}grouped-hide-dev-mixed`)
+      expect(names).not.toContain(`${PREFIX}grouped-hide-dev-only`)
+    })
+
+    it('should hide dev-only versions inside a grouped component', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (runtimeVersion:Component { name: $name, version: '1.0.0', packageManager: 'npm', purl: $runtimePurl })
+        CREATE (devVersion:Component { name: $name, version: '2.0.0', packageManager: 'npm', purl: $devPurl })
+        CREATE (runtimeSystem:System { name: $runtimeSystemName })
+        CREATE (devSystem:System { name: $devSystemName })
+        CREATE (runtimeSystem)-[:USES { scope: 'runtime', isDirect: true }]->(runtimeVersion)
+        CREATE (devSystem)-[:USES { scope: 'dev', isDirect: true }]->(devVersion)
+      `, {
+        name: `${PREFIX}grouped-hide-dev-version`,
+        runtimePurl: `pkg:npm/${PREFIX}grouped-hide-dev-version@1.0.0`,
+        devPurl: `pkg:npm/${PREFIX}grouped-hide-dev-version@2.0.0`,
+        runtimeSystemName: `${PREFIX}grouped-hide-dev-version-runtime-system`,
+        devSystemName: `${PREFIX}grouped-hide-dev-version-dev-system`
+      })
+
+      const { data } = await repo.findAllGrouped({
+        search: `${PREFIX}grouped-hide-dev-version`,
+        directOnly: true,
+        includeDev: false
+      })
+      const group = data.find(component => component.name === `${PREFIX}grouped-hide-dev-version`)
+
+      expect(group).toBeDefined()
+      expect(group!.versions).toEqual(['1.0.0'])
+      expect(group!.versionDetails.map(version => version.version)).not.toContain('2.0.0')
     })
   })
 


### PR DESCRIPTION
## Description

Updates the Components page so it lists direct system dependencies and adds a persisted toggle for showing or hiding dev dependencies. When dev dependencies are hidden, components that are dev-only are excluded, while components that are dev dependencies in one system but normal direct dependencies in another remain visible.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made

<!-- List the specific changes you made -->

- Filter `/components` grouped results to direct dependencies by default.
- Add a persisted `Show dev dependencies` switch backed by a browser cookie.
- Add API and repository support for `includeDev=false`, including grouped result expansion so dev-only versions do not leak into the modal.
- Add repository and API tests covering direct-only filtering, dev-only hiding, and mixed normal/dev usage.

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

Not applicable.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed

## Additional Notes

<!-- Add any additional information that reviewers should know -->

Validation run:

- `npm run test`
- `npm run lint`
- `npm run mdlint`