### PR TITLE
Add OpenSSF Scorecard enrichment

### DIFF
--- a/app/pages/components/[key].vue
+++ b/app/pages/components/[key].vue
@@ -279,6 +279,85 @@
             />
           </div>
         </UCard>
+
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between gap-3">
+              <h2 class="text-lg font-semibold">Security Scorecard</h2>
+              <UBadge :color="getSecurityScorecardColor(component.securityScorecard?.score, component.securityScorecard?.status)" variant="subtle">
+                {{ getSecurityScorecardLabel(component.securityScorecard?.score, component.securityScorecard?.status) }}
+              </UBadge>
+            </div>
+          </template>
+
+          <div class="space-y-4">
+            <p class="text-sm text-(--ui-text-muted)">
+              Security score data is provided by OpenSSF Scorecard. Polaris displays this third-party information for visibility and does not store security scorecard data.
+            </p>
+
+            <UAlert
+              v-if="!component.securityScorecard || component.securityScorecard.status === 'unavailable'"
+              color="neutral"
+              variant="subtle"
+              icon="i-lucide-circle-help"
+              title="No security scorecard available"
+              :description="getSecurityScorecardUnavailableDescription(component.securityScorecard?.reason)"
+            />
+
+            <template v-else>
+              <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Repository</span>
+                  <p class="font-medium break-all">
+                    {{ component.securityScorecard.repository ? `${component.securityScorecard.repository.owner}/${component.securityScorecard.repository.name}` : '—' }}
+                  </p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Overall Score</span>
+                  <p class="font-medium">{{ formatScore(component.securityScorecard.score) }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Scanned</span>
+                  <p class="font-medium">{{ component.securityScorecard.scannedAt ? formatDate(component.securityScorecard.scannedAt) : '—' }}</p>
+                </div>
+                <div>
+                  <span class="text-sm text-(--ui-text-muted)">Source</span>
+                  <p class="font-medium">{{ component.securityScorecard.source.name }}</p>
+                </div>
+              </div>
+
+              <div v-if="component.securityScorecard.checks.length > 0">
+                <span class="text-sm text-(--ui-text-muted)">Selected Checks</span>
+                <div class="mt-2 space-y-2">
+                  <div
+                    v-for="check in component.securityScorecard.checks"
+                    :key="check.name"
+                    class="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between"
+                  >
+                    <div>
+                      <p class="font-medium">{{ check.name }}</p>
+                      <p v-if="check.reason" class="text-sm text-(--ui-text-muted)">{{ check.reason }}</p>
+                    </div>
+                    <UBadge :color="getSecurityCheckColor(check.score)" variant="subtle">
+                      {{ formatScore(check.score) }}
+                    </UBadge>
+                  </div>
+                </div>
+              </div>
+            </template>
+
+            <UButton
+              v-if="component.securityScorecard?.source.url"
+              :to="component.securityScorecard.source.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              label="View Source"
+              icon="i-lucide-external-link"
+              variant="outline"
+              size="sm"
+            />
+          </div>
+        </UCard>
       </div>
 
       <UCard v-if="component.purl || component.cpe || component.bomRef">
@@ -424,7 +503,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, PackageMetadataStatus } from '~~/types/api'
+import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, PackageMetadataStatus, SecurityScorecardStatus } from '~~/types/api'
 
 const route = useRoute()
 const router = useRouter()
@@ -509,6 +588,36 @@ function getPackageMetadataUnavailableDescription(reason?: string): string {
     fetch_failed: 'The third-party package metadata source could not be reached.'
   }
   return descriptions[reason || ''] || 'No package metadata is available from the configured third-party source.'
