### PR TITLE
Add component maintenance health scoring

### DIFF
--- a/app/pages/components/[key].vue
+++ b/app/pages/components/[key].vue
@@ -129,7 +129,65 @@
             </div>
           </UCard>
 
-          <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-4 gap-6">
+            <UCard>
+              <template #header>
+                <div class="flex items-center justify-between gap-3">
+                  <div>
+                    <h2 class="text-lg font-semibold">Maintenance</h2>
+                    <p class="text-xs text-(--ui-text-muted)">Derived from available component and registry data</p>
+                  </div>
+                  <UBadge :color="getMaintenanceHealthColor(component.maintenanceHealth?.status)" variant="subtle">
+                    {{ getMaintenanceHealthLabel(component.maintenanceHealth?.status) }}
+                  </UBadge>
+                </div>
+              </template>
+
+              <div class="space-y-4">
+                <UAlert
+                  v-if="!component.maintenanceHealth || component.maintenanceHealth.status === 'unknown'"
+                  color="neutral"
+                  variant="subtle"
+                  icon="i-lucide-circle-help"
+                  title="Maintenance health unknown"
+                  :description="getMaintenanceReasonDescription(component.maintenanceHealth?.reasonCodes[0])"
+                />
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4">
+                  <div>
+                    <span class="text-sm text-(--ui-text-muted)">Confidence</span>
+                    <p class="font-medium">{{ getMaintenanceConfidenceLabel(component.maintenanceHealth?.confidence) }}</p>
+                  </div>
+                  <div>
+                    <span class="text-sm text-(--ui-text-muted)">Version Age</span>
+                    <p class="font-medium">{{ formatAge(component.maintenanceHealth?.ageInDays) }}</p>
+                  </div>
+                  <div>
+                    <span class="text-sm text-(--ui-text-muted)">Update Status</span>
+                    <p class="font-medium">{{ getMaintenanceUpdateLabel(component.maintenanceHealth?.updateType) }}</p>
+                  </div>
+                  <div>
+                    <span class="text-sm text-(--ui-text-muted)">Recent Activity</span>
+                    <p class="font-medium">{{ formatNullableBoolean(component.maintenanceHealth?.recentActivity) }}</p>
+                  </div>
+                </div>
+
+                <div v-if="component.maintenanceHealth?.reasonCodes.length">
+                  <span class="text-sm text-(--ui-text-muted)">Reasons</span>
+                  <div class="mt-2 flex flex-wrap gap-2">
+                    <UBadge
+                      v-for="reason in component.maintenanceHealth.reasonCodes.slice(0, 3)"
+                      :key="reason"
+                      color="neutral"
+                      variant="subtle"
+                    >
+                      {{ getMaintenanceReasonLabel(reason) }}
+                    </UBadge>
+                  </div>
+                </div>
+              </div>
+            </UCard>
+
             <UCard>
               <template #header>
                 <div class="flex items-center justify-between gap-3">
@@ -482,7 +540,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, PackageMetadataSource, PackageMetadataStatus, SecurityScorecardStatus } from '~~/types/api'
+import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, MaintenanceHealthConfidence, MaintenanceHealthReasonCode, MaintenanceHealthStatus, PackageMetadataSource, PackageMetadataStatus, SecurityScorecardStatus } from '~~/types/api'
 
 const route = useRoute()
 const router = useRouter()
@@ -579,6 +637,86 @@ function getEolUnknownDescription(reason?: string): string {
   return descriptions[reason || ''] || 'No lifecycle data is available from the configured third-party source.'
 }
 
