### PR TITLE
Add OSV vulnerability overlay to component detail

### DIFF
--- a/app/pages/components/[key].vue
+++ b/app/pages/components/[key].vue
@@ -103,6 +103,9 @@
                   <UBadge v-if="component.securityScorecard?.status === 'available'" color="success" variant="subtle">
                     Scorecard
                   </UBadge>
+                  <UBadge v-if="component.vulnerabilities?.status === 'available'" :color="vulnerabilityCount > 0 ? 'warning' : 'success'" variant="subtle">
+                    OSV.dev
+                  </UBadge>
                   <span v-if="!hasExternalSignals" class="font-medium text-(--ui-text-muted)">None</span>
                 </div>
               </div>
@@ -358,6 +361,97 @@
           <template #header>
             <div class="flex items-center justify-between gap-3">
               <div>
+                <h2 class="text-lg font-semibold">Known Vulnerabilities</h2>
+                <p class="text-xs text-(--ui-text-muted)">Source: OSV.dev</p>
+              </div>
+              <UBadge :color="getVulnerabilityColor(component.vulnerabilities?.status, vulnerabilityCount)" variant="subtle">
+                {{ getVulnerabilityLabel(component.vulnerabilities?.status, vulnerabilityCount) }}
+              </UBadge>
+            </div>
+          </template>
+
+          <div class="space-y-4">
+            <UAlert
+              v-if="!component.vulnerabilities || component.vulnerabilities.status === 'unavailable'"
+              color="neutral"
+              variant="subtle"
+              icon="i-lucide-circle-help"
+              title="No vulnerability lookup available"
+              :description="getVulnerabilityUnavailableDescription(component.vulnerabilities?.reason)"
+            />
+
+            <UAlert
+              v-else-if="component.vulnerabilities.vulnerabilities.length === 0"
+              color="success"
+              variant="subtle"
+              icon="i-lucide-shield-check"
+              title="No known vulnerabilities found"
+              description="OSV.dev did not report vulnerabilities for this package URL."
+            />
+
+            <div v-else class="space-y-4">
+              <div
+                v-for="vulnerability in component.vulnerabilities.vulnerabilities"
+                :key="vulnerability.id"
+                class="space-y-2 border-b border-(--ui-border) pb-4 last:border-b-0 last:pb-0"
+              >
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <p class="font-medium">{{ vulnerability.id }}</p>
+                    <p v-if="vulnerability.summary" class="text-sm text-(--ui-text-muted)">{{ vulnerability.summary }}</p>
+                  </div>
+                  <UBadge color="warning" variant="subtle">
+                    {{ getVulnerabilitySeverityLabel(vulnerability) }}
+                  </UBadge>
+                </div>
+
+                <div v-if="vulnerability.affectedRanges.length > 0">
+                  <span class="text-sm text-(--ui-text-muted)">Affected Versions</span>
+                  <div class="mt-2 flex flex-wrap gap-2">
+                    <UBadge
+                      v-for="range in vulnerability.affectedRanges.slice(0, 3)"
+                      :key="range"
+                      color="neutral"
+                      variant="subtle"
+                    >
+                      {{ range }}
+                    </UBadge>
+                    <UBadge v-if="vulnerability.affectedRanges.length > 3" color="neutral" variant="subtle">
+                      +{{ vulnerability.affectedRanges.length - 3 }} more
+                    </UBadge>
+                  </div>
+                </div>
+
+                <UButton
+                  :to="vulnerability.advisoryUrl"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  label="Open advisory"
+                  icon="i-lucide-external-link"
+                  variant="outline"
+                  color="warning"
+                  size="sm"
+                />
+              </div>
+            </div>
+
+            <UButton
+              v-if="component.vulnerabilities?.source.url"
+              :to="component.vulnerabilities.source.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              label="Open OSV.dev"
+              icon="i-lucide-external-link"
+              variant="outline"
+              size="sm"
+            />
+          </div>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <div class="flex items-center justify-between gap-3">
+              <div>
                 <h2 class="text-lg font-semibold">Security</h2>
                 <p class="text-xs text-(--ui-text-muted)">Source: OpenSSF Scorecard</p>
               </div>
@@ -540,7 +634,7 @@
 </template>
 
 <script setup lang="ts">
-import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, MaintenanceHealthConfidence, MaintenanceHealthReasonCode, MaintenanceHealthStatus, PackageMetadataSource, PackageMetadataStatus, SecurityScorecardStatus } from '~~/types/api'
+import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, KnownVulnerability, MaintenanceHealthConfidence, MaintenanceHealthReasonCode, MaintenanceHealthStatus, PackageMetadataSource, PackageMetadataStatus, SecurityScorecardStatus, VulnerabilityStatus } from '~~/types/api'
 
 const route = useRoute()
 const router = useRouter()
