### PR TITLE
Add registry metadata fallbacks

### DIFF
--- a/app/pages/components/[key].vue
+++ b/app/pages/components/[key].vue
@@ -95,7 +95,7 @@
                 <span class="text-sm text-(--ui-text-muted)">External Signals</span>
                 <div class="mt-1 flex flex-wrap gap-2">
                   <UBadge v-if="component.packageMetadata?.status === 'available'" color="success" variant="subtle">
-                    deps.dev
+                    {{ getPackageSourceLabel(component.packageMetadata.source.name) }}
                   </UBadge>
                   <UBadge v-if="component.eol?.source.url" color="neutral" variant="subtle">
                     endoflife.date
@@ -198,7 +198,7 @@
             <div class="flex items-center justify-between gap-3">
               <div>
                 <h2 class="text-lg font-semibold">Registry</h2>
-                <p class="text-xs text-(--ui-text-muted)">Source: deps.dev</p>
+                <p class="text-xs text-(--ui-text-muted)">Source: {{ getPackageSourceLabel(component.packageMetadata?.source.name) }}</p>
               </div>
               <UBadge :color="getPackageMetadataColor(component.packageMetadata?.status)" variant="subtle">
                 {{ getPackageMetadataLabel(component.packageMetadata?.status) }}
@@ -223,7 +223,7 @@
                 variant="subtle"
                 icon="i-lucide-triangle-alert"
                 title="Package version is deprecated"
-                :description="component.packageMetadata.deprecatedReason || 'deps.dev reports this package version as deprecated.'"
+                :description="component.packageMetadata.deprecatedReason || `${getPackageSourceLabel(component.packageMetadata.source.name)} reports this package version as deprecated.`"
               />
 
               <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4">
@@ -288,7 +288,7 @@
               :to="component.packageMetadata.source.url"
               target="_blank"
               rel="noopener noreferrer"
-              label="Open deps.dev"
+              :label="`Open ${getPackageSourceLabel(component.packageMetadata.source.name)}`"
               icon="i-lucide-external-link"
               variant="outline"
               size="sm"
@@ -482,7 +482,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, PackageMetadataStatus, SecurityScorecardStatus } from '~~/types/api'
+import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, PackageMetadataSource, PackageMetadataStatus, SecurityScorecardStatus } from '~~/types/api'
 
 const route = useRoute()
 const router = useRouter()
