### PR TITLE
Fix Nuxt dev server startup

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,7 +34,11 @@ export default defineNuxtConfig({
     '@sidebase/nuxt-auth',
   ],
 
-
+  fonts: {
+    providers: {
+      bunny: false
+    }
+  },
 
   auth: {
     // AUTH_ORIGIN overrides auto-detection. Required when the app is behind a proxy

--- a/schema/scripts/migrate.ts
+++ b/schema/scripts/migrate.ts
@@ -77,7 +77,7 @@ async function testConnection(driver: neo4j.Driver): Promise<void> {
       helpMessage += '  • Port conflicts: Ensure ports 7474 and 7687 are available\n'
     }
     
-    throw new Error(`Cannot connect to Neo4j database.\n${helpMessage}`)
+    throw new Error(`Cannot connect to Neo4j database.\n${helpMessage}`, { cause: error })
   } finally {
     await session.close()
   }

--- a/schema/scripts/seed-github.ts
+++ b/schema/scripts/seed-github.ts
@@ -180,7 +180,7 @@ async function cloneRepository(repoUrl: string, branch: string, targetDir: strin
     })
     console.log(`  ✅ Cloned successfully`)
   } catch (error) {
-    throw new Error(`Failed to clone repository: ${error instanceof Error ? error.message : error}`)
+    throw new Error(`Failed to clone repository: ${error instanceof Error ? error.message : error}`, { cause: error })
   }
 }
 
@@ -215,7 +215,7 @@ async function generateSBOM(repoPath: string, repoName: string): Promise<object>
       return bom as object
     }
   } catch (error) {
-    throw new Error(`Failed to generate SBOM: ${error instanceof Error ? error.message : error}`)
+    throw new Error(`Failed to generate SBOM: ${error instanceof Error ? error.message : error}`, { cause: error })
   }
 }
 
@@ -279,7 +279,7 @@ async function ensureSystemExists(config: RepositoryConfig, apiToken: string): P
       console.log(`  ✅ System already exists`)
     } else {
       const msg = error instanceof Error ? error.message : String(error)
-      throw new Error(`Failed to create system via API at ${baseUrl}/api/systems: ${msg}. Is the Nuxt dev server running? Start it with 'npm run dev' and ensure ${baseUrl} is reachable.`)
+      throw new Error(`Failed to create system via API at ${baseUrl}/api/systems: ${msg}. Is the Nuxt dev server running? Start it with 'npm run dev' and ensure ${baseUrl} is reachable.`, { cause: error })
     }
   }
   
@@ -319,7 +319,7 @@ async function ensureRepositoryExists(config: RepositoryConfig, apiToken: string
     if (error instanceof Error && error.message.includes('409')) {
       console.log(`  ✅ Repository already linked to system`)
     } else {
-      throw new Error(`Failed to register repository: ${error instanceof Error ? error.message : error}`)
+      throw new Error(`Failed to register repository: ${error instanceof Error ? error.message : error}`, { cause: error })
     }
   }
 }
@@ -401,7 +401,7 @@ async function postSBOM(repoUrl: string, sbom: object, apiToken: string): Promis
     console.log(`     Components updated: ${result.componentsUpdated}`)
     console.log(`     Relationships created: ${result.relationshipsCreated}`)
   } catch (error) {
-    throw new Error(`Failed to post SBOM: ${error instanceof Error ? error.message : error}`)
+    throw new Error(`Failed to post SBOM: ${error instanceof Error ? error.message : error}`, { cause: error })
   }
 }
 
@@ -461,7 +461,7 @@ async function seedFixtures(clear: boolean): Promise<void> {
     })
     console.log('\n✅ Governance data seeded\n')
   } catch (error) {
-    throw new Error(`Failed to seed fixtures: ${error instanceof Error ? error.message : error}`)
+    throw new Error(`Failed to seed fixtures: ${error instanceof Error ? error.message : error}`, { cause: error })
   }
 }
 