@@ -605,7 +699,9 @@ const hasExternalSignals = computed(() => Boolean(
   component.value?.packageMetadata?.status === 'available'
   || component.value?.eol?.source.url
   || component.value?.securityScorecard?.status === 'available'
+  || component.value?.vulnerabilities?.status === 'available'
 ))
+const vulnerabilityCount = computed(() => component.value?.vulnerabilities?.vulnerabilities.length ?? 0)
 
 function getEolColor(status?: EOLStatusValue): 'success' | 'warning' | 'error' | 'neutral' {
   const colors: Record<EOLStatusValue, 'success' | 'warning' | 'error' | 'neutral'> = {
@@ -771,6 +867,35 @@ function getSecurityScorecardUnavailableDescription(reason?: string): string {
     fetch_failed: 'The third-party security score source could not be reached.'
   }
   return descriptions[reason || ''] || 'No security scorecard data is available from the configured third-party source.'
+}
+
+function getVulnerabilityColor(status?: VulnerabilityStatus, count = 0): 'success' | 'warning' | 'neutral' {
+  if (status !== 'available') return 'neutral'
+  return count > 0 ? 'warning' : 'success'
+}
+
+function getVulnerabilityLabel(status?: VulnerabilityStatus, count = 0): string {
+  if (status !== 'available') return 'Unavailable'
+  if (count === 0) return 'None found'
+  if (count === 1) return '1 found'
+  return `${count} found`
+}
+
+function getVulnerabilityUnavailableDescription(reason?: string): string {
+  const descriptions: Record<string, string> = {
+    missing_purl: 'This component does not have a package URL for OSV.dev lookup.',
+    fetch_failed: 'The third-party vulnerability source could not be reached.'
+  }
+  return descriptions[reason || ''] || 'No vulnerability data is available from the configured third-party source.'
+}
+
+function getVulnerabilitySeverityLabel(vulnerability: KnownVulnerability): string {
+  if (typeof vulnerability.severity?.cvssScore === 'number') {
+    return `CVSS ${vulnerability.severity.cvssScore.toFixed(1)}`
+  }
+  if (vulnerability.severity?.score) return vulnerability.severity.score
+  if (vulnerability.severity?.type) return vulnerability.severity.type
+  return 'Severity unknown'
 }
 
 function formatScore(score?: number | null): string {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -2,6 +2,8 @@
 
 const isEnabled = (value: string | undefined) => value === 'true' || value === '1'
 const shouldTrustAuthHost = process.env.NODE_ENV !== 'production' || isEnabled(process.env.AUTH_TRUST_HOST)
+const apiCacheDriver = process.env.API_CACHE_DRIVER || 'memory'
+const apiCacheBase = process.env.API_CACHE_BASE || './.cache/api'
 
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
@@ -83,8 +85,8 @@ export default defineNuxtConfig({
     },
     storage: {
       'cache:api': {
-        driver: 'fs',
-        base: './.cache/api'
+        driver: apiCacheDriver,
+        ...(apiCacheDriver === 'fs' && { base: apiCacheBase })
       }
     }
   }

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -80,6 +80,12 @@ export default defineNuxtConfig({
     // runtime — bundling strips those files and causes ENOENT errors in production.
     externals: {
       external: ['@cyclonedx/cdxgen']
+    },
+    storage: {
+      'cache:api': {
+        driver: 'fs',
+        base: './.cache/api'
+      }
     }
   }
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -4918,6 +4918,10 @@
                                 "securityScorecard": {
                                   "type": "object",
                                   "nullable": true
+                                },
+                                "vulnerabilities": {
+                                  "type": "object",
+                                  "nullable": true
                                 }
                               }
                             }

--- a/server/api/components/[key].get.ts
+++ b/server/api/components/[key].get.ts
@@ -1,6 +1,6 @@
 import { decodeComponentKey } from '../../../utils/component-identity'
-import type { PackageMetadata, SecurityScorecard } from '~~/types/api'
-import { componentService, eolService, packageMetadataService, securityScoreService } from '../../services/singletons'
+import type { PackageMetadata, SecurityScorecard, VulnerabilityReport } from '~~/types/api'
+import { componentService, eolService, packageMetadataService, securityScoreService, vulnerabilityService } from '../../services/singletons'
 import { calculateMaintenanceHealth } from '../../utils/component-health'
 
 /**
@@ -63,6 +63,9 @@ import { calculateMaintenanceHealth } from '../../utils/component-health'
  *                             securityScorecard:
  *                               type: object
  *                               nullable: true
+ *                             vulnerabilities:
+ *                               type: object
+ *                               nullable: true
  *       400:
  *         description: Component key is missing or invalid
  *       404:
@@ -93,7 +96,7 @@ export default defineEventHandler(async (event) => {
     })
   }
 
-  const [eol, packageMetadata, securityScorecard] = await Promise.all([
+  const [eol, packageMetadata, securityScorecard, vulnerabilities] = await Promise.all([
     eolService.getEOLStatus(component),
     packageMetadataService.getMetadata(component).catch((): PackageMetadata => ({
       status: 'unavailable',
@@ -126,6 +129,15 @@ export default defineEventHandler(async (event) => {
         name: 'OpenSSF Scorecard',
         url: null
       }
+    })),
+    vulnerabilityService.getVulnerabilities(component).catch((): VulnerabilityReport => ({
+      status: 'unavailable',
+      reason: 'fetch_failed',
+      vulnerabilities: [],
+      source: {
+        name: 'OSV.dev',
+        url: null
+      }
     }))
   ])
   const maintenanceHealth = calculateMaintenanceHealth(component, packageMetadata)
@@ -137,7 +149,8 @@ export default defineEventHandler(async (event) => {
       eol,
       packageMetadata,
       maintenanceHealth,
-      securityScorecard
+      securityScorecard,
+      vulnerabilities
     }
   }
 })

--- a/server/services/singletons.ts
+++ b/server/services/singletons.ts
@@ -27,6 +27,7 @@ import { EOLService } from './eol.service'
 import { EOLRollupService } from './eol-rollup.service'
 import { PackageMetadataService } from './package-metadata.service'
 import { SecurityScoreService } from './security-score.service'
+import { VulnerabilityService } from './vulnerability.service'
 
 export const technologyService = new TechnologyService()
 export const teamService = new TeamService()
@@ -45,3 +46,4 @@ export const eolService = new EOLService()
 export const eolRollupService = new EOLRollupService()
 export const packageMetadataService = new PackageMetadataService()
 export const securityScoreService = new SecurityScoreService()
+export const vulnerabilityService = new VulnerabilityService()

--- a/server/services/vulnerability.service.ts
+++ b/server/services/vulnerability.service.ts
@@ -1,0 +1,211 @@
+import type { Component, KnownVulnerability, VulnerabilityReport, VulnerabilityUnavailableReason } from '~~/types/api'
+import { cachedFetch } from '../utils/cache'
+
+interface CacheStorage {
+  getItem<T>(key: string): Promise<T | null>
+  setItem<T>(key: string, value: T): Promise<void>
+}
+
+interface OsvQueryResponse {
+  vulns?: OsvVulnerability[]
+}
+
+interface OsvVulnerability {
+  id?: string
+  aliases?: string[]
+  summary?: string
+  details?: string
+  modified?: string
+  published?: string
+  affected?: OsvAffected[]
+  severity?: OsvSeverity[]
+  references?: OsvReference[]
+  database_specific?: {
+    severity?: string
+    cvss_score?: number
+  }
+}
+
+interface OsvAffected {
+  ranges?: OsvRange[]
+  versions?: string[]
+}
+
+interface OsvRange {
+  type?: string
+  events?: OsvRangeEvent[]
+}
+
+interface OsvRangeEvent {
+  introduced?: string
+  fixed?: string
+  last_affected?: string
+  limit?: string
+}
+
+interface OsvSeverity {
+  type?: string
+  score?: string
+}
+
+interface OsvReference {
+  type?: string
+  url?: string
+}
+
+type OsvFetcher = <T>(url: string, init: RequestInit) => Promise<T>
+
+const OSV_QUERY_URL = 'https://api.osv.dev/v1/query'
+const OSV_WEB_BASE = 'https://osv.dev/vulnerability'
+const CACHE_TTL_SECONDS = 6 * 60 * 60
+
+export class VulnerabilityService {
+  constructor(
+    private readonly fetcher: OsvFetcher = fetchJson,
+    private readonly storageFactory: () => CacheStorage = () => useStorage('cache:api') as CacheStorage
+  ) {}
+
+  async getVulnerabilities(component: Pick<Component, 'purl'>): Promise<VulnerabilityReport> {
+    if (!component.purl) {
+      return this.unavailable('missing_purl')
+    }
+
+    try {
+      return await cachedFetch(
+        `vulnerabilities:v1:purl:${encodeURIComponent(component.purl)}`,
+        async () => this.available(component.purl!, await this.queryOsv(component.purl!)),
+        CACHE_TTL_SECONDS,
+        this.storageFactory
+      )
+    } catch {
+      return this.unavailable('fetch_failed')
+    }
+  }
+
+  private async queryOsv(purl: string): Promise<OsvQueryResponse> {
+    return await this.fetcher<OsvQueryResponse>(OSV_QUERY_URL, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        package: {
+          purl
+        }
+      })
+    })
+  }
+
+  private available(purl: string, response: OsvQueryResponse): VulnerabilityReport {
+    return {
+      status: 'available',
+      vulnerabilities: (response.vulns || [])
+        .filter(vulnerability => Boolean(vulnerability.id))
+        .map(vulnerability => this.toKnownVulnerability(vulnerability)),
+      source: {
+        name: 'OSV.dev',
+        url: `https://osv.dev/list?${new URLSearchParams({ q: purl }).toString()}`
+      }
+    }
+  }
+
+  private unavailable(reason: VulnerabilityUnavailableReason): VulnerabilityReport {
+    return {
+      status: 'unavailable',
+      reason,
+      vulnerabilities: [],
+      source: {
+        name: 'OSV.dev',
+        url: null
+      }
+    }
+  }
+
+  private toKnownVulnerability(vulnerability: OsvVulnerability): KnownVulnerability {
+    return {
+      id: vulnerability.id!,
+      aliases: vulnerability.aliases || [],
+      summary: vulnerability.summary || vulnerability.details || null,
+      severity: this.severity(vulnerability),
+      affectedRanges: this.affectedRanges(vulnerability.affected || []),
+      advisoryUrl: this.advisoryUrl(vulnerability),
+      publishedAt: vulnerability.published || null,
+      modifiedAt: vulnerability.modified || null
+    }
+  }
+
+  private severity(vulnerability: OsvVulnerability): KnownVulnerability['severity'] {
+    const explicitSeverity = vulnerability.severity?.find(item => item.type || item.score)
+    const cvssScore = typeof vulnerability.database_specific?.cvss_score === 'number'
+      ? vulnerability.database_specific.cvss_score
+      : null
+
+    if (!explicitSeverity && !vulnerability.database_specific?.severity && cvssScore === null) {
+      return null
+    }
+
+    return {
+      type: explicitSeverity?.type || vulnerability.database_specific?.severity || null,
+      score: explicitSeverity?.score || null,
+      cvssScore
+    }
+  }
+
+  private affectedRanges(affected: OsvAffected[]): string[] {
+    const ranges = affected.flatMap(item => item.ranges || [])
+      .flatMap(range => this.rangeLabels(range))
+
+    if (ranges.length > 0) {
+      return [...new Set(ranges)]
+    }
+
+    return [...new Set(affected.flatMap(item => item.versions || []))]
+      .slice(0, 10)
+  }
+
+  private rangeLabels(range: OsvRange): string[] {
+    const events = range.events || []
+    const labels: string[] = []
+
+    for (let index = 0; index < events.length; index += 1) {
+      const event = events[index]
+      if (!event.introduced) continue
+
+      const closing = events.slice(index + 1).find(candidate => candidate.fixed || candidate.last_affected || candidate.limit)
+      labels.push(this.rangeLabel(event.introduced, closing))
+    }
+
+    return labels
+  }
+
+  private rangeLabel(introduced: string, closing?: OsvRangeEvent): string {
+    const lower = introduced === '0' ? 'all versions before' : `>= ${introduced}, before`
+
+    if (closing?.fixed) return `${lower} ${closing.fixed}`
+    if (closing?.last_affected) return `${introduced === '0' ? '<=' : `${introduced} -`} ${closing.last_affected}`
+    if (closing?.limit) return `${lower} ${closing.limit}`
+
+    return introduced === '0' ? 'all versions' : `>= ${introduced}`
+  }
+
+  private advisoryUrl(vulnerability: OsvVulnerability): string {
+    const preferredReference = vulnerability.references?.find(reference => reference.type === 'ADVISORY' && reference.url)
+      || vulnerability.references?.find(reference => reference.url)
+
+    return preferredReference?.url || `${OSV_WEB_BASE}/${encodeURIComponent(vulnerability.id!)}`
+  }
+}
+
+class FetchJsonError extends Error {
+  constructor(message: string, readonly statusCode: number) {
+    super(message)
+  }
+}
+
+async function fetchJson<T>(url: string, init: RequestInit): Promise<T> {
+  const response = await fetch(url, init)
+  if (!response.ok) {
+    throw new FetchJsonError(`Request failed with status ${response.status}`, response.status)
+  }
+  return await response.json() as T
+}

--- a/server/utils/cache.ts
+++ b/server/utils/cache.ts
@@ -1,0 +1,31 @@
+interface CacheEntry<T> {
+  expiresAt: number
+  value: T
+}
+
+interface CacheStorage {
+  getItem<T>(key: string): Promise<T | null>
+  setItem<T>(key: string, value: T): Promise<void>
+}
+
+export async function cachedFetch<T>(
+  key: string,
+  producer: () => Promise<T>,
+  ttlSeconds: number,
+  storageFactory: () => CacheStorage = () => useStorage('cache:api') as CacheStorage
+): Promise<T> {
+  const storage = storageFactory()
+  const cached = await storage.getItem<CacheEntry<T>>(key)
+
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.value
+  }
+
+  const value = await producer()
+  await storage.setItem(key, {
+    expiresAt: Date.now() + ttlSeconds * 1000,
+    value
+  })
+
+  return value
+}

--- a/server/utils/cache.ts
+++ b/server/utils/cache.ts
@@ -15,17 +15,33 @@ export async function cachedFetch<T>(
   storageFactory: () => CacheStorage = () => useStorage('cache:api') as CacheStorage
 ): Promise<T> {
   const storage = storageFactory()
-  const cached = await storage.getItem<CacheEntry<T>>(key)
+  const cached = await getCachedValue(storage, key)
 
   if (cached && cached.expiresAt > Date.now()) {
     return cached.value
   }
 
   const value = await producer()
-  await storage.setItem(key, {
-    expiresAt: Date.now() + ttlSeconds * 1000,
-    value
-  })
+  await setCachedValue(storage, key, value, ttlSeconds)
 
   return value
+}
+
+async function getCachedValue<T>(storage: CacheStorage, key: string): Promise<CacheEntry<T> | null> {
+  try {
+    return await storage.getItem<CacheEntry<T>>(key)
+  } catch {
+    return null
+  }
+}
+
+async function setCachedValue<T>(storage: CacheStorage, key: string, value: T, ttlSeconds: number): Promise<void> {
+  try {
+    await storage.setItem(key, {
+      expiresAt: Date.now() + ttlSeconds * 1000,
+      value
+    })
+  } catch {
+    // Cache persistence must not make successful upstream enrichment unavailable.
+  }
 }

--- a/test/app/pages/components/key.test.ts
+++ b/test/app/pages/components/key.test.ts
@@ -46,7 +46,8 @@ const baseComponent: ComponentDetail = {
   eol: null,
   packageMetadata: null,
   maintenanceHealth: null,
-  securityScorecard: null
+  securityScorecard: null,
+  vulnerabilities: null
 }
 
 function mountPage(options: {
@@ -191,6 +192,65 @@ describe('component detail dependencies section', () => {
     expect(wrapper.text()).toContain('8.5 / 10')
     expect(wrapper.text()).toContain('Code-Review')
     expect(wrapper.text()).toContain('Vulnerabilities')
+  })
+
+  it('renders known vulnerabilities when OSV reports matches', async () => {
+    const { wrapper } = mountPage({
+      component: {
+        vulnerabilities: {
+          status: 'available',
+          vulnerabilities: [
+            {
+              id: 'GHSA-xxxx-yyyy-zzzz',
+              aliases: ['CVE-2026-1234'],
+              summary: 'Prototype pollution in example package.',
+              severity: {
+                type: 'CVSS_V3',
+                score: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
+                cvssScore: 9.8
+              },
+              affectedRanges: ['all versions before 24.16.1'],
+              advisoryUrl: 'https://osv.dev/vulnerability/GHSA-xxxx-yyyy-zzzz',
+              publishedAt: '2026-05-01T00:00:00Z',
+              modifiedAt: '2026-05-02T00:00:00Z'
+            }
+          ],
+          source: {
+            name: 'OSV.dev',
+            url: 'https://osv.dev/list?q=pkg%3Anpm%2Fnode%4024.16.0'
+          }
+        }
+      }
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Known Vulnerabilities')
+    expect(wrapper.text()).toContain('1 found')
+    expect(wrapper.text()).toContain('GHSA-xxxx-yyyy-zzzz')
+    expect(wrapper.text()).toContain('CVSS 9.8')
+    expect(wrapper.text()).toContain('all versions before 24.16.1')
+    expect(wrapper.text()).toContain('Open advisory')
+    expect(wrapper.text()).toContain('Open OSV.dev')
+  })
+
+  it('renders an empty known vulnerabilities state', async () => {
+    const { wrapper } = mountPage({
+      component: {
+        vulnerabilities: {
+          status: 'available',
+          vulnerabilities: [],
+          source: {
+            name: 'OSV.dev',
+            url: 'https://osv.dev/list?q=pkg%3Anpm%2Fnode%4024.16.0'
+          }
+        }
+      }
+    })
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Known Vulnerabilities')
+    expect(wrapper.text()).toContain('None found')
+    expect(wrapper.text()).toContain('No known vulnerabilities found')
   })
 
   it('renders maintenance health when available', async () => {

--- a/test/server/api/component-detail.spec.ts
+++ b/test/server/api/component-detail.spec.ts
@@ -3,13 +3,14 @@ import { mockEvent } from '../../fixtures/h3-event'
 import { encodeComponentKey } from '../../../utils/component-identity'
 import handler from '../../../server/api/components/[key].get'
 import eolHandler from '../../../server/api/components/eol.get'
-import { componentService, eolService, packageMetadataService, securityScoreService } from '../../../server/services/singletons'
+import { componentService, eolService, packageMetadataService, securityScoreService, vulnerabilityService } from '../../../server/services/singletons'
 
 vi.mock('../../../server/services/singletons', () => ({
   componentService: { findByIdentity: vi.fn() },
   eolService: { getEOLStatus: vi.fn() },
   packageMetadataService: { getMetadata: vi.fn() },
-  securityScoreService: { getScore: vi.fn() }
+  securityScoreService: { getScore: vi.fn() },
+  vulnerabilityService: { getVulnerabilities: vi.fn() }
 }))
 
 const mockComponent = {
@@ -52,7 +53,8 @@ const mockComponent = {
   eol: null,
   packageMetadata: null,
   maintenanceHealth: null,
-  securityScorecard: null
+  securityScorecard: null,
+  vulnerabilities: null
 }
 
 const mockEol = {
@@ -101,6 +103,23 @@ const mockSecurityScorecard = {
   source: { name: 'OpenSSF Scorecard' as const, url: 'https://scorecard.dev/viewer/?uri=github.com/nodejs/node' }
 }
 
+const mockVulnerabilities = {
+  status: 'available' as const,
+  vulnerabilities: [
+    {
+      id: 'GHSA-xxxx-yyyy-zzzz',
+      aliases: ['CVE-2026-1234'],
+      summary: 'Example vulnerability',
+      severity: { type: 'CVSS_V3', score: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H', cvssScore: 9.8 },
+      affectedRanges: ['all versions before 24.16.1'],
+      advisoryUrl: 'https://osv.dev/vulnerability/GHSA-xxxx-yyyy-zzzz',
+      publishedAt: '2026-05-01T00:00:00Z',
+      modifiedAt: '2026-05-02T00:00:00Z'
+    }
+  ],
+  source: { name: 'OSV.dev' as const, url: 'https://osv.dev/list?q=pkg%3Anpm%2Fnode%4024.16.0' }
+}
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
@@ -111,6 +130,7 @@ describe('GET /api/components/{key}', () => {
     vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
     vi.mocked(packageMetadataService.getMetadata).mockResolvedValue(mockPackageMetadata)
     vi.mocked(securityScoreService.getScore).mockResolvedValue(mockSecurityScorecard)
+    vi.mocked(vulnerabilityService.getVulnerabilities).mockResolvedValue(mockVulnerabilities)
 
     const key = encodeComponentKey(mockComponent)
     const result = await handler(mockEvent({ params: { key } }))
@@ -119,6 +139,7 @@ describe('GET /api/components/{key}', () => {
     expect(eolService.getEOLStatus).toHaveBeenCalledWith(mockComponent)
     expect(packageMetadataService.getMetadata).toHaveBeenCalledWith(mockComponent)
     expect(securityScoreService.getScore).toHaveBeenCalledWith(mockComponent)
+    expect(vulnerabilityService.getVulnerabilities).toHaveBeenCalledWith(mockComponent)
     expect(result).toMatchObject({
       success: true,
       data: {
@@ -131,7 +152,8 @@ describe('GET /api/components/{key}', () => {
           updateType: 'minor',
           reasonCodes: expect.arrayContaining(['minor_update_available'])
         },
-        securityScorecard: mockSecurityScorecard
+        securityScorecard: mockSecurityScorecard,
+        vulnerabilities: mockVulnerabilities
       }
     })
   })
@@ -147,6 +169,7 @@ describe('GET /api/components/{key}', () => {
     vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
     vi.mocked(packageMetadataService.getMetadata).mockRejectedValue(new Error('deps.dev unavailable'))
     vi.mocked(securityScoreService.getScore).mockResolvedValue(mockSecurityScorecard)
+    vi.mocked(vulnerabilityService.getVulnerabilities).mockResolvedValue(mockVulnerabilities)
 
     const key = encodeComponentKey(mockComponent)
     const result = await handler(mockEvent({ params: { key } }))
@@ -165,7 +188,8 @@ describe('GET /api/components/{key}', () => {
           status: 'unknown',
           reasonCodes: expect.arrayContaining(['metadata_unavailable', 'missing_release_date', 'update_status_unknown'])
         },
-        securityScorecard: mockSecurityScorecard
+        securityScorecard: mockSecurityScorecard,
+        vulnerabilities: mockVulnerabilities
       }
     })
   })
@@ -175,6 +199,7 @@ describe('GET /api/components/{key}', () => {
     vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
     vi.mocked(packageMetadataService.getMetadata).mockResolvedValue(mockPackageMetadata)
     vi.mocked(securityScoreService.getScore).mockRejectedValue(new Error('scorecard unavailable'))
+    vi.mocked(vulnerabilityService.getVulnerabilities).mockResolvedValue(mockVulnerabilities)
 
     const key = encodeComponentKey(mockComponent)
     const result = await handler(mockEvent({ params: { key } }))
@@ -193,6 +218,34 @@ describe('GET /api/components/{key}', () => {
           reason: 'fetch_failed',
           score: null,
           checks: []
+        },
+        vulnerabilities: mockVulnerabilities
+      }
+    })
+  })
+
+  it('does not fail component details when vulnerability enrichment throws', async () => {
+    vi.mocked(componentService.findByIdentity).mockResolvedValue(mockComponent)
+    vi.mocked(eolService.getEOLStatus).mockResolvedValue(mockEol)
+    vi.mocked(packageMetadataService.getMetadata).mockResolvedValue(mockPackageMetadata)
+    vi.mocked(securityScoreService.getScore).mockResolvedValue(mockSecurityScorecard)
+    vi.mocked(vulnerabilityService.getVulnerabilities).mockRejectedValue(new Error('osv unavailable'))
+
+    const key = encodeComponentKey(mockComponent)
+    const result = await handler(mockEvent({ params: { key } }))
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        name: 'node',
+        vulnerabilities: {
+          status: 'unavailable',
+          reason: 'fetch_failed',
+          vulnerabilities: [],
+          source: {
+            name: 'OSV.dev',
+            url: null
+          }
         }
       }
     })

--- a/test/server/services/vulnerability.service.spec.ts
+++ b/test/server/services/vulnerability.service.spec.ts
@@ -141,6 +141,27 @@ describe('VulnerabilityService', () => {
     expect(fetcher).toHaveBeenCalledTimes(1)
   })
 
+  it('returns fetched vulnerabilities when cache persistence fails', async () => {
+    const storage = {
+      getItem: vi.fn(async () => null),
+      setItem: vi.fn(async () => {
+        throw new Error('read-only cache')
+      })
+    }
+    const fetcher = vi.fn().mockResolvedValue(osvResponse)
+    const service = new VulnerabilityService(fetcher as never, () => storage)
+
+    await expect(service.getVulnerabilities({ purl: 'pkg:npm/node@24.16.0' })).resolves.toMatchObject({
+      status: 'available',
+      vulnerabilities: [
+        {
+          id: 'GHSA-xxxx-yyyy-zzzz'
+        }
+      ]
+    })
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
   it('returns unavailable when OSV cannot be reached', async () => {
     const service = new VulnerabilityService(vi.fn(async () => {
       throw new Error('OSV unavailable')

--- a/test/server/services/vulnerability.service.spec.ts
+++ b/test/server/services/vulnerability.service.spec.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { VulnerabilityService } from '../../../server/services/vulnerability.service'
+
+function createStorage() {
+  const cache = new Map<string, unknown>()
+  return {
+    getItem: vi.fn(async (key: string) => cache.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: unknown) => {
+      cache.set(key, value)
+    })
+  }
+}
+
+const osvResponse = {
+  vulns: [
+    {
+      id: 'GHSA-xxxx-yyyy-zzzz',
+      aliases: ['CVE-2026-1234'],
+      summary: 'Prototype pollution in example package.',
+      published: '2026-05-01T00:00:00Z',
+      modified: '2026-05-02T00:00:00Z',
+      severity: [
+        {
+          type: 'CVSS_V3',
+          score: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'
+        }
+      ],
+      database_specific: {
+        cvss_score: 9.8
+      },
+      affected: [
+        {
+          ranges: [
+            {
+              type: 'SEMVER',
+              events: [
+                { introduced: '0' },
+                { fixed: '24.16.1' }
+              ]
+            }
+          ]
+        }
+      ],
+      references: [
+        {
+          type: 'ADVISORY',
+          url: 'https://osv.dev/vulnerability/GHSA-xxxx-yyyy-zzzz'
+        }
+      ]
+    }
+  ]
+}
+
+describe('VulnerabilityService', () => {
+  beforeEach(() => {
+    vi.spyOn(Date, 'now').mockReturnValue(Date.parse('2026-06-18T00:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('queries OSV by package URL and maps known vulnerabilities', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn().mockResolvedValue(osvResponse)
+    const service = new VulnerabilityService(fetcher as never, () => storage)
+
+    const report = await service.getVulnerabilities({ purl: 'pkg:npm/node@24.16.0' })
+
+    expect(fetcher).toHaveBeenCalledWith('https://api.osv.dev/v1/query', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({
+        package: {
+          purl: 'pkg:npm/node@24.16.0'
+        }
+      })
+    })
+    expect(report).toMatchObject({
+      status: 'available',
+      source: {
+        name: 'OSV.dev',
+        url: 'https://osv.dev/list?q=pkg%3Anpm%2Fnode%4024.16.0'
+      },
+      vulnerabilities: [
+        {
+          id: 'GHSA-xxxx-yyyy-zzzz',
+          aliases: ['CVE-2026-1234'],
+          summary: 'Prototype pollution in example package.',
+          severity: {
+            type: 'CVSS_V3',
+            score: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H',
+            cvssScore: 9.8
+          },
+          affectedRanges: ['all versions before 24.16.1'],
+          advisoryUrl: 'https://osv.dev/vulnerability/GHSA-xxxx-yyyy-zzzz',
+          publishedAt: '2026-05-01T00:00:00Z',
+          modifiedAt: '2026-05-02T00:00:00Z'
+        }
+      ]
+    })
+    expect(storage.setItem).toHaveBeenCalledWith(
+      'vulnerabilities:v1:purl:pkg%3Anpm%2Fnode%4024.16.0',
+      expect.objectContaining({
+        expiresAt: Date.parse('2026-06-18T06:00:00Z')
+      })
+    )
+  })
+
+  it('returns an available empty report when OSV finds no vulnerabilities', async () => {
+    const service = new VulnerabilityService(vi.fn().mockResolvedValue({ vulns: [] }) as never, () => createStorage())
+
+    await expect(service.getVulnerabilities({ purl: 'pkg:npm/node@24.16.0' })).resolves.toMatchObject({
+      status: 'available',
+      vulnerabilities: []
+    })
+  })
+
+  it('returns unavailable for components without a package URL', async () => {
+    const fetcher = vi.fn()
+    const service = new VulnerabilityService(fetcher as never, () => createStorage())
+
+    await expect(service.getVulnerabilities({ purl: null })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'missing_purl',
+      vulnerabilities: []
+    })
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
+  it('caches OSV responses for repeated lookups', async () => {
+    const storage = createStorage()
+    const fetcher = vi.fn().mockResolvedValue(osvResponse)
+    const service = new VulnerabilityService(fetcher as never, () => storage)
+
+    await service.getVulnerabilities({ purl: 'pkg:npm/node@24.16.0' })
+    await service.getVulnerabilities({ purl: 'pkg:npm/node@24.16.0' })
+
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns unavailable when OSV cannot be reached', async () => {
+    const service = new VulnerabilityService(vi.fn(async () => {
+      throw new Error('OSV unavailable')
+    }) as never, () => createStorage())
+
+    await expect(service.getVulnerabilities({ purl: 'pkg:npm/node@24.16.0' })).resolves.toMatchObject({
+      status: 'unavailable',
+      reason: 'fetch_failed',
+      vulnerabilities: []
+    })
+  })
+})

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -308,6 +308,39 @@ export interface SecurityScorecard {
   }
 }
 
+export type VulnerabilityStatus = 'available' | 'unavailable'
+
+export type VulnerabilityUnavailableReason =
+  | 'missing_purl'
+  | 'fetch_failed'
+
+export interface KnownVulnerabilitySeverity {
+  type: string | null
+  score: string | null
+  cvssScore: number | null
+}
+
+export interface KnownVulnerability {
+  id: string
+  aliases: string[]
+  summary: string | null
+  severity: KnownVulnerabilitySeverity | null
+  affectedRanges: string[]
+  advisoryUrl: string
+  publishedAt: string | null
+  modifiedAt: string | null
+}
+
+export interface VulnerabilityReport {
+  status: VulnerabilityStatus
+  reason?: VulnerabilityUnavailableReason
+  vulnerabilities: KnownVulnerability[]
+  source: {
+    name: 'OSV.dev'
+    url: string | null
+  }
+}
+
 export interface ComponentDetail extends Component {
   systems: ComponentSystemUsage[]
   directDependencies: ComponentDirectDependency[]
@@ -315,6 +348,7 @@ export interface ComponentDetail extends Component {
   packageMetadata: PackageMetadata | null
   maintenanceHealth: MaintenanceHealth | null
   securityScorecard: SecurityScorecard | null
+  vulnerabilities: VulnerabilityReport | null
 }
 
 export interface TechnologyVersionLifecycle {


### PR DESCRIPTION
## Description

Adds a read-through OSV.dev vulnerability overlay to the single component detail page. The component detail API now fetches OSV vulnerability data by package URL, caches the response for 6 hours, and exposes a typed `vulnerabilities` payload for the page to render.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Configuration or build changes

## Related Issues

Fixes #559
Relates to #599
Relates to #601
Relates to #603

## Changes Made

- Added a `VulnerabilityService` that queries OSV.dev `/v1/query` using the component PURL and maps IDs, aliases, severity, affected ranges, and advisory links.
- Added shared `cachedFetch()` support backed by Nitro `cache:api` storage and configured the storage mount.
- Wired vulnerability enrichment into `GET /api/components/{key}` and extended shared API types/OpenAPI output.
- Added a “Known Vulnerabilities” card to the component detail page with unavailable, empty, and populated states.
- Added focused service, API, and Vue page tests.

## Screenshots

Not included. The change is covered by component rendering tests.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

Verification run:

- `npm run test -- test/server/services/vulnerability.service.spec.ts test/server/api/component-detail.spec.ts test/app/pages/components/key.test.ts`
- `npm run lint`
- `npm run mdlint`
- `npm run build`