@@ -585,6 +585,16 @@ function getPackageMetadataColor(status?: PackageMetadataStatus): 'success' | 'n
 
 function getPackageMetadataLabel(status?: PackageMetadataStatus): string {
   return status === 'available' ? 'Available' : 'Unavailable'
+}
+
+function getPackageSourceLabel(source?: PackageMetadataSource): string {
+  const labels: Record<PackageMetadataSource, string> = {
+    'deps.dev': 'deps.dev',
+    npm: 'npm',
+    pypi: 'PyPI',
+    maven: 'Maven Central'
+  }
+  return source ? labels[source] : 'deps.dev'
 }
 
 function getPackageMetadataUnavailableDescription(reason?: string): string {

--- a/server/services/package-metadata.service.ts
+++ b/server/services/package-metadata.service.ts
@@ -1,4 +1,4 @@
-import type { Component, PackageAdvisory, PackageMetadata, PackageMetadataUnavailableReason } from '~~/types/api'
+import type { Component, PackageAdvisory, PackageMetadata, PackageMetadataSource, PackageMetadataUnavailableReason } from '~~/types/api'
 
 interface CacheEntry<T> {
   expiresAt: number
@@ -35,6 +35,44 @@ interface DepsVersionResponse {
   links?: Array<{ label?: string; url?: string }>
 }
 
+interface NpmVersionResponse {
+  deprecated?: string
+  license?: string
+  licenses?: Array<{ type?: string } | string> | string
+}
+
+interface NpmPackageResponse {
+  'dist-tags'?: {
+    latest?: string
+  }
+  time?: Record<string, string>
+  versions?: Record<string, NpmVersionResponse>
+}
+
+interface PyPIPackageResponse {
+  info?: {
+    version?: string
+    license?: string
+    classifiers?: string[]
+  }
+  releases?: Record<string, Array<{
+    upload_time_iso_8601?: string
+    yanked?: boolean
+    yanked_reason?: string
+  }>>
+}
+
+interface MavenSearchResponse {
+  response?: {
+    docs?: Array<{
+      g?: string
+      a?: string
+      latestVersion?: string
+      timestamp?: number
+    }>
+  }
+}
+
 export interface ParsedPackagePurl {
   system: string
   packageName: string
@@ -45,6 +83,12 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000
 const RECENT_RELEASE_WINDOW_MS = 365 * 24 * 60 * 60 * 1000
 const DEPS_DEV_API_BASE = 'https://api.deps.dev/v3'
 const DEPS_DEV_WEB_BASE = 'https://deps.dev'
+const NPM_REGISTRY_BASE = 'https://registry.npmjs.org'
+const NPM_WEB_BASE = 'https://www.npmjs.com/package'
+const PYPI_API_BASE = 'https://pypi.org/pypi'
+const PYPI_WEB_BASE = 'https://pypi.org/project'
+const MAVEN_SEARCH_API = 'https://search.maven.org/solrsearch/select'
+const MAVEN_SEARCH_WEB = 'https://search.maven.org/search'
 
 const SYSTEM_MAP: Record<string, string> = {
   npm: 'npm',
@@ -81,16 +125,30 @@ export class PackageMetadataService {
     try {
       packageData = await this.getPackage(parsed.system, parsed.packageName)
     } catch (error) {
-      return this.unavailable(this.isNotFound(error) ? 'package_not_found' : 'fetch_failed', parsed.system, parsed.packageName, currentVersion)
+      return await this.fallbackOrUnavailable(
+        this.isNotFound(error) ? 'package_not_found' : 'fetch_failed',
+        parsed.system,
+        parsed.packageName,
+        currentVersion
+      )
     }
 
     try {
       const versionData = currentVersion
         ? await this.getVersion(parsed.system, parsed.packageName, currentVersion)
         : null
-      return this.available(parsed.system, parsed.packageName, currentVersion, packageData, versionData)
+      const metadata = this.available(parsed.system, parsed.packageName, currentVersion, packageData, versionData)
+      if (this.isIncomplete(metadata)) {
+        return await this.fallbackOrMetadata(metadata, parsed.system, parsed.packageName, currentVersion)
+      }
+      return metadata
     } catch (error) {
-      return this.unavailable(this.isNotFound(error) ? 'version_not_found' : 'fetch_failed', parsed.system, parsed.packageName, currentVersion)
+      return await this.fallbackOrUnavailable(
+        this.isNotFound(error) ? 'version_not_found' : 'fetch_failed',
+        parsed.system,
+        parsed.packageName,
+        currentVersion
+      )
     }
   }
 
@@ -129,6 +187,52 @@ export class PackageMetadataService {
   private async getVersion(system: string, packageName: string, version: string): Promise<DepsVersionResponse> {
     const key = `package-metadata:v2:version:${system}:${encodeURIComponent(packageName)}:${encodeURIComponent(version)}`
     return await this.cached(key, () => this.fetcher<DepsVersionResponse>(this.versionApiUrl(system, packageName, version)))
+  }
+
+  private async fallbackOrMetadata(
+    metadata: PackageMetadata,
+    system: string,
+    packageName: string,
+    currentVersion: string | null
+  ): Promise<PackageMetadata> {
+    try {
+      return await this.getNativeMetadata(system, packageName, currentVersion)
+    } catch {
+      return metadata
+    }
+  }
+
+  private async fallbackOrUnavailable(
+    reason: PackageMetadataUnavailableReason,
+    system: string,
+    packageName: string,
+    currentVersion: string | null
+  ): Promise<PackageMetadata> {
+    try {
+      return await this.getNativeMetadata(system, packageName, currentVersion)
+    } catch {
+      return this.unavailable(reason, system, packageName, currentVersion)
+    }
+  }
+
+  private async getNativeMetadata(
+    system: string,
+    packageName: string,
+    currentVersion: string | null
+  ): Promise<PackageMetadata> {
+    const key = `package-metadata:v2:native:${system}:${encodeURIComponent(packageName)}:${encodeURIComponent(currentVersion || '_')}`
+    return await this.cached(key, async () => {
+      switch (system) {
+        case 'npm':
+          return await this.getNpmMetadata(packageName, currentVersion)
+        case 'pypi':
+          return await this.getPyPIMetadata(packageName, currentVersion)
+        case 'maven':
+          return await this.getMavenMetadata(packageName, currentVersion)
+        default:
+          throw new Error(`Unsupported native registry system: ${system}`)
+      }
+    })
   }
 
   private async cached<T>(key: string, producer: () => Promise<T>): Promise<T> {
@@ -180,6 +284,41 @@ export class PackageMetadataService {
     }
   }
 
+  private nativeAvailable(input: {
+    source: PackageMetadataSource
+    system: string
+    packageName: string
+    currentVersion: string | null
+    latestVersion: string | null
+    defaultVersion?: string | null
+    publishedAt?: string | null
+    isDeprecated?: boolean | null
+    deprecatedReason?: string | null
+    licenses?: string[]
+    recentReleases?: number | null
+    url: string | null
+  }): PackageMetadata {
+    return {
+      status: 'available',
+      system: input.system,
+      packageName: input.packageName,
+      currentVersion: input.currentVersion,
+      latestVersion: input.latestVersion,
+      defaultVersion: input.defaultVersion ?? input.latestVersion,
+      publishedAt: input.publishedAt ?? null,
+      isDeprecated: input.isDeprecated ?? null,
+      deprecatedReason: input.deprecatedReason ?? null,
+      licenses: input.licenses ?? [],
+      advisoryCount: null,
+      advisories: [],
+      recentReleases: input.recentReleases ?? null,
+      source: {
+        name: input.source,
+        url: input.url
+      }
+    }
+  }
+
   private unavailable(
     reason: PackageMetadataUnavailableReason,
     system: string | null,
@@ -227,6 +366,14 @@ export class PackageMetadataService {
     }).length
   }
 
+  private recentReleaseCountFromDates(dates: string[]): number {
+    const cutoff = Date.now() - RECENT_RELEASE_WINDOW_MS
+    return dates.filter((date) => {
+      const publishedAt = Date.parse(date)
+      return !Number.isNaN(publishedAt) && publishedAt >= cutoff
+    }).length
+  }
+
   private advisories(advisoryKeys: Array<{ id?: string }>): PackageAdvisory[] {
     return advisoryKeys
       .map(advisory => advisory.id)
@@ -255,6 +402,152 @@ export class PackageMetadataService {
       : null
 
     return statusCode === 404
+  }
+
+  private isIncomplete(metadata: PackageMetadata): boolean {
+    return metadata.status === 'available'
+      && (
+        !metadata.latestVersion
+        || (Boolean(metadata.currentVersion) && metadata.publishedAt === null && metadata.isDeprecated === null)
+      )
+  }
+
+  private async getNpmMetadata(packageName: string, currentVersion: string | null): Promise<PackageMetadata> {
+    const data = await this.fetcher<NpmPackageResponse>(`${NPM_REGISTRY_BASE}/${encodeURIComponent(packageName)}`)
+    const latestVersion = data['dist-tags']?.latest || null
+    const selectedVersion = currentVersion || latestVersion
+    const versionData = selectedVersion ? data.versions?.[selectedVersion] : undefined
+    const deprecatedReason = typeof versionData?.deprecated === 'string' && versionData.deprecated.trim()
+      ? versionData.deprecated
+      : null
+    const publishDates = Object.entries(data.time || {})
+      .filter(([key]) => key !== 'created' && key !== 'modified')
+      .map(([, value]) => value)
+
+    return this.nativeAvailable({
+      source: 'npm',
+      system: 'npm',
+      packageName,
+      currentVersion,
+      latestVersion,
+      defaultVersion: latestVersion,
+      publishedAt: selectedVersion ? data.time?.[selectedVersion] || null : data.time?.modified || null,
+      isDeprecated: deprecatedReason !== null,
+      deprecatedReason,
+      licenses: this.npmLicenses(versionData),
+      recentReleases: this.recentReleaseCountFromDates(publishDates),
+      url: `${NPM_WEB_BASE}/${packageName}`
+    })
+  }
+
+  private async getPyPIMetadata(packageName: string, currentVersion: string | null): Promise<PackageMetadata> {
+    const data = await this.fetcher<PyPIPackageResponse>(`${PYPI_API_BASE}/${encodeURIComponent(packageName)}/json`)
+    const latestVersion = data.info?.version || null
+    const selectedVersion = currentVersion || latestVersion
+    const releaseFiles = selectedVersion ? data.releases?.[selectedVersion] || [] : []
+    const yankedFiles = releaseFiles.filter(file => file.yanked)
+    const isDeprecated = releaseFiles.length > 0 ? yankedFiles.length === releaseFiles.length : null
+    const deprecatedReason = yankedFiles.map(file => file.yanked_reason).find(Boolean) || null
+    const releaseDates = Object.values(data.releases || {})
+      .flat()
+      .map(file => file.upload_time_iso_8601)
+      .filter((date): date is string => Boolean(date))
+
+    return this.nativeAvailable({
+      source: 'pypi',
+      system: 'pypi',
+      packageName,
+      currentVersion,
+      latestVersion,
+      defaultVersion: latestVersion,
+      publishedAt: this.firstReleaseUploadTime(releaseFiles),
+      isDeprecated,
+      deprecatedReason,
+      licenses: this.pypiLicenses(data),
+      recentReleases: this.recentReleaseCountFromDates(releaseDates),
+      url: `${PYPI_WEB_BASE}/${encodeURIComponent(packageName)}/`
+    })
+  }
+
+  private async getMavenMetadata(packageName: string, currentVersion: string | null): Promise<PackageMetadata> {
+    const coordinates = this.mavenCoordinates(packageName)
+    if (!coordinates) {
+      throw new Error(`Invalid Maven coordinates: ${packageName}`)
+    }
+
+    const query = `g:"${coordinates.group}" AND a:"${coordinates.artifact}"`
+    const params = new URLSearchParams({
+      q: query,
+      rows: '1',
+      wt: 'json'
+    })
+    const data = await this.fetcher<MavenSearchResponse>(`${MAVEN_SEARCH_API}?${params.toString()}`)
+    const doc = data.response?.docs?.[0]
+    if (!doc?.latestVersion) {
+      throw new Error(`Maven metadata not found for ${packageName}`)
+    }
+
+    const timestamp = typeof doc.timestamp === 'number' ? new Date(doc.timestamp).toISOString() : null
+    return this.nativeAvailable({
+      source: 'maven',
+      system: 'maven',
+      packageName,
+      currentVersion,
+      latestVersion: doc.latestVersion,
+      defaultVersion: doc.latestVersion,
+      publishedAt: currentVersion === doc.latestVersion ? timestamp : null,
+      isDeprecated: null,
+      deprecatedReason: null,
+      licenses: [],
+      recentReleases: null,
+      url: `${MAVEN_SEARCH_WEB}?${new URLSearchParams({ q: query }).toString()}`
+    })
+  }
+
+  private npmLicenses(versionData: NpmVersionResponse | undefined): string[] {
+    if (!versionData) return []
+
+    if (typeof versionData.license === 'string' && versionData.license.trim()) {
+      return [versionData.license]
+    }
+
+    if (typeof versionData.licenses === 'string' && versionData.licenses.trim()) {
+      return [versionData.licenses]
+    }
+
+    if (Array.isArray(versionData.licenses)) {
+      return versionData.licenses
+        .map(license => typeof license === 'string' ? license : license.type)
+        .filter((license): license is string => Boolean(license))
+    }
+
+    return []
+  }
+
+  private pypiLicenses(data: PyPIPackageResponse): string[] {
+    const license = data.info?.license?.trim()
+    if (license) return [license]
+
+    return (data.info?.classifiers || [])
+      .filter(classifier => classifier.startsWith('License :: '))
+      .map(classifier => classifier.split(' :: ').at(-1))
+      .filter((classifier): classifier is string => Boolean(classifier))
+  }
+
+  private firstReleaseUploadTime(files: Array<{ upload_time_iso_8601?: string }>): string | null {
+    return files.map(file => file.upload_time_iso_8601).find(Boolean) || null
+  }
+
+  private mavenCoordinates(packageName: string): { group: string; artifact: string } | null {
+    const separatorIndex = packageName.indexOf(':')
+    if (separatorIndex <= 0 || separatorIndex === packageName.length - 1) {
+      return null
+    }
+
+    return {
+      group: packageName.slice(0, separatorIndex),
+      artifact: packageName.slice(separatorIndex + 1)
+    }
   }
 
   private packageApiUrl(system: string, packageName: string): string {

--- a/server/services/package-metadata.service.ts
+++ b/server/services/package-metadata.service.ts
@@ -1,4 +1,5 @@
 import type { Component, PackageAdvisory, PackageMetadata, PackageMetadataSource, PackageMetadataUnavailableReason } from '~~/types/api'
+import { logger } from '../utils/logger'
 
 interface CacheEntry<T> {
   expiresAt: number
@@ -197,7 +198,13 @@ export class PackageMetadataService {
   ): Promise<PackageMetadata> {
     try {
       return await this.getNativeMetadata(system, packageName, currentVersion)
-    } catch {
+    } catch (error) {
+      logger.warn({
+        err: error,
+        system,
+        packageName,
+        currentVersion
+      }, 'Native package metadata fallback failed; returning deps.dev metadata')
       return metadata
     }
   }
@@ -210,7 +217,14 @@ export class PackageMetadataService {
   ): Promise<PackageMetadata> {
     try {
       return await this.getNativeMetadata(system, packageName, currentVersion)
-    } catch {
+    } catch (error) {
+      logger.warn({
+        err: error,
+        system,
+        packageName,
+        currentVersion,
+        reason
+      }, 'Native package metadata fallback failed; returning unavailable metadata')
       return this.unavailable(reason, system, packageName, currentVersion)
     }
   }
@@ -475,7 +489,9 @@ export class PackageMetadataService {
       throw new Error(`Invalid Maven coordinates: ${packageName}`)
     }
 
-    const query = `g:"${coordinates.group}" AND a:"${coordinates.artifact}"`
+    const group = this.escapeSolrPhrase(coordinates.group)
+    const artifact = this.escapeSolrPhrase(coordinates.artifact)
+    const query = `g:"${group}" AND a:"${artifact}"`
     const params = new URLSearchParams({
       q: query,
       rows: '1',
@@ -535,7 +551,11 @@ export class PackageMetadataService {
   }
 
   private firstReleaseUploadTime(files: Array<{ upload_time_iso_8601?: string }>): string | null {
-    return files.map(file => file.upload_time_iso_8601).find(Boolean) || null
+    return files
+      .map(file => file.upload_time_iso_8601)
+      .filter((date): date is string => Boolean(date) && !Number.isNaN(Date.parse(date)))
+      .sort((a, b) => Date.parse(a) - Date.parse(b))
+      .at(0) || null
   }
 
   private mavenCoordinates(packageName: string): { group: string; artifact: string } | null {
@@ -548,6 +568,10 @@ export class PackageMetadataService {
       group: packageName.slice(0, separatorIndex),
       artifact: packageName.slice(separatorIndex + 1)
     }
+  }
+
+  private escapeSolrPhrase(value: string): string {
+    return value.replace(/([+\-&|!(){}[\]^"~*?:\\/])/g, '\\$1')
   }
 
   private packageApiUrl(system: string, packageName: string): string {

--- a/test/server/services/package-metadata.service.spec.ts
+++ b/test/server/services/package-metadata.service.spec.ts
@@ -49,6 +49,61 @@ function notFound() {
   return Object.assign(new Error('not found'), { statusCode: 404 })
 }
 
+const npmResponse = {
+  'dist-tags': { latest: '2.0.0' },
+  time: {
+    created: '2023-01-01T00:00:00.000Z',
+    modified: '2026-05-22T00:00:00.000Z',
+    '1.2.0': '2025-09-23T12:05:06.000Z',
+    '2.0.0': '2026-05-21T00:00:00.000Z'
+  },
+  versions: {
+    '1.2.0': {
+      deprecated: 'Use 2.x instead.',
+      license: 'MIT'
+    },
+    '2.0.0': {
+      license: 'MIT'
+    }
+  }
+}
+
+const pypiResponse = {
+  info: {
+    version: '5.0.2',
+    license: '',
+    classifiers: ['License :: OSI Approved :: BSD License']
+  },
+  releases: {
+    '5.0.1': [
+      {
+        upload_time_iso_8601: '2025-05-01T08:00:00.000Z',
+        yanked: true,
+        yanked_reason: 'Broken wheel metadata.'
+      }
+    ],
+    '5.0.2': [
+      {
+        upload_time_iso_8601: '2026-04-01T08:00:00.000Z',
+        yanked: false
+      }
+    ]
+  }
+}
+
+const mavenResponse = {
+  response: {
+    docs: [
+      {
+        g: 'org.springframework',
+        a: 'spring-core',
+        latestVersion: '6.2.8',
+        timestamp: Date.parse('2026-05-11T10:30:00.000Z')
+      }
+    ]
+  }
+}
+
 describe('PackageMetadataService', () => {
   beforeEach(() => {
     vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-06-02T00:00:00Z'))
@@ -195,6 +250,129 @@ describe('PackageMetadataService', () => {
       system: 'npm',
       packageName: 'missing',
       currentVersion: '1.0.0'
+    })
+  })
+
+  it('falls back to npm metadata when deps.dev package lookup fails', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn()
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValueOnce(npmResponse)
+    const service = new PackageMetadataService(fetcher as never, () => storage)
+
+    const metadata = await service.getMetadata({
+      purl: 'pkg:npm/@nuxt/ui@1.2.0',
+      version: '1.2.0'
+    })
+
+    expect(fetcher).toHaveBeenNthCalledWith(1, 'https://api.deps.dev/v3/systems/npm/packages/%40nuxt%2Fui')
+    expect(fetcher).toHaveBeenNthCalledWith(2, 'https://registry.npmjs.org/%40nuxt%2Fui')
+    expect(metadata).toMatchObject({
+      status: 'available',
+      system: 'npm',
+      packageName: '@nuxt/ui',
+      currentVersion: '1.2.0',
+      latestVersion: '2.0.0',
+      defaultVersion: '2.0.0',
+      publishedAt: '2025-09-23T12:05:06.000Z',
+      isDeprecated: true,
+      deprecatedReason: 'Use 2.x instead.',
+      licenses: ['MIT'],
+      advisoryCount: null,
+      advisories: [],
+      recentReleases: 2,
+      source: {
+        name: 'npm',
+        url: 'https://www.npmjs.com/package/@nuxt/ui'
+      }
+    })
+  })
+
+  it('falls back to PyPI metadata when deps.dev version lookup fails', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(packageResponse)
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValueOnce(pypiResponse)
+    const service = new PackageMetadataService(fetcher as never, () => storage)
+
+    const metadata = await service.getMetadata({
+      purl: 'pkg:pypi/Django@5.0.1',
+      version: '5.0.1'
+    })
+
+    expect(fetcher).toHaveBeenNthCalledWith(1, 'https://api.deps.dev/v3/systems/pypi/packages/Django')
+    expect(fetcher).toHaveBeenNthCalledWith(2, 'https://api.deps.dev/v3/systems/pypi/packages/Django/versions/5.0.1')
+    expect(fetcher).toHaveBeenNthCalledWith(3, 'https://pypi.org/pypi/Django/json')
+    expect(metadata).toMatchObject({
+      status: 'available',
+      system: 'pypi',
+      packageName: 'Django',
+      currentVersion: '5.0.1',
+      latestVersion: '5.0.2',
+      publishedAt: '2025-05-01T08:00:00.000Z',
+      isDeprecated: true,
+      deprecatedReason: 'Broken wheel metadata.',
+      licenses: ['BSD License'],
+      source: {
+        name: 'pypi',
+        url: 'https://pypi.org/project/Django/'
+      }
+    })
+  })
+
+  it('falls back to Maven metadata with encoded group and artifact query', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn()
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValueOnce(mavenResponse)
+    const service = new PackageMetadataService(fetcher as never, () => storage)
+
+    const metadata = await service.getMetadata({
+      purl: 'pkg:maven/org.springframework/spring-core@6.2.8',
+      version: '6.2.8'
+    })
+
+    const mavenUrl = new URL(fetcher.mock.calls[1][0])
+    expect(mavenUrl.origin + mavenUrl.pathname).toBe('https://search.maven.org/solrsearch/select')
+    expect(mavenUrl.searchParams.get('q')).toBe('g:"org.springframework" AND a:"spring-core"')
+    expect(mavenUrl.searchParams.get('rows')).toBe('1')
+    expect(mavenUrl.searchParams.get('wt')).toBe('json')
+    expect(metadata).toMatchObject({
+      status: 'available',
+      system: 'maven',
+      packageName: 'org.springframework:spring-core',
+      currentVersion: '6.2.8',
+      latestVersion: '6.2.8',
+      publishedAt: '2026-05-11T10:30:00.000Z',
+      isDeprecated: null,
+      deprecatedReason: null,
+      licenses: [],
+      advisoryCount: null,
+      recentReleases: null,
+      source: {
+        name: 'maven'
+      }
+    })
+  })
+
+  it('returns deps.dev unavailable metadata when native fallback also fails', async () => {
+    const storage = createStorage()
+    const service = new PackageMetadataService(vi.fn(async () => {
+      throw notFound()
+    }) as never, () => storage)
+
+    const metadata = await service.getMetadata({ purl: 'pkg:npm/missing@1.0.0', version: '1.0.0' })
+
+    expect(metadata).toMatchObject({
+      status: 'unavailable',
+      reason: 'package_not_found',
+      system: 'npm',
+      packageName: 'missing',
+      currentVersion: '1.0.0',
+      source: {
+        name: 'deps.dev'
+      }
     })
   })
 

--- a/test/server/services/package-metadata.service.spec.ts
+++ b/test/server/services/package-metadata.service.spec.ts
@@ -77,6 +77,10 @@ const pypiResponse = {
   releases: {
     '5.0.1': [
       {
+        upload_time_iso_8601: '2025-05-02T08:00:00.000Z',
+        yanked: true
+      },
+      {
         upload_time_iso_8601: '2025-05-01T08:00:00.000Z',
         yanked: true,
         yanked_reason: 'Broken wheel metadata.'
@@ -335,7 +339,7 @@ describe('PackageMetadataService', () => {
 
     const mavenUrl = new URL(fetcher.mock.calls[1][0])
     expect(mavenUrl.origin + mavenUrl.pathname).toBe('https://search.maven.org/solrsearch/select')
-    expect(mavenUrl.searchParams.get('q')).toBe('g:"org.springframework" AND a:"spring-core"')
+    expect(mavenUrl.searchParams.get('q')).toBe('g:"org.springframework" AND a:"spring\\-core"')
     expect(mavenUrl.searchParams.get('rows')).toBe('1')
     expect(mavenUrl.searchParams.get('wt')).toBe('json')
     expect(metadata).toMatchObject({
@@ -354,6 +358,22 @@ describe('PackageMetadataService', () => {
         name: 'maven'
       }
     })
+  })
+
+  it('escapes Maven Solr phrase values before querying native metadata', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn()
+      .mockRejectedValueOnce(notFound())
+      .mockResolvedValueOnce(mavenResponse)
+    const service = new PackageMetadataService(fetcher as never, () => storage)
+
+    await service.getMetadata({
+      purl: 'pkg:maven/com.example/foo%22bar%5Cbaz@1.0.0',
+      version: '1.0.0'
+    })
+
+    const mavenUrl = new URL(fetcher.mock.calls[1][0])
+    expect(mavenUrl.searchParams.get('q')).toBe('g:"com.example" AND a:"foo\\"bar\\\\baz"')
   })
 
   it('returns deps.dev unavailable metadata when native fallback also fails', async () => {

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -200,6 +200,8 @@ export interface PackageAdvisory {
   url: string | null
 }
 
+export type PackageMetadataSource = 'deps.dev' | 'npm' | 'pypi' | 'maven'
+
 export interface PackageMetadata {
   status: PackageMetadataStatus
   reason?: PackageMetadataUnavailableReason
@@ -216,7 +218,7 @@ export interface PackageMetadata {
   advisories: PackageAdvisory[]
   recentReleases: number | null
   source: {
-    name: 'deps.dev'
+    name: PackageMetadataSource
     url: string | null
   }
 }


### PR DESCRIPTION
## Description

Adds ecosystem-specific native registry fallbacks for package metadata when deps.dev is unavailable or incomplete. The fallback data is normalized into the existing `packageMetadata` API shape and preserves source labels for deps.dev, npm, PyPI, and Maven Central.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Fixes #602
Relates to #599

## Changes Made

- Added npm, PyPI, and Maven Central package metadata fallbacks inside the existing package metadata service.
- Extended package metadata source typing and component detail labels to show the active metadata source.
- Added focused fallback tests for npm scoped package metadata, PyPI yanked metadata, Maven query encoding, and native fallback failures.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed

## Additional Notes

Download counts are intentionally omitted from this first implementation per scope decision.

Verification run:
- `npm run test:server:services -- package-metadata.service.spec.ts`
- `npx vitest run test/app/pages/components/key.test.ts`
- `npm run lint`
- `npm run mdlint`
- `./node_modules/.bin/tsc --noEmit --project tsconfig.json`

`npx nuxi typecheck` was also attempted before the final commit, but failed before project diagnostics because the temporary `vue-tsc` runner could not resolve `typescript/lib/tsc`.