+function getMaintenanceHealthColor(status?: MaintenanceHealthStatus): 'success' | 'warning' | 'error' | 'neutral' {
+  const colors: Record<MaintenanceHealthStatus, 'success' | 'warning' | 'error' | 'neutral'> = {
+    healthy: 'success',
+    stable: 'success',
+    aging: 'warning',
+    stale: 'error',
+    unknown: 'neutral'
+  }
+  return colors[status || 'unknown']
+}
+
+function getMaintenanceHealthLabel(status?: MaintenanceHealthStatus): string {
+  const labels: Record<MaintenanceHealthStatus, string> = {
+    healthy: 'Healthy',
+    stable: 'Stable',
+    aging: 'Aging',
+    stale: 'Stale',
+    unknown: 'Unknown'
+  }
+  return labels[status || 'unknown']
+}
+
+function getMaintenanceConfidenceLabel(confidence?: MaintenanceHealthConfidence): string {
+  const labels: Record<MaintenanceHealthConfidence, string> = {
+    high: 'High',
+    medium: 'Medium',
+    low: 'Low'
+  }
+  return confidence ? labels[confidence] : '—'
+}
+
+function getMaintenanceUpdateLabel(updateType?: string): string {
+  const labels: Record<string, string> = {
+    none: 'Current',
+    patch: 'Patch available',
+    minor: 'Minor update available',
+    major: 'Major update available',
+    unknown: 'Unknown'
+  }
+  return labels[updateType || 'unknown'] || 'Unknown'
+}
+
+function getMaintenanceReasonLabel(reason: MaintenanceHealthReasonCode): string {
+  const labels: Record<MaintenanceHealthReasonCode, string> = {
+    insufficient_data: 'Insufficient data',
+    missing_release_date: 'Missing release date',
+    invalid_release_date: 'Invalid release date',
+    missing_version: 'Missing version',
+    unsupported_version_scheme: 'Unsupported version',
+    metadata_unavailable: 'Metadata unavailable',
+    version_recent: 'Recent version',
+    version_moderately_old: 'Moderate age',
+    version_old: 'Old version',
+    version_very_old: 'Very old version',
+    mature_version: 'Mature version',
+    pre_1_0_version: 'Pre-1.0',
+    upstream_recent_activity: 'Recent activity',
+    upstream_no_recent_activity: 'No recent activity',
+    update_status_unknown: 'Update status unknown',
+    current_version_current: 'Current version',
+    patch_update_available: 'Patch available',
+    minor_update_available: 'Minor available',
+    major_update_available: 'Major available',
+    package_deprecated: 'Deprecated',
+    advisories_reported: 'Advisories reported'
+  }
+  return labels[reason]
+}
+
+function getMaintenanceReasonDescription(reason?: MaintenanceHealthReasonCode): string {
+  const descriptions: Partial<Record<MaintenanceHealthReasonCode, string>> = {
+    insufficient_data: 'There is not enough date, version, or registry metadata to classify this component.',
+    missing_release_date: 'No component or registry publication date was available.',
+    invalid_release_date: 'The available release date could not be parsed.',
+    unsupported_version_scheme: 'This component uses a version format that Polaris cannot compare safely.',
+    metadata_unavailable: 'Registry metadata was unavailable, so the result uses only local component data.'
+  }
+  return descriptions[reason || 'insufficient_data'] || 'Maintenance health could not be classified with high confidence.'
+}
+
 function getPackageMetadataColor(status?: PackageMetadataStatus): 'success' | 'neutral' {
   return status === 'available' ? 'success' : 'neutral'
 }
@@ -637,6 +775,18 @@ function getSecurityScorecardUnavailableDescription(reason?: string): string {
 
 function formatScore(score?: number | null): string {
   return typeof score === 'number' ? `${score.toFixed(1)} / 10` : '—'
+}
+
+function formatAge(ageInDays?: number | null): string {
+  if (typeof ageInDays !== 'number') return '—'
+  if (ageInDays === 1) return '1 day'
+  return `${ageInDays} days`
+}
+
+function formatNullableBoolean(value?: boolean | null): string {
+  if (value === true) return 'Yes'
+  if (value === false) return 'No'
+  return '—'
 }
 
 function formatDate(dateString: string): string {

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Polaris API",
-    "version": "0.6.7",
+    "version": "0.6.14",
     "description": "# Polaris Technology Catalog API\n\nThe Polaris API provides programmatic access to the technology catalog, enabling automation, integration, and custom tooling.\n\n## Key Features\n\n- **RESTful Design** - Resource-based URLs with proper HTTP methods\n- **Comprehensive Coverage** - Systems, Teams, Technologies, Components, Policies, and more\n- **Developer-Friendly** - Clear error messages and consistent response structure\n\n## Authentication\n\nMost endpoints require authentication using session-based authentication integrated with the web application.\n\n**Authorization Levels:**\n- **Public** - No authentication required\n- **Authenticated** - Valid user session required  \n- **Team Member** - User must belong to a team\n- **Team Owner** - User must belong to team that owns the resource\n- **Superuser** - User must have superuser role\n\n## Response Format\n\nAll successful responses follow this structure:\n```json\n{\n  \"success\": true,\n  \"data\": [...],\n  \"count\": 10\n}\n```\n\nAll errors follow this structure:\n```json\n{\n  \"statusCode\": 404,\n  \"message\": \"Resource 'example' not found\"\n}\n```\n\n## Richardson Maturity Model\n\nThis API implements **RMM Level 2** with proper use of HTTP methods and status codes.",
     "license": {
       "name": "MIT",
@@ -533,6 +533,88 @@
           "systemCount": {
             "type": "integer",
             "description": "Number of systems using this component"
+          }
+        }
+      },
+      "MaintenanceHealth": {
+        "type": "object",
+        "required": [
+          "status",
+          "confidence",
+          "ageInDays",
+          "isMature",
+          "currentVersion",
+          "latestVersion",
+          "updateType",
+          "recentActivity",
+          "reasonCodes",
+          "inputsUsed",
+          "calculatedAt"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "stable",
+              "aging",
+              "stale",
+              "unknown"
+            ]
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "ageInDays": {
+            "type": "integer",
+            "nullable": true
+          },
+          "isMature": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "currentVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "latestVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "updateType": {
+            "type": "string",
+            "enum": [
+              "none",
+              "patch",
+              "minor",
+              "major",
+              "unknown"
+            ]
+          },
+          "recentActivity": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "reasonCodes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "inputsUsed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "calculatedAt": {
+            "type": "string",
+            "format": "date-time"
           }
         }
       },