+}
+
+function getSecurityScorecardColor(score?: number | null, status?: SecurityScorecardStatus): 'success' | 'warning' | 'error' | 'neutral' {
+  if (status !== 'available' || score === null || score === undefined) return 'neutral'
+  if (score >= 8) return 'success'
+  if (score >= 5) return 'warning'
+  return 'error'
+}
+
+function getSecurityCheckColor(score?: number | null): 'success' | 'warning' | 'error' | 'neutral' {
+  return getSecurityScorecardColor(score, 'available')
+}
+
+function getSecurityScorecardLabel(score?: number | null, status?: SecurityScorecardStatus): string {
+  if (status !== 'available') return 'Unavailable'
+  return formatScore(score)
+}
+
+function getSecurityScorecardUnavailableDescription(reason?: string): string {
+  const descriptions: Record<string, string> = {
+    missing_repository: 'This component does not have a repository reference for OpenSSF Scorecard lookup.',
+    unsupported_repository: 'OpenSSF Scorecard is only available for public GitHub repositories.',
+    repository_not_found: 'OpenSSF Scorecard did not find a score for this GitHub repository.',
+    fetch_failed: 'The third-party security score source could not be reached.'
+  }
+  return descriptions[reason || ''] || 'No security scorecard data is available from the configured third-party source.'
+}
+
+function formatScore(score?: number | null): string {
+  return typeof score === 'number' ? `${score.toFixed(1)} / 10` : '—'
 }
 
 function formatDate(dateString: string): string {

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -4828,6 +4828,10 @@
                                 "packageMetadata": {
                                   "type": "object",
                                   "nullable": true
+                                },
+                                "securityScorecard": {
+                                  "type": "object",
+                                  "nullable": true
                                 }
                               }
                             }

--- a/server/api/components/[key].get.ts
+++ b/server/api/components/[key].get.ts
@@ -1,6 +1,6 @@
 import { decodeComponentKey } from '../../../utils/component-identity'