@@ -527,7 +527,7 @@ async function ensureTechnicalUserExists(): Promise<string> {
     
     return email
   } catch (error) {
-    throw new Error(`Failed to ensure technical user exists: ${error instanceof Error ? error.message : error}`)
+    throw new Error(`Failed to ensure technical user exists: ${error instanceof Error ? error.message : error}`, { cause: error })
   } finally {
     await session.close()
     await driver.close()

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -123,6 +123,8 @@ export class ComponentRepository extends BaseRepository {
       usagePredicates.push('u.isDirect = true')
     }
     if (filters.system && filters.depScope) {
+      usagePredicates.push('u.scope = $depScope')
+    }
     if (filters.includeDev === false) {
       usagePredicates.push('(u.scope IS NULL OR (u.scope <> "dev" AND u.scope <> "test"))')
     }
@@ -164,14 +166,6 @@ export class ComponentRepository extends BaseRepository {
     return { componentConditions, params }
   }
 
-  /**
-   * Return the license MATCH clause for the filter phase.
-   *
-   * Only included when the WHERE clause references `l`:
-   * - Required MATCH when filtering by a specific license ID
-   * - OPTIONAL MATCH when filtering by license presence (hasLicense)
-   * - Empty when no license filtering is needed (avoids row multiplication)
-   */
   /**
    * Inject dynamic placeholders into a loaded query template.
    */

--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -311,16 +311,15 @@ export class SBOMService {
     // Determine scope for each direct dep
     const directScopes = new Map<string, string | null>()
     for (const bomRef of directBomRefs) {
-      let scope: string | null = null
-      if (scopedEdges) {
+      const scope = scopedEdges
+        ? (() => {
         // For SPDX: find the edge from root to this bomRef and use its scope
-        const edge = scopedEdges.find(e =>
-          (e.from === rootBomRef || (rootName && e.from.includes(rootName))) && e.to === bomRef
-        )
-        scope = edge?.scope ?? null
-      } else {
-        scope = componentScopeByBomRef.get(bomRef) ?? null
-      }
+          const edge = scopedEdges.find(e =>
+            (e.from === rootBomRef || (rootName && e.from.includes(rootName))) && e.to === bomRef
+          )
+          return edge?.scope ?? null
+        })()
+        : componentScopeByBomRef.get(bomRef) ?? null
       directScopes.set(bomRef, scope)
     }
 

--- a/server/utils/sbom-validator.ts
+++ b/server/utils/sbom-validator.ts
@@ -86,7 +86,7 @@ export class SbomValidator {
       logger.info('SBOM validators initialized successfully')
     } catch (error) {
       logger.error({ err: error }, 'Failed to initialize SBOM validators')
-      throw new Error(`Failed to initialize SBOM validators: ${error instanceof Error ? error.message : 'Unknown error'}`)
+      throw new Error(`Failed to initialize SBOM validators: ${error instanceof Error ? error.message : 'Unknown error'}`, { cause: error })
     }
   }
 


### PR DESCRIPTION
## Description

Fixes the Nuxt dev server startup transform error in the component repository and disables the Bunny font provider to avoid repeated dev-server metadata fetch warnings when Bunny is unreachable. Also includes lint-only fixes required by the repository PR workflow.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Fixes #
Relates to #

## Changes Made

- Fixed the unfinished `depScope` filter branch in `ComponentRepository` so Nitro can transform the server bundle and scoped dependency filters add the intended `USES` edge predicate.
- Disabled the Bunny provider in Nuxt Fonts configuration to prevent repeated `https://fonts.bunny.net/list` retry warnings during dev startup.
- Fixed existing lint errors by preserving caught errors as `cause` and removing a useless assignment in SBOM service logic.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

Verification performed:

- `npx nuxt prepare`
- `npx eslint server/repositories/component.repository.ts nuxt.config.ts`
- `npm run test:server:repositories`
- `npm run lint`
- `npm run mdlint`

The running `nuxt-dev` Ona service restarted cleanly after the changes; Nitro built successfully and the Bunny fetch warning was absent from the fresh startup logs.