@@ -4826,6 +4908,10 @@
                                   "nullable": true
                                 },
                                 "packageMetadata": {
+                                  "type": "object",
+                                  "nullable": true
+                                },
+                                "maintenanceHealth": {
                                   "type": "object",
                                   "nullable": true
                                 },

--- a/server/api/components/[key].get.ts
+++ b/server/api/components/[key].get.ts
@@ -1,6 +1,7 @@
 import { decodeComponentKey } from '../../../utils/component-identity'
 import type { PackageMetadata, SecurityScorecard } from '~~/types/api'
 import { componentService, eolService, packageMetadataService, securityScoreService } from '../../services/singletons'
+import { calculateMaintenanceHealth } from '../../utils/component-health'
 
 /**
  * @openapi
@@ -54,6 +55,9 @@ import { componentService, eolService, packageMetadataService, securityScoreServ
  *                               type: object
  *                               nullable: true
  *                             packageMetadata:
+ *                               type: object
+ *                               nullable: true
+ *                             maintenanceHealth:
  *                               type: object
  *                               nullable: true
  *                             securityScorecard:
@@ -124,6 +128,7 @@ export default defineEventHandler(async (event) => {
       }
     }))
   ])
+  const maintenanceHealth = calculateMaintenanceHealth(component, packageMetadata)
 
   return {
     success: true,
@@ -131,6 +136,7 @@ export default defineEventHandler(async (event) => {
       ...component,
       eol,
       packageMetadata,
+      maintenanceHealth,
       securityScorecard
     }
   }

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -467,6 +467,38 @@ This API implements **RMM Level 2** with proper use of HTTP methods and status c
             }
           }
         },
+        MaintenanceHealth: {
+          type: 'object',
+          required: ['status', 'confidence', 'ageInDays', 'isMature', 'currentVersion', 'latestVersion', 'updateType', 'recentActivity', 'reasonCodes', 'inputsUsed', 'calculatedAt'],
+          properties: {
+            status: {
+              type: 'string',
+              enum: ['healthy', 'stable', 'aging', 'stale', 'unknown']
+            },
+            confidence: {
+              type: 'string',
+              enum: ['high', 'medium', 'low']
+            },
+            ageInDays: { type: 'integer', nullable: true },
+            isMature: { type: 'boolean', nullable: true },
+            currentVersion: { type: 'string', nullable: true },
+            latestVersion: { type: 'string', nullable: true },
+            updateType: {
+              type: 'string',
+              enum: ['none', 'patch', 'minor', 'major', 'unknown']
+            },
+            recentActivity: { type: 'boolean', nullable: true },
+            reasonCodes: {
+              type: 'array',
+              items: { type: 'string' }
+            },
+            inputsUsed: {
+              type: 'array',
+              items: { type: 'string' }
+            },
+            calculatedAt: { type: 'string', format: 'date-time' }
+          }
+        },
         GroupedComponentVersion: {
           type: 'object',
           required: ['name', 'version'],

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -571,6 +571,7 @@ export class ComponentRepository extends BaseRepository {
       })),
       eol: null,
       packageMetadata: null,
+      maintenanceHealth: null,
       securityScorecard: null
     }
   }

--- a/server/utils/component-health.ts
+++ b/server/utils/component-health.ts
@@ -1,0 +1,263 @@
+import semver from 'semver'
+import type {
+  Component,
+  MaintenanceHealth,
+  MaintenanceHealthConfidence,
+  MaintenanceHealthInput,
+  MaintenanceHealthReasonCode,
+  MaintenanceHealthStatus,
+  PackageMetadata
+} from '~~/types/api'
+
+const DAY_MS = 24 * 60 * 60 * 1000
+const RECENT_DAYS = 180
+const OLD_DAYS = 365
+const VERY_OLD_DAYS = 730
+
+type UpdateType = MaintenanceHealth['updateType']
+
+interface HealthState {
+  ageInDays: number | null
+  dateWasInvalid: boolean
+  isMature: boolean | null
+  currentVersion: string | null
+  latestVersion: string | null
+  updateType: UpdateType
+  recentActivity: boolean | null
+  isDeprecated: boolean
+  advisoryCount: number | null
+  inputsUsed: Set<MaintenanceHealthInput>
+  reasonCodes: Set<MaintenanceHealthReasonCode>
+}
+
+export function calculateMaintenanceHealth(
+  component: Pick<Component, 'releaseDate' | 'publishedDate' | 'modifiedDate' | 'version'>,
+  packageMetadata?: PackageMetadata | null,
+  now = new Date()
+): MaintenanceHealth {
+  const state = buildHealthState(component, packageMetadata, now)
+  const { status, confidence } = scoreHealth(state)
+
+  return {
+    status,
+    confidence,
+    ageInDays: state.ageInDays,
+    isMature: state.isMature,
+    currentVersion: state.currentVersion,
+    latestVersion: state.latestVersion,
+    updateType: state.updateType,
+    recentActivity: state.recentActivity,
+    reasonCodes: [...state.reasonCodes],
+    inputsUsed: [...state.inputsUsed],
+    calculatedAt: now.toISOString()
+  }
+}
+
+function buildHealthState(
+  component: Pick<Component, 'releaseDate' | 'publishedDate' | 'modifiedDate' | 'version'>,
+  packageMetadata: PackageMetadata | null | undefined,
+  now: Date
+): HealthState {
+  const inputsUsed = new Set<MaintenanceHealthInput>()
+  const reasonCodes = new Set<MaintenanceHealthReasonCode>()
+  const releaseDate = selectReleaseDate(component, packageMetadata, inputsUsed)
+  const ageResult = calculateAgeInDays(releaseDate, now)
+
+  if (!releaseDate) {
+    reasonCodes.add('missing_release_date')
+  } else if (ageResult.invalid) {
+    reasonCodes.add('invalid_release_date')
+  } else if (ageResult.ageInDays !== null) {
+    if (ageResult.ageInDays < RECENT_DAYS) reasonCodes.add('version_recent')
+    else if (ageResult.ageInDays < OLD_DAYS) reasonCodes.add('version_moderately_old')
+    else if (ageResult.ageInDays < VERY_OLD_DAYS) reasonCodes.add('version_old')
+    else reasonCodes.add('version_very_old')
+  }
+
+  const currentVersion = packageMetadata?.currentVersion || component.version || null
+  const latestVersion = packageMetadata?.status === 'available' ? packageMetadata.latestVersion : null
+  const currentSemver = normalizeSemver(currentVersion)
+  const latestSemver = normalizeSemver(latestVersion)
+
+  if (currentVersion) {
+    inputsUsed.add('component.version')
+  } else {
+    reasonCodes.add('missing_version')
+  }
+
+  let isMature: boolean | null = null
+  if (currentSemver) {
+    isMature = semver.gte(currentSemver, '1.0.0')
+    reasonCodes.add(isMature ? 'mature_version' : 'pre_1_0_version')
+  } else if (currentVersion) {
+    reasonCodes.add('unsupported_version_scheme')
+  }
+
+  if (latestVersion) {
+    inputsUsed.add('packageMetadata.latestVersion')
+  }
+
+  const updateType = getUpdateType(currentSemver, latestSemver)
+  addUpdateReason(updateType, reasonCodes)
+
+  let recentActivity: boolean | null = null
+  if (packageMetadata?.status === 'available') {
+    if (packageMetadata.recentReleases !== null) {
+      inputsUsed.add('packageMetadata.recentReleases')
+      recentActivity = packageMetadata.recentReleases > 0
+      reasonCodes.add(recentActivity ? 'upstream_recent_activity' : 'upstream_no_recent_activity')
+    }
+    if (packageMetadata.isDeprecated !== null) {
+      inputsUsed.add('packageMetadata.isDeprecated')
+    }
+    if (packageMetadata.advisoryCount !== null) {
+      inputsUsed.add('packageMetadata.advisoryCount')
+    }
+  } else if (packageMetadata?.status === 'unavailable') {
+    reasonCodes.add('metadata_unavailable')
+  }
+
+  const isDeprecated = packageMetadata?.status === 'available' && packageMetadata.isDeprecated === true
+  if (isDeprecated) reasonCodes.add('package_deprecated')
+
+  const advisoryCount = packageMetadata?.status === 'available' ? packageMetadata.advisoryCount : null
+  if (typeof advisoryCount === 'number' && advisoryCount > 0) reasonCodes.add('advisories_reported')
+
+  return {
+    ageInDays: ageResult.ageInDays,
+    dateWasInvalid: ageResult.invalid,
+    isMature,
+    currentVersion,
+    latestVersion,
+    updateType,
+    recentActivity,
+    isDeprecated,
+    advisoryCount,
+    inputsUsed,
+    reasonCodes
+  }
+}
+
+function selectReleaseDate(
+  component: Pick<Component, 'releaseDate' | 'publishedDate' | 'modifiedDate'>,
+  packageMetadata: PackageMetadata | null | undefined,
+  inputsUsed: Set<MaintenanceHealthInput>
+): string | null {
+  if (component.releaseDate) {
+    inputsUsed.add('component.releaseDate')
+    return component.releaseDate
+  }
+  if (component.publishedDate) {
+    inputsUsed.add('component.publishedDate')
+    return component.publishedDate
+  }
+  if (packageMetadata?.status === 'available' && packageMetadata.publishedAt) {
+    inputsUsed.add('packageMetadata.publishedAt')
+    return packageMetadata.publishedAt
+  }
+  if (component.modifiedDate) {
+    inputsUsed.add('component.modifiedDate')
+    return component.modifiedDate
+  }
+  return null
+}
+
+function calculateAgeInDays(dateString: string | null, now: Date): { ageInDays: number | null; invalid: boolean } {
+  if (!dateString) return { ageInDays: null, invalid: false }
+
+  const timestamp = Date.parse(dateString)
+  if (Number.isNaN(timestamp)) return { ageInDays: null, invalid: true }
+
+  return {
+    ageInDays: Math.max(0, Math.floor((now.getTime() - timestamp) / DAY_MS)),
+    invalid: false
+  }
+}
+
+function normalizeSemver(version: string | null): string | null {
+  if (!version) return null
+  const trimmed = version.trim()
+  if (!trimmed) return null
+
+  return semver.valid(trimmed) || (trimmed.startsWith('v') ? semver.valid(trimmed.slice(1)) : null)
+}
+
+function getUpdateType(currentVersion: string | null, latestVersion: string | null): UpdateType {
+  if (!currentVersion || !latestVersion) return 'unknown'
+  if (semver.lte(latestVersion, currentVersion)) return 'none'
+  if (semver.major(latestVersion) > semver.major(currentVersion)) return 'major'
+  if (semver.minor(latestVersion) > semver.minor(currentVersion)) return 'minor'
+  if (semver.patch(latestVersion) > semver.patch(currentVersion)) return 'patch'
+  return 'unknown'
+}
+
+function addUpdateReason(updateType: UpdateType, reasonCodes: Set<MaintenanceHealthReasonCode>) {
+  switch (updateType) {
+    case 'none':
+      reasonCodes.add('current_version_current')
+      break
+    case 'patch':
+      reasonCodes.add('patch_update_available')
+      break
+    case 'minor':
+      reasonCodes.add('minor_update_available')
+      break
+    case 'major':
+      reasonCodes.add('major_update_available')
+      break
+    default:
+      reasonCodes.add('update_status_unknown')
+  }
+}
+
+function scoreHealth(state: HealthState): { status: MaintenanceHealthStatus; confidence: MaintenanceHealthConfidence } {
+  if (state.isDeprecated) {
+    return { status: 'stale', confidence: 'high' }
+  }
+
+  if (state.dateWasInvalid) {
+    return { status: 'unknown', confidence: 'low' }
+  }
+
+  const hasDate = state.ageInDays !== null
+  const hasVersionSignal = state.isMature !== null || state.updateType !== 'unknown'
+  const hasActivitySignal = state.recentActivity !== null
+  if (!hasDate && !hasVersionSignal && !hasActivitySignal) {
+    state.reasonCodes.add('insufficient_data')
+    return { status: 'unknown', confidence: 'low' }
+  }
+
+  if (hasDate && state.ageInDays! >= VERY_OLD_DAYS && state.recentActivity === false) {
+    return { status: 'stale', confidence: 'high' }
+  }
+
+  if (hasDate && state.ageInDays! >= VERY_OLD_DAYS && state.updateType === 'major') {
+    return { status: 'stale', confidence: 'high' }
+  }
+
+  if (hasDate && state.ageInDays! >= OLD_DAYS && state.updateType !== 'none') {
+    return { status: 'aging', confidence: state.updateType === 'unknown' ? 'low' : 'medium' }
+  }
+
+  if (state.updateType === 'major') {
+    return { status: 'aging', confidence: 'medium' }
+  }
+
+  if (hasDate && state.ageInDays! < RECENT_DAYS && (state.updateType === 'none' || state.updateType === 'unknown')) {
+    return { status: 'healthy', confidence: state.updateType === 'none' ? 'high' : 'medium' }
+  }
+
+  if (state.isMature === true && state.updateType === 'none' && state.recentActivity !== false) {
+    return { status: 'stable', confidence: hasActivitySignal ? 'high' : 'medium' }
+  }
+
+  if (state.isMature === true && hasDate && state.ageInDays! < VERY_OLD_DAYS) {
+    return { status: 'stable', confidence: state.updateType === 'unknown' ? 'low' : 'medium' }
+  }
+
+  if (hasDate && state.ageInDays! >= VERY_OLD_DAYS) {
+    return { status: 'stale', confidence: hasActivitySignal ? 'medium' : 'low' }
+  }
+
+  return { status: 'unknown', confidence: 'low' }
+}

--- a/server/utils/component-health.ts
+++ b/server/utils/component-health.ts
@@ -74,13 +74,15 @@ function buildHealthState(
     else reasonCodes.add('version_very_old')
   }
 
-  const currentVersion = packageMetadata?.currentVersion || component.version || null
+  const currentVersion = component.version || packageMetadata?.currentVersion || null
   const latestVersion = packageMetadata?.status === 'available' ? packageMetadata.latestVersion : null
   const currentSemver = normalizeSemver(currentVersion)
   const latestSemver = normalizeSemver(latestVersion)
 
-  if (currentVersion) {
+  if (component.version) {
     inputsUsed.add('component.version')
+  } else if (packageMetadata?.currentVersion) {
+    inputsUsed.add('packageMetadata.currentVersion')
   } else {
     reasonCodes.add('missing_version')
   }
@@ -167,9 +169,10 @@ function calculateAgeInDays(dateString: string | null, now: Date): { ageInDays: 
 
   const timestamp = Date.parse(dateString)
   if (Number.isNaN(timestamp)) return { ageInDays: null, invalid: true }
+  if (timestamp > now.getTime()) return { ageInDays: null, invalid: true }
 
   return {
-    ageInDays: Math.max(0, Math.floor((now.getTime() - timestamp) / DAY_MS)),
+    ageInDays: Math.floor((now.getTime() - timestamp) / DAY_MS),
     invalid: false
   }
 }

--- a/test/app/pages/components/key.test.ts
+++ b/test/app/pages/components/key.test.ts
@@ -45,6 +45,7 @@ const baseComponent: ComponentDetail = {
   ],
   eol: null,
   packageMetadata: null,
+  maintenanceHealth: null,
   securityScorecard: null
 }
 
@@ -190,6 +191,35 @@ describe('component detail dependencies section', () => {
     expect(wrapper.text()).toContain('8.5 / 10')
     expect(wrapper.text()).toContain('Code-Review')
     expect(wrapper.text()).toContain('Vulnerabilities')
+  })
+
+  it('renders maintenance health when available', async () => {
+    const { wrapper } = mountPage({
+      component: {
+        maintenanceHealth: {
+          status: 'aging',
+          confidence: 'medium',
+          ageInDays: 420,
+          isMature: true,
+          currentVersion: '1.2.0',
+          latestVersion: '1.3.0',
+          updateType: 'minor',
+          recentActivity: false,
+          reasonCodes: ['version_old', 'minor_update_available', 'upstream_no_recent_activity'],
+          inputsUsed: ['component.version', 'packageMetadata.latestVersion', 'packageMetadata.recentReleases'],
+          calculatedAt: '2026-06-18T00:00:00.000Z'
+        }
+      }
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Maintenance')
+    expect(wrapper.text()).toContain('Aging')
+    expect(wrapper.text()).toContain('Medium')
+    expect(wrapper.text()).toContain('420 days')
+    expect(wrapper.text()).toContain('Minor update available')
+    expect(wrapper.text()).toContain('No')
+    expect(wrapper.text()).toContain('Old version')
   })
 
   it('does not repeat canonical package identity in registry enrichment', async () => {

--- a/test/server/api/component-detail.spec.ts
+++ b/test/server/api/component-detail.spec.ts
@@ -51,6 +51,7 @@ const mockComponent = {
   ],
   eol: null,
   packageMetadata: null,
+  maintenanceHealth: null,
   securityScorecard: null
 }
 
@@ -125,6 +126,11 @@ describe('GET /api/components/{key}', () => {
         directDependencies: mockComponent.directDependencies,
         eol: mockEol,
         packageMetadata: mockPackageMetadata,
+        maintenanceHealth: {
+          status: 'stable',
+          updateType: 'minor',
+          reasonCodes: expect.arrayContaining(['minor_update_available'])
+        },
         securityScorecard: mockSecurityScorecard
       }
     })
@@ -155,6 +161,10 @@ describe('GET /api/components/{key}', () => {
           reason: 'fetch_failed',
           currentVersion: '24.16.0'
         },
+        maintenanceHealth: {
+          status: 'unknown',
+          reasonCodes: expect.arrayContaining(['metadata_unavailable', 'missing_release_date', 'update_status_unknown'])
+        },
         securityScorecard: mockSecurityScorecard
       }
     })
@@ -175,6 +185,9 @@ describe('GET /api/components/{key}', () => {
         name: 'node',
         eol: mockEol,
         packageMetadata: mockPackageMetadata,
+        maintenanceHealth: {
+          status: 'stable'
+        },
         securityScorecard: {
           status: 'unavailable',
           reason: 'fetch_failed',

--- a/test/server/utils/component-health.spec.ts
+++ b/test/server/utils/component-health.spec.ts
@@ -202,4 +202,58 @@ describe('calculateMaintenanceHealth', () => {
       reasonCodes: expect.arrayContaining(['package_deprecated'])
     })
   })
+
+  it('prefers the component version when package metadata disagrees', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      version: '1.2.3',
+      releaseDate: '2026-05-01T00:00:00Z'
+    }, {
+      ...baseMetadata,
+      currentVersion: '9.9.9',
+      latestVersion: '1.2.4'
+    }, now)
+
+    expect(health).toMatchObject({
+      currentVersion: '1.2.3',
+      latestVersion: '1.2.4',
+      updateType: 'patch',
+      inputsUsed: expect.arrayContaining(['component.version'])
+    })
+    expect(health.inputsUsed).not.toContain('packageMetadata.currentVersion')
+  })
+
+  it('tracks package metadata current version when component version is missing', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      version: '',
+      releaseDate: '2026-05-01T00:00:00Z'
+    }, {
+      ...baseMetadata,
+      currentVersion: '1.2.3',
+      latestVersion: '1.2.4'
+    }, now)
+
+    expect(health).toMatchObject({
+      currentVersion: '1.2.3',
+      updateType: 'patch',
+      inputsUsed: expect.arrayContaining(['packageMetadata.currentVersion'])
+    })
+    expect(health.inputsUsed).not.toContain('component.version')
+  })
+
+  it('treats future dates as invalid instead of clamping them to recent', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      releaseDate: '2026-07-01T00:00:00Z'
+    }, baseMetadata, now)
+
+    expect(health).toMatchObject({
+      status: 'unknown',
+      confidence: 'low',
+      ageInDays: null,
+      reasonCodes: expect.arrayContaining(['invalid_release_date'])
+    })
+    expect(health.reasonCodes).not.toContain('version_recent')
+  })
 })

--- a/test/server/utils/component-health.spec.ts
+++ b/test/server/utils/component-health.spec.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import { calculateMaintenanceHealth } from '../../../server/utils/component-health'
+import type { Component, PackageMetadata } from '../../../types/api'
+
+const now = new Date('2026-06-18T00:00:00Z')
+
+const baseComponent: Pick<Component, 'releaseDate' | 'publishedDate' | 'modifiedDate' | 'version'> = {
+  version: '1.2.3',
+  releaseDate: null,
+  publishedDate: null,
+  modifiedDate: null
+}
+
+const baseMetadata: PackageMetadata = {
+  status: 'available',
+  system: 'npm',
+  packageName: 'example',
+  currentVersion: '1.2.3',
+  latestVersion: '1.2.3',
+  defaultVersion: '1.2.3',
+  publishedAt: '2026-05-01T00:00:00Z',
+  isDeprecated: false,
+  deprecatedReason: null,
+  licenses: [],
+  advisoryCount: 0,
+  advisories: [],
+  recentReleases: 2,
+  source: {
+    name: 'deps.dev',
+    url: 'https://deps.dev/npm/example/1.2.3'
+  }
+}
+
+describe('calculateMaintenanceHealth', () => {
+  it('returns healthy for a recent current version', () => {
+    const health = calculateMaintenanceHealth(baseComponent, baseMetadata, now)
+
+    expect(health).toMatchObject({
+      status: 'healthy',
+      confidence: 'high',
+      ageInDays: 48,
+      isMature: true,
+      updateType: 'none',
+      recentActivity: true,
+      reasonCodes: expect.arrayContaining(['version_recent', 'current_version_current', 'upstream_recent_activity'])
+    })
+  })
+
+  it('returns stable for mature current versions with moderate age', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      releaseDate: '2025-09-01T00:00:00Z'
+    }, {
+      ...baseMetadata,
+      publishedAt: null,
+      recentReleases: 1
+    }, now)
+
+    expect(health).toMatchObject({
+      status: 'stable',
+      confidence: 'high',
+      updateType: 'none',
+      recentActivity: true,
+      reasonCodes: expect.arrayContaining(['version_moderately_old', 'mature_version'])
+    })
+  })
+
+  it('returns aging when an old version is behind a minor update', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      releaseDate: '2025-01-01T00:00:00Z'
+    }, {
+      ...baseMetadata,
+      latestVersion: '1.3.0',
+      recentReleases: 0
+    }, now)
+
+    expect(health).toMatchObject({
+      status: 'aging',
+      confidence: 'medium',
+      updateType: 'minor',
+      recentActivity: false,
+      reasonCodes: expect.arrayContaining(['version_old', 'minor_update_available', 'upstream_no_recent_activity'])
+    })
+  })
+
+  it('returns stale for very old versions without recent upstream activity', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      releaseDate: '2023-01-01T00:00:00Z'
+    }, {
+      ...baseMetadata,
+      recentReleases: 0
+    }, now)
+
+    expect(health).toMatchObject({
+      status: 'stale',
+      confidence: 'high',
+      recentActivity: false,
+      reasonCodes: expect.arrayContaining(['version_very_old', 'upstream_no_recent_activity'])
+    })
+  })
+
+  it('returns unknown when dates and usable version signals are missing', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      version: ''
+    }, {
+      status: 'unavailable',
+      reason: 'missing_purl',
+      system: null,
+      packageName: null,
+      currentVersion: null,
+      latestVersion: null,
+      defaultVersion: null,
+      publishedAt: null,
+      isDeprecated: null,
+      deprecatedReason: null,
+      licenses: [],
+      advisoryCount: null,
+      advisories: [],
+      recentReleases: null,
+      source: {
+        name: 'deps.dev',
+        url: null
+      }
+    }, now)
+
+    expect(health).toMatchObject({
+      status: 'unknown',
+      confidence: 'low',
+      ageInDays: null,
+      isMature: null,
+      updateType: 'unknown',
+      reasonCodes: expect.arrayContaining(['missing_release_date', 'missing_version', 'metadata_unavailable', 'insufficient_data'])
+    })
+  })
+
+  it('returns unknown for invalid dates', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      releaseDate: 'not-a-date'
+    }, baseMetadata, now)
+
+    expect(health).toMatchObject({
+      status: 'unknown',
+      confidence: 'low',
+      ageInDays: null,
+      reasonCodes: expect.arrayContaining(['invalid_release_date'])
+    })
+  })
+
+  it('does not force unsupported version schemes through semver', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      version: '1:2.0.0-1ubuntu1',
+      releaseDate: '2026-04-01T00:00:00Z'
+    }, {
+      ...baseMetadata,
+      currentVersion: '1:2.0.0-1ubuntu1',
+      latestVersion: '1:2.0.0-2ubuntu1'
+    }, now)
+
+    expect(health).toMatchObject({
+      status: 'healthy',
+      confidence: 'medium',
+      isMature: null,
+      updateType: 'unknown',
+      reasonCodes: expect.arrayContaining(['unsupported_version_scheme', 'update_status_unknown'])
+    })
+  })
+
+  it('flags pre-1.0 versions without treating them as mature', () => {
+    const health = calculateMaintenanceHealth({
+      ...baseComponent,
+      version: '0.8.0',
+      releaseDate: '2026-02-01T00:00:00Z'
+    }, {
+      ...baseMetadata,
+      currentVersion: '0.8.0',
+      latestVersion: '0.8.1'
+    }, now)
+
+    expect(health).toMatchObject({
+      status: 'unknown',
+      isMature: false,
+      updateType: 'patch',
+      reasonCodes: expect.arrayContaining(['pre_1_0_version', 'patch_update_available'])
+    })
+  })
+
+  it('marks deprecated packages stale', () => {
+    const health = calculateMaintenanceHealth(baseComponent, {
+      ...baseMetadata,
+      isDeprecated: true,
+      deprecatedReason: 'Package no longer maintained.'
+    }, now)
+
+    expect(health).toMatchObject({
+      status: 'stale',
+      confidence: 'high',
+      reasonCodes: expect.arrayContaining(['package_deprecated'])
+    })
+  })
+})

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -223,6 +223,58 @@ export interface PackageMetadata {
   }
 }
 
+export type MaintenanceHealthStatus = 'healthy' | 'stable' | 'aging' | 'stale' | 'unknown'
+
+export type MaintenanceHealthConfidence = 'high' | 'medium' | 'low'
+
+export type MaintenanceHealthReasonCode =
+  | 'insufficient_data'
+  | 'missing_release_date'
+  | 'invalid_release_date'
+  | 'missing_version'
+  | 'unsupported_version_scheme'
+  | 'metadata_unavailable'
+  | 'version_recent'
+  | 'version_moderately_old'
+  | 'version_old'
+  | 'version_very_old'
+  | 'mature_version'
+  | 'pre_1_0_version'
+  | 'upstream_recent_activity'
+  | 'upstream_no_recent_activity'
+  | 'update_status_unknown'
+  | 'current_version_current'
+  | 'patch_update_available'
+  | 'minor_update_available'
+  | 'major_update_available'
+  | 'package_deprecated'
+  | 'advisories_reported'
+
+export type MaintenanceHealthInput =
+  | 'component.releaseDate'
+  | 'component.publishedDate'
+  | 'component.modifiedDate'
+  | 'component.version'
+  | 'packageMetadata.publishedAt'
+  | 'packageMetadata.latestVersion'
+  | 'packageMetadata.recentReleases'
+  | 'packageMetadata.isDeprecated'
+  | 'packageMetadata.advisoryCount'
+
+export interface MaintenanceHealth {
+  status: MaintenanceHealthStatus
+  confidence: MaintenanceHealthConfidence
+  ageInDays: number | null
+  isMature: boolean | null
+  currentVersion: string | null
+  latestVersion: string | null
+  updateType: 'none' | 'patch' | 'minor' | 'major' | 'unknown'
+  recentActivity: boolean | null
+  reasonCodes: MaintenanceHealthReasonCode[]
+  inputsUsed: MaintenanceHealthInput[]
+  calculatedAt: string
+}
+
 export type SecurityScorecardStatus = 'available' | 'unavailable'
 
 export type SecurityScorecardUnavailableReason =
@@ -260,6 +312,7 @@ export interface ComponentDetail extends Component {
   directDependencies: ComponentDirectDependency[]
   eol: EOLStatus | null
   packageMetadata: PackageMetadata | null
+  maintenanceHealth: MaintenanceHealth | null
   securityScorecard: SecurityScorecard | null
 }
 

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -256,6 +256,7 @@ export type MaintenanceHealthInput =
   | 'component.modifiedDate'
   | 'component.version'
   | 'packageMetadata.publishedAt'
+  | 'packageMetadata.currentVersion'
   | 'packageMetadata.latestVersion'
   | 'packageMetadata.recentReleases'
   | 'packageMetadata.isDeprecated'


### PR DESCRIPTION
## Description

Adds component-detail maintenance health scoring using local component metadata and the existing package metadata enrichment. The score is derived on demand and exposed only on component detail responses/pages.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Configuration or build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #600
Relates to #599

## Changes Made

<!-- List the specific changes you made -->

- Added shared `MaintenanceHealth` API types and a pure server-side health calculator.
- Added `maintenanceHealth` to `GET /api/components/{key}` based on existing package metadata enrichment.
- Added a component-detail Maintenance card with status, confidence, age, update status, recent activity, and reason codes.
- Added focused utility, API, and page tests.
- Regenerated the OpenAPI document.

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

Not included.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

<!-- Add any additional information that reviewers should know -->

Verification run:

- `npm test -- test/server/utils/component-health.spec.ts test/server/api/component-detail.spec.ts test/app/pages/components/key.test.ts`
- `npm run lint`
- `npm run mdlint`
- `npm run build`

`npm run build` completed successfully with existing bundle-size and sourcemap warnings from Nuxt/Vite/Tailwind dependencies.