-import type { PackageMetadata } from '~~/types/api'
-import { componentService, eolService, packageMetadataService } from '../../services/singletons'
+import type { PackageMetadata, SecurityScorecard } from '~~/types/api'
+import { componentService, eolService, packageMetadataService, securityScoreService } from '../../services/singletons'
 
 /**
  * @openapi
@@ -56,6 +56,9 @@ import { componentService, eolService, packageMetadataService } from '../../serv
  *                             packageMetadata:
  *                               type: object
  *                               nullable: true
+ *                             securityScorecard:
+ *                               type: object
+ *                               nullable: true
  *       400:
  *         description: Component key is missing or invalid
  *       404:
@@ -86,7 +89,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const [eol, packageMetadata] = await Promise.all([
+  const [eol, packageMetadata, securityScorecard] = await Promise.all([
     eolService.getEOLStatus(component),
     packageMetadataService.getMetadata(component).catch((): PackageMetadata => ({
       status: 'unavailable',
@@ -107,6 +110,18 @@ export default defineEventHandler(async (event) => {
         name: 'deps.dev',
         url: null
       }
+    })),
+    securityScoreService.getScore(component).catch((): SecurityScorecard => ({
+      status: 'unavailable',
+      reason: 'fetch_failed',
+      repository: null,
+      score: null,
+      checks: [],
+      scannedAt: null,
+      source: {
+        name: 'OpenSSF Scorecard',
+        url: null
+      }
     }))
   ])
 
@@ -115,7 +130,8 @@ export default defineEventHandler(async (event) => {
     data: {
       ...component,
       eol,
-      packageMetadata
+      packageMetadata,
+      securityScorecard
     }
   }
 })

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -568,9 +568,10 @@ export class ComponentRepository extends BaseRepository {
           purl: dependency.purl ?? null,
           scope: dependency.scope ?? null,
           isDirect: true
-        })),
+      })),
       eol: null,
-      packageMetadata: null
+      packageMetadata: null,
+      securityScorecard: null
     }
   }
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -14,6 +14,7 @@ export { GitHubImportService } from './github-import.service'
 export { EOLService } from './eol.service'
 export { EOLRollupService } from './eol-rollup.service'
 export { PackageMetadataService } from './package-metadata.service'
+export { SecurityScoreService } from './security-score.service'
 export {
   complianceService,
   componentService,
@@ -30,7 +31,8 @@ export {
   gitHubImportService,
   eolService,
   eolRollupService,
-  packageMetadataService
+  packageMetadataService,
+  securityScoreService
 } from './singletons'
 export type { ViolationResult as VersionConstraintViolationResult } from './version-constraint.service'
 export type { ViolationResult as ComplianceViolationResult } from './compliance.service'

--- a/server/services/security-score.service.ts
+++ b/server/services/security-score.service.ts
@@ -1,0 +1,239 @@
+import type { Component, ExternalReference, SecurityScorecard, SecurityScorecardCheck, SecurityScorecardUnavailableReason } from '~~/types/api'
+
+interface CacheEntry<T> {
+  expiresAt: number
+  value: T
+}
+
+interface CacheStorage {
+  getItem<T>(key: string): Promise<T | null>
+  setItem<T>(key: string, value: T): Promise<void>
+}
+
+type JsonFetcher = <T>(url: string) => Promise<T>
+
+interface ScorecardResponse {
+  date?: string
+  score?: number
+  checks?: ScorecardCheckResponse[]
+}
+
+interface ScorecardCheckResponse {
+  name?: string
+  score?: number
+  reason?: string
+}
+
+export interface GitHubRepository {
+  owner: string
+  name: string
+}
+
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000
+const SCORECARD_API_BASE = 'https://api.scorecard.dev/projects/github.com'
+const SCORECARD_WEB_BASE = 'https://scorecard.dev/viewer/?uri=github.com'
+
+const SELECTED_CHECKS = [
+  'Code-Review',
+  'Dependency-Update-Tool',
+  'Vulnerabilities',
+  'Security-Policy',
+  'Maintained',
+  'SAST',
+  'Signed-Releases'
+]
+
+const REPOSITORY_REFERENCE_TYPES = new Set([
+  'vcs',
+  'source',
+  'source-distribution',
+  'distribution',
+  'website'
+])
+
+export class SecurityScoreService {
+  constructor(
+    private readonly fetcher: JsonFetcher = fetchJson,
+    private readonly storageFactory: () => CacheStorage = () => useStorage('cache:api') as CacheStorage
+  ) {}
+
+  async getScore(component: Pick<Component, 'homepage' | 'externalReferences'>): Promise<SecurityScorecard> {
+    const repository = this.resolveRepository(component)
+    if (!repository) {
+      return this.unavailable(this.hasRepositoryCandidate(component) ? 'unsupported_repository' : 'missing_repository', null)
+    }
+
+    try {
+      const scorecard = await this.getScorecard(repository)
+      return this.available(repository, scorecard)
+    } catch (error) {
+      return this.unavailable(this.isNotFound(error) ? 'repository_not_found' : 'fetch_failed', repository)
+    }
+  }
+
+  resolveRepository(component: Pick<Component, 'homepage' | 'externalReferences'>): GitHubRepository | null {
+    const candidates = [
+      ...this.referenceCandidates(component.externalReferences),
+      component.homepage
+    ]
+
+    for (const candidate of candidates) {
+      const repository = this.parseGitHubRepository(candidate)
+      if (repository) return repository
+    }
+
+    return null
+  }
+
+  parseGitHubRepository(value?: string | null): GitHubRepository | null {
+    if (!value) return null
+
+    const normalized = value.trim()
+      .replace(/^git\+/, '')
+      .replace(/^ssh:\/\/git@github\.com\//i, 'https://github.com/')
+      .replace(/^git:\/\/github\.com\//i, 'https://github.com/')
+      .replace(/^git@github\.com:/i, 'https://github.com/')
+      .replace(/^git@github\.com\//i, 'https://github.com/')
+
+    let path: string
+    try {
+      const url = new URL(normalized)
+      if (url.hostname.toLowerCase() !== 'github.com') return null
+      path = url.pathname
+    } catch {
+      return null
+    }
+
+    const [owner, repo] = path
+      .replace(/^\/+/, '')
+      .split(/[?#]/, 1)[0]!
+      .split('/')
+
+    if (!owner || !repo) return null
+
+    const name = repo.replace(/\.git$/i, '')
+    if (!this.validGitHubPathSegment(owner) || !this.validGitHubPathSegment(name)) {
+      return null
+    }
+
+    return {
+      owner: owner.toLowerCase(),
+      name: name.toLowerCase()
+    }
+  }
+
+  private referenceCandidates(references: ExternalReference[] = []): Array<string | null> {
+    const prioritized = references.filter(reference => REPOSITORY_REFERENCE_TYPES.has(reference.type?.toLowerCase()))
+    const remaining = references.filter(reference => !REPOSITORY_REFERENCE_TYPES.has(reference.type?.toLowerCase()))
+    return [...prioritized, ...remaining].map(reference => reference.url)
+  }
+
+  private hasRepositoryCandidate(component: Pick<Component, 'homepage' | 'externalReferences'>): boolean {
+    return Boolean(component.homepage || component.externalReferences.some(reference => reference.url))
+  }
+
+  private async getScorecard(repository: GitHubRepository): Promise<ScorecardResponse> {
+    const key = `scorecard:v1:github:${repository.owner}/${repository.name}`
+    return await this.cached(key, () => this.fetcher<ScorecardResponse>(this.apiUrl(repository)))
+  }
+
+  private async cached<T>(key: string, producer: () => Promise<T>): Promise<T> {
+    const storage = this.storageFactory()
+    const cached = await storage.getItem<CacheEntry<T>>(key)
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.value
+    }
+
+    const value = await producer()
+    await storage.setItem(key, {
+      expiresAt: Date.now() + CACHE_TTL_MS,
+      value
+    })
+    return value
+  }
+
+  private available(repository: GitHubRepository, response: ScorecardResponse): SecurityScorecard {
+    return {
+      status: 'available',
+      repository: this.repositoryPayload(repository),
+      score: typeof response.score === 'number' ? response.score : null,
+      checks: this.selectedChecks(response.checks || []),
+      scannedAt: response.date || null,
+      source: {
+        name: 'OpenSSF Scorecard',
+        url: this.webUrl(repository)
+      }
+    }
+  }
+
+  private unavailable(reason: SecurityScorecardUnavailableReason, repository: GitHubRepository | null): SecurityScorecard {
+    return {
+      status: 'unavailable',
+      reason,
+      repository: repository ? this.repositoryPayload(repository) : null,
+      score: null,
+      checks: [],
+      scannedAt: null,
+      source: {
+        name: 'OpenSSF Scorecard',
+        url: repository ? this.webUrl(repository) : null
+      }
+    }
+  }
+
+  private selectedChecks(checks: ScorecardCheckResponse[]): SecurityScorecardCheck[] {
+    const byName = new Map(checks.map(check => [check.name, check]))
+
+    return SELECTED_CHECKS
+      .map(name => byName.get(name))
+      .filter((check): check is ScorecardCheckResponse => Boolean(check?.name))
+      .map(check => ({
+        name: check.name!,
+        score: typeof check.score === 'number' ? check.score : null,
+        reason: check.reason || null
+      }))
+  }
+
+  private repositoryPayload(repository: GitHubRepository): NonNullable<SecurityScorecard['repository']> {
+    return {
+      host: 'github.com',
+      owner: repository.owner,
+      name: repository.name,
+      url: `https://github.com/${repository.owner}/${repository.name}`
+    }
+  }
+
+  private apiUrl(repository: GitHubRepository): string {
+    return `${SCORECARD_API_BASE}/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}`
+  }
+
+  private webUrl(repository: GitHubRepository): string {
+    return `${SCORECARD_WEB_BASE}/${encodeURIComponent(repository.owner)}/${encodeURIComponent(repository.name)}`
+  }
+
+  private validGitHubPathSegment(value: string): boolean {
+    return /^[a-z0-9_.-]+$/i.test(value)
+  }
+
+  private isNotFound(error: unknown): boolean {
+    const statusCode = typeof error === 'object' && error && 'statusCode' in error
+      ? Number((error as { statusCode?: unknown }).statusCode)
+      : null
+
+    return statusCode === 404
+  }
+}
+
+class FetchJsonError extends Error {
+  constructor(message: string, readonly statusCode: number) {
+    super(message)
+  }
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new FetchJsonError(`Request failed with status ${response.status}`, response.status)
+  }
+  return await response.json() as T
+}

--- a/server/services/singletons.ts
+++ b/server/services/singletons.ts
@@ -26,6 +26,7 @@ import { GitHubImportService } from './github-import.service'
 import { EOLService } from './eol.service'
 import { EOLRollupService } from './eol-rollup.service'
 import { PackageMetadataService } from './package-metadata.service'
+import { SecurityScoreService } from './security-score.service'
 
 export const technologyService = new TechnologyService()
 export const teamService = new TeamService()
@@ -43,3 +44,4 @@ export const gitHubImportService = new GitHubImportService()
 export const eolService = new EOLService()
 export const eolRollupService = new EOLRollupService()
 export const packageMetadataService = new PackageMetadataService()
+export const securityScoreService = new SecurityScoreService()

--- a/test/app/pages/components/key.test.ts
+++ b/test/app/pages/components/key.test.ts
@@ -44,7 +44,8 @@ const baseComponent: ComponentDetail = {
     }
   ],
   eol: null,
-  packageMetadata: null
+  packageMetadata: null,
+  securityScorecard: null
 }
 
 function mountPage(options: {
@@ -156,5 +157,38 @@ describe('component detail dependencies section', () => {
     await flushPromises()
 
     expect(wrapper.text()).toContain('0 direct dependencies')
+  })
+
+  it('renders security scorecard enrichment when available', async () => {
+    const { wrapper } = mountPage({
+      component: {
+        securityScorecard: {
+          status: 'available',
+          repository: {
+            host: 'github.com',
+            owner: 'nodejs',
+            name: 'node',
+            url: 'https://github.com/nodejs/node'
+          },
+          score: 8.5,
+          checks: [
+            { name: 'Code-Review', score: 9, reason: 'Found pull request reviews.' },
+            { name: 'Vulnerabilities', score: 7, reason: 'No known vulnerabilities detected.' }
+          ],
+          scannedAt: '2026-05-30',
+          source: {
+            name: 'OpenSSF Scorecard',
+            url: 'https://scorecard.dev/viewer/?uri=github.com/nodejs/node'
+          }
+        }
+      }
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Security Scorecard')
+    expect(wrapper.text()).toContain('nodejs/node')
+    expect(wrapper.text()).toContain('8.5 / 10')
+    expect(wrapper.text()).toContain('Code-Review')
+    expect(wrapper.text()).toContain('Vulnerabilities')
   })
 })

--- a/test/server/api/component-detail.spec.ts
+++ b/test/server/api/component-detail.spec.ts
@@ -3,12 +3,13 @@ import { mockEvent } from '../../fixtures/h3-event'
 import { encodeComponentKey } from '../../../utils/component-identity'
 import handler from '../../../server/api/components/[key].get'
 import eolHandler from '../../../server/api/components/eol.get'
-import { componentService, eolService, packageMetadataService } from '../../../server/services/singletons'
+import { componentService, eolService, packageMetadataService, securityScoreService } from '../../../server/services/singletons'
 
 vi.mock('../../../server/services/singletons', () => ({
   componentService: { findByIdentity: vi.fn() },
   eolService: { getEOLStatus: vi.fn() },
-  packageMetadataService: { getMetadata: vi.fn() }
+  packageMetadataService: { getMetadata: vi.fn() },
+  securityScoreService: { getScore: vi.fn() }
 }))
 
 const mockComponent = {
@@ -29,7 +30,7 @@ const mockComponent = {
   author: null,
   publisher: null,
   homepage: null,
-  externalReferences: [],
+  externalReferences: [{ type: 'vcs', url: 'https://github.com/nodejs/node' }],
   description: null,
   releaseDate: null,
   publishedDate: null,
@@ -49,7 +50,8 @@ const mockComponent = {
     }
   ],
   eol: null,
-  packageMetadata: null
+  packageMetadata: null,
+  securityScorecard: null
 }
 
 const mockEol = {
@@ -82,6 +84,22 @@ const mockPackageMetadata = {
   source: { name: 'deps.dev' as const, url: 'https://deps.dev/npm/node/24.16.0' }
 }
 
+const mockSecurityScorecard = {
+  status: 'available' as const,
+  repository: {
+    host: 'github.com' as const,
+    owner: 'nodejs',
+    name: 'node',
+    url: 'https://github.com/nodejs/node'
+  },
+  score: 8.5,
+  checks: [
+    { name: 'Code-Review', score: 9, reason: 'Found pull request reviews.' }
+  ],
+  scannedAt: '2026-05-30',
+  source: { name: 'OpenSSF Scorecard' as const, url: 'https://scorecard.dev/viewer/?uri=github.com/nodejs/node' }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
@@ -91,6 +109,7 @@ describe('GET /api/components/{key}', () => {
     vi.mocked(componentService.findByIdentity).mockResolvedValue(mockComponent)
     vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
     vi.mocked(packageMetadataService.getMetadata).mockResolvedValue(mockPackageMetadata)
+    vi.mocked(securityScoreService.getScore).mockResolvedValue(mockSecurityScorecard)
 
     const key = encodeComponentKey(mockComponent)
     const result = await handler(mockEvent({ params: { key } }))
@@ -98,13 +117,15 @@ describe('GET /api/components/{key}', () => {
     expect(componentService.findByIdentity).toHaveBeenCalledWith({ purl: 'pkg:npm/node@24.16.0' })
     expect(eolService.getEOLStatus).toHaveBeenCalledWith(mockComponent)
     expect(packageMetadataService.getMetadata).toHaveBeenCalledWith(mockComponent)
+    expect(securityScoreService.getScore).toHaveBeenCalledWith(mockComponent)
     expect(result).toMatchObject({
       success: true,
       data: {
         name: 'node',
         directDependencies: mockComponent.directDependencies,
         eol: mockEol,
-        packageMetadata: mockPackageMetadata
+        packageMetadata: mockPackageMetadata,
+        securityScorecard: mockSecurityScorecard
       }
     })
   })
@@ -119,6 +140,7 @@ describe('GET /api/components/{key}', () => {
     vi.mocked(componentService.findByIdentity).mockResolvedValue(mockComponent)
     vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
     vi.mocked(packageMetadataService.getMetadata).mockRejectedValue(new Error('deps.dev unavailable'))
+    vi.mocked(securityScoreService.getScore).mockResolvedValue(mockSecurityScorecard)
 
     const key = encodeComponentKey(mockComponent)
     const result = await handler(mockEvent({ params: { key } }))
@@ -132,6 +154,32 @@ describe('GET /api/components/{key}', () => {
           status: 'unavailable',
           reason: 'fetch_failed',
           currentVersion: '24.16.0'
+        },
+        securityScorecard: mockSecurityScorecard
+      }
+    })
+  })
+
+  it('does not fail component details when security scorecard enrichment throws', async () => {
+    vi.mocked(componentService.findByIdentity).mockResolvedValue(mockComponent)
+    vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
+    vi.mocked(packageMetadataService.getMetadata).mockResolvedValue(mockPackageMetadata)
+    vi.mocked(securityScoreService.getScore).mockRejectedValue(new Error('scorecard unavailable'))
+
+    const key = encodeComponentKey(mockComponent)
+    const result = await handler(mockEvent({ params: { key } }))
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        name: 'node',
+        eol: mockEol,
+        packageMetadata: mockPackageMetadata,
+        securityScorecard: {
+          status: 'unavailable',
+          reason: 'fetch_failed',
+          score: null,
+          checks: []
         }
       }
     })

--- a/test/server/services/security-score.service.spec.ts
+++ b/test/server/services/security-score.service.spec.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SecurityScoreService } from '../../../server/services/security-score.service'
+
+function createStorage() {
+  const cache = new Map<string, unknown>()
+  return {
+    getItem: vi.fn(async (key: string) => cache.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value)
+    })
+  }
+}
+
+const scorecardResponse = {
+  date: '2026-05-30',
+  score: 8.4,
+  checks: [
+    { name: 'Code-Review', score: 9, reason: 'Found pull request reviews.' },
+    { name: 'Dependency-Update-Tool', score: 10, reason: 'Detected dependency update tool.' },
+    { name: 'Vulnerabilities', score: 7, reason: 'No known vulnerabilities detected.' },
+    { name: 'Maintained', score: 8, reason: 'Repository has recent commits.' },
+    { name: 'Binary-Artifacts', score: 4, reason: 'Binary artifacts detected.' }
+  ]
+}
+
+function notFound() {
+  return Object.assign(new Error('not found'), { statusCode: 404 })
+}
+
+describe('SecurityScoreService', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-06-02T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('parses supported GitHub repository URLs', () => {
+    const service = new SecurityScoreService()
+
+    expect(service.parseGitHubRepository('https://github.com/nuxt/nuxt')).toEqual({ owner: 'nuxt', name: 'nuxt' })
+    expect(service.parseGitHubRepository('https://github.com/nuxt/nuxt.git')).toEqual({ owner: 'nuxt', name: 'nuxt' })
+    expect(service.parseGitHubRepository('https://github.com/nuxt/nuxt/tree/main')).toEqual({ owner: 'nuxt', name: 'nuxt' })
+    expect(service.parseGitHubRepository('git+https://github.com/nuxt/nuxt.git')).toEqual({ owner: 'nuxt', name: 'nuxt' })
+    expect(service.parseGitHubRepository('git://github.com/nuxt/nuxt.git')).toEqual({ owner: 'nuxt', name: 'nuxt' })
+    expect(service.parseGitHubRepository('ssh://git@github.com/nuxt/nuxt.git')).toEqual({ owner: 'nuxt', name: 'nuxt' })
+    expect(service.parseGitHubRepository('git@github.com:nuxt/nuxt.git')).toEqual({ owner: 'nuxt', name: 'nuxt' })
+  })
+
+  it('ignores unsupported repository URLs', () => {
+    const service = new SecurityScoreService()
+
+    expect(service.parseGitHubRepository('https://gitlab.com/nuxt/nuxt')).toBeNull()
+    expect(service.parseGitHubRepository('https://github.com/nuxt')).toBeNull()
+    expect(service.parseGitHubRepository('not-a-url')).toBeNull()
+  })
+
+  it('prefers VCS external references over homepage when resolving a repository', () => {
+    const service = new SecurityScoreService()
+
+    expect(service.resolveRepository({
+      homepage: 'https://github.com/other/project',
+      externalReferences: [
+        { type: 'documentation', url: 'https://github.com/docs/project' },
+        { type: 'vcs', url: 'https://github.com/nuxt/nuxt.git' }
+      ]
+    })).toEqual({ owner: 'nuxt', name: 'nuxt' })
+  })
+
+  it('fetches scorecard data and maps a stable Polaris response', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn(async () => scorecardResponse)
+    const service = new SecurityScoreService(fetcher as never, () => storage)
+
+    const scorecard = await service.getScore({
+      homepage: null,
+      externalReferences: [{ type: 'vcs', url: 'https://github.com/nuxt/nuxt' }]
+    })
+
+    expect(fetcher).toHaveBeenCalledWith('https://api.scorecard.dev/projects/github.com/nuxt/nuxt')
+    expect(scorecard).toMatchObject({
+      status: 'available',
+      repository: {
+        host: 'github.com',
+        owner: 'nuxt',
+        name: 'nuxt',
+        url: 'https://github.com/nuxt/nuxt'
+      },
+      score: 8.4,
+      scannedAt: '2026-05-30',
+      source: {
+        name: 'OpenSSF Scorecard',
+        url: 'https://scorecard.dev/viewer/?uri=github.com/nuxt/nuxt'
+      }
+    })
+    expect(scorecard.checks).toEqual([
+      { name: 'Code-Review', score: 9, reason: 'Found pull request reviews.' },
+      { name: 'Dependency-Update-Tool', score: 10, reason: 'Detected dependency update tool.' },
+      { name: 'Vulnerabilities', score: 7, reason: 'No known vulnerabilities detected.' },
+      { name: 'Maintained', score: 8, reason: 'Repository has recent commits.' }
+    ])
+  })
+
+  it('caches scorecard responses for repeated lookups', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn(async () => scorecardResponse)
+    const service = new SecurityScoreService(fetcher as never, () => storage)
+
+    await service.getScore({ homepage: 'https://github.com/nuxt/nuxt', externalReferences: [] })
+    await service.getScore({ homepage: 'https://github.com/nuxt/nuxt', externalReferences: [] })
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+    expect(storage.setItem).toHaveBeenCalledWith('scorecard:v1:github:nuxt/nuxt', expect.any(Object))
+  })
+
+  it('returns unavailable for missing, unsupported, not found, and failed lookups', async () => {
+    const storage = createStorage()
+    const service = new SecurityScoreService(vi.fn(async () => {
+      throw new Error('network unavailable')
+    }) as never, () => storage)
+
+    await expect(service.getScore({ homepage: null, externalReferences: [] })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'missing_repository'
+    })
+    await expect(service.getScore({ homepage: 'https://gitlab.com/nuxt/nuxt', externalReferences: [] })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'unsupported_repository'
+    })
+    await expect(service.getScore({ homepage: 'https://github.com/nuxt/nuxt', externalReferences: [] })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'fetch_failed'
+    })
+
+    const notFoundService = new SecurityScoreService(vi.fn(async () => {
+      throw notFound()
+    }) as never, () => createStorage())
+    await expect(notFoundService.getScore({ homepage: 'https://github.com/missing/project', externalReferences: [] })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'repository_not_found',
+      repository: {
+        owner: 'missing',
+        name: 'project'
+      }
+    })
+  })
+})

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -221,11 +221,44 @@ export interface PackageMetadata {
   }
 }
 
+export type SecurityScorecardStatus = 'available' | 'unavailable'
+
+export type SecurityScorecardUnavailableReason =
+  | 'missing_repository'
+  | 'unsupported_repository'
+  | 'repository_not_found'
+  | 'fetch_failed'
+
+export interface SecurityScorecardCheck {
+  name: string
+  score: number | null
+  reason: string | null
+}
+
+export interface SecurityScorecard {
+  status: SecurityScorecardStatus
+  reason?: SecurityScorecardUnavailableReason
+  repository: {
+    host: 'github.com'
+    owner: string
+    name: string
+    url: string
+  } | null
+  score: number | null
+  checks: SecurityScorecardCheck[]
+  scannedAt: string | null
+  source: {
+    name: 'OpenSSF Scorecard'
+    url: string | null
+  }
+}
+
 export interface ComponentDetail extends Component {
   systems: ComponentSystemUsage[]
   directDependencies: ComponentDirectDependency[]
   eol: EOLStatus | null
   packageMetadata: PackageMetadata | null
+  securityScorecard: SecurityScorecard | null
 }
 
 export interface TechnologyVersionLifecycle {


### PR DESCRIPTION
## Description

Adds read-through OpenSSF Scorecard enrichment to component detail pages. Components with public GitHub repository references now show normalized Scorecard data, selected security checks, scan date, and a source link without persisting Scorecard data to Neo4j.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Configuration or build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #601
Relates to #599

## Changes Made

<!-- List the specific changes you made -->

- Added `SecurityScoreService` with GitHub repository URL parsing, Scorecard API fetches, 7-day `cache:api` read-through caching, and typed unavailable states.
- Added `securityScorecard` to component detail API responses and UI, including score badge, repository, selected checks, scan date, unavailable state, and source link.
- Added service, API, and page tests for Scorecard enrichment and regenerated OpenAPI output.

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

Not included; changes are covered by component page tests.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

<!-- Add any additional information that reviewers should know -->

Verification run:

- `npm run test:server`
- `npm run test:app`
- `npm run build`
- `npm run lint`
- `npm run mdlint`

`npm run build` completed successfully with existing Nuxt/Vite sourcemap and chunk-size warnings from build tooling.