### PR TITLE
Add GitHub owner import selection

### DIFF
--- a/app/pages/systems/index.vue
+++ b/app/pages/systems/index.vue
@@ -80,33 +80,92 @@
             description="Dependencies are discovered from manifest files fetched via the GitHub API. The full transitive dependency graph is only available after the polaris-sbom.yml workflow runs against this repository."
           />
 
-          <UFormField name="repositoryUrl" label="GitHub Repository" required>
+          <UFormField name="organization" label="GitHub Owner" required>
             <UInput
-              v-model="importState.repositoryUrl"
-              placeholder="owner/repo or https://github.com/owner/repo"
+              v-model="importState.organization"
+              placeholder="owner or https://github.com/owner"
+              :disabled="isImporting"
             />
-            <template #help>
-              <span class="text-(--ui-text-muted)">
-                Repository metadata and dependencies will be fetched via the GitHub API.
-              </span>
-            </template>
           </UFormField>
 
-          <UFormField name="domain" label="Domain">
-            <UInput v-model="importState.domain" placeholder="Development" />
-          </UFormField>
+          <div class="grid md:grid-cols-3 gap-3">
+            <UFormField name="language" label="Language">
+              <UInput v-model="importState.language" placeholder="TypeScript" :disabled="isImporting" />
+            </UFormField>
+            <UFormField name="topic" label="Topic">
+              <UInput v-model="importState.topic" placeholder="platform" :disabled="isImporting" />
+            </UFormField>
+            <UFormField name="namePattern" label="Name Pattern">
+              <UInput v-model="importState.namePattern" placeholder="^service-" :disabled="isImporting" />
+            </UFormField>
+          </div>
+
+          <div v-if="ownerRepositories.length" class="space-y-3 rounded-md border border-(--ui-border) p-3">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <p class="font-medium">{{ ownerRepositories.length }} repositories found</p>
+                <p class="text-sm text-(--ui-text-muted)">{{ selectedRepositoryFullNames.length }} selected</p>
+              </div>
+              <div class="flex gap-2">
+                <UButton label="Select All" size="xs" color="neutral" variant="outline" :disabled="isImporting" @click="selectAllOwnerRepositories" />
+                <UButton label="Clear" size="xs" color="neutral" variant="ghost" :disabled="isImporting" @click="clearSelectedOwnerRepositories" />
+              </div>
+            </div>
+            <div class="max-h-72 overflow-auto divide-y divide-(--ui-border)">
+              <label
+                v-for="repo in ownerRepositories"
+                :key="repo.fullName"
+                class="flex cursor-pointer items-start gap-3 py-2"
+              >
+                <UCheckbox
+                  :model-value="selectedRepositoryFullNames.includes(repo.fullName)"
+                  :disabled="isImporting"
+                  @update:model-value="toggleOwnerRepository(repo.fullName, Boolean($event))"
+                />
+                <span class="min-w-0 flex-1">
+                  <span class="flex flex-wrap items-center gap-2">
+                    <span class="truncate text-sm font-medium">{{ repo.fullName }}</span>
+                    <UBadge v-if="repo.private" color="warning" variant="subtle">private</UBadge>
+                    <UBadge v-if="repo.archived" color="neutral" variant="subtle">archived</UBadge>
+                    <UBadge v-if="repo.fork" color="info" variant="subtle">fork</UBadge>
+                  </span>
+                  <span class="mt-1 block truncate text-xs text-(--ui-text-muted)">
+                    {{ repo.language || 'Unknown language' }}<template v-if="repo.description"> · {{ repo.description }}</template>
+                  </span>
+                </span>
+              </label>
+            </div>
+          </div>
 
           <UFormField name="ownerTeam" label="Owner Team" required>
-            <USelect v-model="importState.ownerTeam" :items="importTeamItems" placeholder="Select a team" />
+            <USelect v-model="importState.ownerTeam" :items="importTeamItems" placeholder="Select a team" :disabled="isImporting" />
           </UFormField>
 
-          <UFormField name="businessCriticality" label="Business Criticality">
-            <USelect v-model="importState.businessCriticality" :items="importCriticalityItems" placeholder="medium" />
-          </UFormField>
-
-          <UFormField name="environment" label="Environment">
-            <USelect v-model="importState.environment" :items="importEnvironmentItems" placeholder="dev" />
-          </UFormField>
+          <div v-if="activeImportJob" class="space-y-3 rounded-md border border-(--ui-border) p-3">
+            <div class="flex items-center justify-between gap-3">
+              <div>
+                <p class="font-medium">{{ importProgressLabel }}</p>
+                <p class="text-sm text-(--ui-text-muted)">{{ activeImportJob.status }}</p>
+              </div>
+              <UBadge :color="importJobStatusColor" variant="subtle">
+                {{ activeImportJob.completed }}/{{ activeImportJob.total }}
+              </UBadge>
+            </div>
+            <div class="h-2 overflow-hidden rounded bg-(--ui-bg-elevated)">
+              <div class="h-full bg-(--ui-primary)" :style="{ width: `${importProgressPercent}%` }" />
+            </div>
+            <div v-if="activeImportJob.items.length" class="max-h-56 overflow-auto divide-y divide-(--ui-border)">
+              <div v-for="item in activeImportJob.items" :key="item.id" class="flex items-start justify-between gap-3 py-2">
+                <div class="min-w-0">
+                  <p class="truncate text-sm font-medium">{{ item.repositoryFullName }}</p>
+                  <p v-if="item.message" class="text-xs text-(--ui-text-muted)">{{ item.message }}</p>
+                </div>
+                <UBadge :color="importItemStatusColor(item.status)" variant="subtle">
+                  {{ item.status }}
+                </UBadge>
+              </div>
+            </div>
+          </div>
 
           <UAlert
             v-if="importError"
@@ -118,12 +177,13 @@
         </UForm>
       </template>
       <template #footer>
-        <UButton label="Cancel" color="neutral" variant="outline" @click="closeImportModal" />
+        <UButton label="Cancel" color="neutral" variant="outline" :disabled="isImporting" @click="closeImportModal" />
         <UButton
           type="submit"
           form="import-form"
-          :loading="isImporting"
-          label="Import"
+          :loading="isImporting || isFetchingRepositories"
+          :disabled="isImportSubmitDisabled"
+          :label="importSubmitLabel"
           color="primary"
         />
       </template>
@@ -311,20 +371,47 @@ interface TeamsResponse {
   count: number
 }
 
-interface ImportResult {
-  systemName: string
+type ImportJobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+type ImportJobItemStatus = 'pending' | 'running' | 'imported' | 'skipped' | 'failed'
+
+interface ImportJobItem {
+  id: string
+  repositoryFullName: string
   repositoryUrl: string
-  manifestsFound: number
-  componentsAdded: number
-  componentsUpdated: number
+  status: ImportJobItemStatus
+  message: string | null
+}
+
+interface ImportJob {
+  id: string
+  status: ImportJobStatus
+  organization: string
+  total: number
+  completed: number
+  failed: number
+  skipped: number
+  error: string | null
+  items: ImportJobItem[]
+}
+
+interface OwnerRepository {
+  name: string
+  fullName: string
+  url: string
+  description: string | null
+  language: string | null
+  private: boolean
+  fork: boolean
+  archived: boolean
+  topics: string[]
 }
 
 const importSchema = z.object({
-  repositoryUrl: z.string().min(1, 'Repository URL is required'),
-  domain: z.string().optional(),
-  ownerTeam: z.string().min(1, 'Owner team is required'),
-  businessCriticality: z.string().optional(),
-  environment: z.string().optional()
+  organization: z.string().min(1, 'GitHub owner is required'),
+  language: z.string().optional(),
+  topic: z.string().optional(),
+  namePattern: z.string().optional(),
+  ownerTeam: z.string().min(1, 'Owner team is required')
 })
 type ImportSchema = z.infer<typeof importSchema>
 
@@ -333,67 +420,136 @@ const importTeamItems = computed(() =>
   (teamsData.value?.data || []).map(t => ({ label: t.name, value: t.name }))
 )
 
-const importCriticalityItems = [
-  { label: 'Critical', value: 'critical' },
-  { label: 'High', value: 'high' },
-  { label: 'Medium', value: 'medium' },
-  { label: 'Low', value: 'low' }
-]
-
-const importEnvironmentItems = [
-  { label: 'Development', value: 'dev' },
-  { label: 'Test', value: 'test' },
-  { label: 'Staging', value: 'staging' },
-  { label: 'Production', value: 'prod' }
-]
-
 const toast = useToast()
 const showImportModal = ref(false)
 const isImporting = ref(false)
+const isFetchingRepositories = ref(false)
 const importError = ref('')
+const activeImportJob = ref<ImportJob | null>(null)
+const ownerRepositories = ref<OwnerRepository[]>([])
+const selectedRepositoryFullNames = ref<string[]>([])
+let importPollTimer: ReturnType<typeof setInterval> | null = null
 
 const importState = reactive<Partial<ImportSchema>>({
-  repositoryUrl: '',
-  domain: '',
-  ownerTeam: '',
-  businessCriticality: '',
-  environment: ''
+  organization: '',
+  language: '',
+  topic: '',
+  namePattern: '',
+  ownerTeam: ''
 })
+
+const importProgressPercent = computed(() => {
+  if (!activeImportJob.value?.total) return 0
+  return Math.round((activeImportJob.value.completed / activeImportJob.value.total) * 100)
+})
+
+const importProgressLabel = computed(() => {
+  const job = activeImportJob.value
+  if (!job) return ''
+  if (job.status === 'queued') return 'Queued'
+  if (job.status === 'running') return `Importing ${job.completed}/${job.total} repositories`
+  if (job.status === 'completed') return `Finished ${job.completed}/${job.total} repositories`
+  return job.error || 'Import failed'
+})
+
+const importJobStatusColor = computed(() => {
+  const status = activeImportJob.value?.status
+  if (status === 'completed') return 'success'
+  if (status === 'failed' || status === 'cancelled') return 'error'
+  return 'info'
+})
+
+const importSubmitLabel = computed(() => {
+  return ownerRepositories.value.length > 0 ? 'Import Selected' : 'Fetch Repositories'
+})
+
+const isImportSubmitDisabled = computed(() => {
+  if (isImporting.value || isFetchingRepositories.value) return true
+  if (ownerRepositories.value.length > 0) {
+    return selectedRepositoryFullNames.value.length === 0
+  }
+  return false
+})
+
+function importItemStatusColor(status: ImportJobItemStatus): 'success' | 'error' | 'warning' | 'info' | 'neutral' {
+  if (status === 'imported') return 'success'
+  if (status === 'failed') return 'error'
+  if (status === 'skipped') return 'warning'
+  if (status === 'running') return 'info'
+  return 'neutral'
+}
+
+function stopImportPolling() {
+  if (importPollTimer) {
+    clearInterval(importPollTimer)
+    importPollTimer = null
+  }
+}
+
+function resetOwnerRepositorySelection() {
+  ownerRepositories.value = []
+  selectedRepositoryFullNames.value = []
+}
+
+function selectAllOwnerRepositories() {
+  selectedRepositoryFullNames.value = ownerRepositories.value.map(repo => repo.fullName)
+}
+
+function clearSelectedOwnerRepositories() {
+  selectedRepositoryFullNames.value = []
+}
+
+function toggleOwnerRepository(fullName: string, selected: boolean) {
+  const current = new Set(selectedRepositoryFullNames.value)
+  if (selected) {
+    current.add(fullName)
+  } else {
+    current.delete(fullName)
+  }
+  selectedRepositoryFullNames.value = ownerRepositories.value
+    .map(repo => repo.fullName)
+    .filter(fullName => current.has(fullName))
+}
+
+watch(
+  () => [
+    importState.organization,
+    importState.language,
+    importState.topic,
+    importState.namePattern
+  ],
+  () => {
+    resetOwnerRepositorySelection()
+  }
+)
 
 function closeImportModal() {
   showImportModal.value = false
   setTimeout(() => {
-    Object.assign(importState, { repositoryUrl: '', domain: '', ownerTeam: '', businessCriticality: '', environment: '' })
+    Object.assign(importState, {
+      organization: '',
+      language: '',
+      topic: '',
+      namePattern: '',
+      ownerTeam: ''
+    })
     importError.value = ''
+    activeImportJob.value = null
+    resetOwnerRepositorySelection()
   }, 300)
 }
 
 async function onImport(event: FormSubmitEvent<ImportSchema>) {
   isImporting.value = true
   importError.value = ''
+  activeImportJob.value = null
+  stopImportPolling()
 
   try {
-    const body: Record<string, string> = { repositoryUrl: event.data.repositoryUrl }
-    if (event.data.domain) body.domain = event.data.domain
-    if (event.data.ownerTeam) body.ownerTeam = event.data.ownerTeam
-    if (event.data.businessCriticality) body.businessCriticality = event.data.businessCriticality
-    if (event.data.environment) body.environment = event.data.environment
-
-    const response = await $fetch<{ success: boolean; data: ImportResult }>('/api/admin/import/github', {
-      method: 'POST',
-      body
-    })
-
-    if (response.success) {
-      const result = response.data
-      closeImportModal()
-      await refreshNuxtData()
-      toast.add({
-        title: `${result.systemName} imported`,
-        description: `${result.manifestsFound} manifest(s) found · ${result.componentsAdded} added · ${result.componentsUpdated} updated`,
-        color: 'success',
-        icon: 'i-lucide-check-circle'
-      })
+    if (ownerRepositories.value.length === 0) {
+      await fetchOwnerRepositories(event.data)
+    } else {
+      await startOrganizationImport(event.data)
     }
   }
   catch (error: unknown) {
@@ -401,9 +557,105 @@ async function onImport(event: FormSubmitEvent<ImportSchema>) {
     importError.value = err.data?.message || err.message || 'Import failed'
   }
   finally {
-    isImporting.value = false
+    if (!activeImportJob.value) {
+      isImporting.value = false
+    }
   }
 }
+
+async function startOrganizationImport(data: ImportSchema) {
+  const selected = ownerRepositories.value.filter(repo => selectedRepositoryFullNames.value.includes(repo.fullName))
+  const body = {
+    owner: data.organization,
+    repositories: selected.map(repo => ({
+      repositoryFullName: repo.fullName,
+      repositoryUrl: repo.url
+    })),
+    filters: {
+      language: data.language || undefined,
+      topic: data.topic || undefined,
+      namePattern: data.namePattern || undefined
+    },
+    ownerTeam: data.ownerTeam
+  }
+
+  const response = await $fetch<{ success: boolean; data: ImportJob }>('/api/admin/import/github-org', {
+    method: 'POST',
+    body
+  })
+
+  activeImportJob.value = response.data
+  startImportPolling(response.data.id)
+}
+
+async function fetchOwnerRepositories(data: ImportSchema) {
+  isFetchingRepositories.value = true
+  importError.value = ''
+
+  try {
+    const response = await $fetch<{ success: boolean; data: OwnerRepository[]; count: number }>('/api/admin/import/github-org/repositories', {
+      method: 'POST',
+      body: {
+        owner: data.organization,
+        filters: {
+          language: data.language || undefined,
+          topic: data.topic || undefined,
+          namePattern: data.namePattern || undefined
+        }
+      }
+    })
+
+    ownerRepositories.value = response.data
+    selectAllOwnerRepositories()
+
+    if (response.count === 0) {
+      importError.value = 'No repositories matched the current owner and filters'
+    }
+  } catch (error: unknown) {
+    const err = error as { data?: { message?: string }; message?: string }
+    importError.value = err.data?.message || err.message || 'Failed to fetch repositories'
+  } finally {
+    isFetchingRepositories.value = false
+  }
+}
+
+function startImportPolling(jobId: string) {
+  const poll = async () => {
+    try {
+      const response = await $fetch<{ success: boolean; data: ImportJob }>(`/api/admin/import/jobs/${encodeURIComponent(jobId)}`)
+      activeImportJob.value = response.data
+
+      if (['completed', 'failed', 'cancelled'].includes(response.data.status)) {
+        stopImportPolling()
+        isImporting.value = false
+
+        if (response.data.status === 'completed') {
+          await refreshNuxtData()
+          toast.add({
+            title: 'Owner import complete',
+            description: `${response.data.completed}/${response.data.total} finished · ${response.data.failed} failed · ${response.data.skipped} skipped`,
+            color: response.data.failed > 0 ? 'warning' : 'success',
+            icon: response.data.failed > 0 ? 'i-lucide-alert-triangle' : 'i-lucide-check-circle'
+          })
+        } else {
+          importError.value = response.data.error || 'Import failed'
+        }
+      }
+    } catch (error: unknown) {
+      stopImportPolling()
+      isImporting.value = false
+      const err = error as { data?: { message?: string }; message?: string }
+      importError.value = err.data?.message || err.message || 'Failed to load import status'
+    }
+  }
+
+  void poll()
+  importPollTimer = setInterval(() => { void poll() }, 2000)
+}
+
+onBeforeUnmount(() => {
+  stopImportPolling()
+})
 
 // --- Edit System ---
 const editSystemSchema = z.object({

--- a/app/pages/systems/index.vue
+++ b/app/pages/systems/index.vue
@@ -429,6 +429,7 @@ const activeImportJob = ref<ImportJob | null>(null)
 const ownerRepositories = ref<OwnerRepository[]>([])
 const selectedRepositoryFullNames = ref<string[]>([])
 let importPollTimer: ReturnType<typeof setInterval> | null = null
+let importPollInFlight = false
 
 const importState = reactive<Partial<ImportSchema>>({
   organization: '',
@@ -621,6 +622,9 @@ async function fetchOwnerRepositories(data: ImportSchema) {
 
 function startImportPolling(jobId: string) {
   const poll = async () => {
+    if (importPollInFlight) return
+    importPollInFlight = true
+
     try {
       const response = await $fetch<{ success: boolean; data: ImportJob }>(`/api/admin/import/jobs/${encodeURIComponent(jobId)}`)
       activeImportJob.value = response.data
@@ -646,6 +650,8 @@ function startImportPolling(jobId: string) {
       isImporting.value = false
       const err = error as { data?: { message?: string }; message?: string }
       importError.value = err.data?.message || err.message || 'Failed to load import status'
+    } finally {
+      importPollInFlight = false
     }
   }
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -6069,6 +6069,218 @@
           }
         }
       }
+    },
+    "/admin/import/github-org": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Start a GitHub owner import job",
+        "description": "Lists repositories for a GitHub organization or user and starts a background import job.\nReturns immediately with a job ID that can be polled for progress.\n",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "owner",
+                  "ownerTeam"
+                ],
+                "properties": {
+                  "owner": {
+                    "type": "string",
+                    "description": "GitHub organization/user login or profile URL",
+                    "example": "https://github.com/localgod"
+                  },
+                  "organization": {
+                    "type": "string",
+                    "deprecated": true,
+                    "description": "Backward-compatible alias for owner"
+                  },
+                  "filters": {
+                    "type": "object",
+                    "properties": {
+                      "language": {
+                        "type": "string"
+                      },
+                      "topic": {
+                        "type": "string"
+                      },
+                      "namePattern": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "dryRun": {
+                    "type": "boolean"
+                  },
+                  "repositories": {
+                    "type": "array",
+                    "description": "Selected repositories to import. When omitted, all matching owner repositories are imported.",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "repositoryFullName",
+                        "repositoryUrl"
+                      ],
+                      "properties": {
+                        "repositoryFullName": {
+                          "type": "string"
+                        },
+                        "repositoryUrl": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "domain": {
+                    "type": "string"
+                  },
+                  "ownerTeam": {
+                    "type": "string"
+                  },
+                  "businessCriticality": {
+                    "type": "string",
+                    "enum": [
+                      "critical",
+                      "high",
+                      "medium",
+                      "low"
+                    ]
+                  },
+                  "environment": {
+                    "type": "string",
+                    "enum": [
+                      "dev",
+                      "test",
+                      "staging",
+                      "prod"
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Import job accepted"
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "403": {
+            "description": "Superuser access required"
+          }
+        }
+      }
+    },
+    "/admin/import/jobs/{jobId}": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get import job status",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Import job status"
+          },
+          "403": {
+            "description": "Superuser access required"
+          },
+          "404": {
+            "description": "Import job not found"
+          }
+        }
+      }
+    },
+    "/admin/import/github-org/repositories": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Preview GitHub owner repositories",
+        "description": "Lists repositories for a GitHub organization or user before starting an import job.\nSuperusers can use the returned list to choose which repositories to import.\n",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "owner"
+                ],
+                "properties": {
+                  "owner": {
+                    "type": "string",
+                    "description": "GitHub organization/user login or profile URL",
+                    "example": "https://github.com/localgod"
+                  },
+                  "organization": {
+                    "type": "string",
+                    "deprecated": true,
+                    "description": "Backward-compatible alias for owner"
+                  },
+                  "filters": {
+                    "type": "object",
+                    "properties": {
+                      "language": {
+                        "type": "string"
+                      },
+                      "topic": {
+                        "type": "string"
+                      },
+                      "namePattern": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Repositories retrieved successfully"
+          },
+          "400": {
+            "description": "Invalid input"
+          },
+          "403": {
+            "description": "Superuser access required"
+          },
+          "422": {
+            "description": "GitHub owner not accessible"
+          }
+        }
+      }
     }
   }
 }

--- a/schema/migrations/common/20260618_120000_add_import_job_schema.down.cypher
+++ b/schema/migrations/common/20260618_120000_add_import_job_schema.down.cypher
@@ -1,0 +1,10 @@
+/*
+ * Rollback: Add import job schema
+ */
+
+DROP INDEX import_job_item_status IF EXISTS;
+DROP INDEX import_job_requested_by IF EXISTS;
+DROP INDEX import_job_status IF EXISTS;
+
+DROP CONSTRAINT import_job_item_id_unique IF EXISTS;
+DROP CONSTRAINT import_job_id_unique IF EXISTS;

--- a/schema/migrations/common/20260618_120000_add_import_job_schema.up.cypher
+++ b/schema/migrations/common/20260618_120000_add_import_job_schema.up.cypher
@@ -1,0 +1,29 @@
+/*
+ * Migration: Add import job schema
+ * Version: 20260618.120000
+ *
+ * Description:
+ * Adds persisted job state for background import workflows.
+ *
+ * Rollback: See 20260618_120000_add_import_job_schema.down.cypher
+ */
+
+CREATE CONSTRAINT import_job_id_unique IF NOT EXISTS
+FOR (j:ImportJob)
+REQUIRE j.id IS UNIQUE;
+
+CREATE CONSTRAINT import_job_item_id_unique IF NOT EXISTS
+FOR (i:ImportJobItem)
+REQUIRE i.id IS UNIQUE;
+
+CREATE INDEX import_job_status IF NOT EXISTS
+FOR (j:ImportJob)
+ON (j.status);
+
+CREATE INDEX import_job_requested_by IF NOT EXISTS
+FOR (j:ImportJob)
+ON (j.requestedBy);
+
+CREATE INDEX import_job_item_status IF NOT EXISTS
+FOR (i:ImportJobItem)
+ON (i.status);

--- a/schema/schema/constraints.cypher
+++ b/schema/schema/constraints.cypher
@@ -19,6 +19,15 @@ CREATE CONSTRAINT audit_log_id_unique IF NOT EXISTS
 FOR (a:AuditLog)
 REQUIRE a.id IS UNIQUE;
 
+// Import job constraints
+CREATE CONSTRAINT import_job_id_unique IF NOT EXISTS
+FOR (j:ImportJob)
+REQUIRE j.id IS UNIQUE;
+
+CREATE CONSTRAINT import_job_item_id_unique IF NOT EXISTS
+FOR (i:ImportJobItem)
+REQUIRE i.id IS UNIQUE;
+
 // License constraints
 CREATE CONSTRAINT license_id_unique IF NOT EXISTS
 FOR (l:License)

--- a/schema/schema/indexes.cypher
+++ b/schema/schema/indexes.cypher
@@ -43,6 +43,19 @@ CREATE INDEX audit_log_entity_composite IF NOT EXISTS
 FOR (a:AuditLog)
 ON (a.entityType, a.entityId, a.timestamp);
 
+// Import job indexes
+CREATE INDEX import_job_status IF NOT EXISTS
+FOR (j:ImportJob)
+ON (j.status);
+
+CREATE INDEX import_job_requested_by IF NOT EXISTS
+FOR (j:ImportJob)
+ON (j.requestedBy);
+
+CREATE INDEX import_job_item_status IF NOT EXISTS
+FOR (i:ImportJobItem)
+ON (i.status);
+
 // License indexes
 CREATE INDEX license_spdx_id IF NOT EXISTS
 FOR (l:License)

--- a/server/api/admin/import/github-org.post.ts
+++ b/server/api/admin/import/github-org.post.ts
@@ -1,0 +1,131 @@
+import { gitHubOrgImportService } from '../../../services/singletons'
+
+/**
+ * @openapi
+ * /admin/import/github-org:
+ *   post:
+ *     tags:
+ *       - Admin
+ *     summary: Start a GitHub owner import job
+ *     description: |
+ *       Lists repositories for a GitHub organization or user and starts a background import job.
+ *       Returns immediately with a job ID that can be polled for progress.
+ *     security:
+ *       - sessionAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - owner
+ *               - ownerTeam
+ *             properties:
+ *               owner:
+ *                 type: string
+ *                 description: GitHub organization/user login or profile URL
+ *                 example: "https://github.com/localgod"
+ *               organization:
+ *                 type: string
+ *                 deprecated: true
+ *                 description: Backward-compatible alias for owner
+ *               filters:
+ *                 type: object
+ *                 properties:
+ *                   language:
+ *                     type: string
+ *                   topic:
+ *                     type: string
+ *                   namePattern:
+ *                     type: string
+ *               dryRun:
+ *                 type: boolean
+ *               repositories:
+ *                 type: array
+ *                 description: Selected repositories to import. When omitted, all matching owner repositories are imported.
+ *                 items:
+ *                   type: object
+ *                   required:
+ *                     - repositoryFullName
+ *                     - repositoryUrl
+ *                   properties:
+ *                     repositoryFullName:
+ *                       type: string
+ *                     repositoryUrl:
+ *                       type: string
+ *               domain:
+ *                 type: string
+ *               ownerTeam:
+ *                 type: string
+ *               businessCriticality:
+ *                 type: string
+ *                 enum: [critical, high, medium, low]
+ *               environment:
+ *                 type: string
+ *                 enum: [dev, test, staging, prod]
+ *     responses:
+ *       202:
+ *         description: Import job accepted
+ *       400:
+ *         description: Invalid input
+ *       403:
+ *         description: Superuser access required
+ */
+export default defineEventHandler(async (event) => {
+  const user = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
+  const body = await readBody(event) || {}
+
+  const owner = typeof body.owner === 'string'
+    ? body.owner.trim()
+    : typeof body.organization === 'string' ? body.organization.trim() : ''
+  const ownerTeam = typeof body.ownerTeam === 'string' ? body.ownerTeam.trim() : ''
+  const filters = body.filters && typeof body.filters === 'object' ? body.filters : {}
+  const repositories = Array.isArray(body.repositories)
+    ? body.repositories.map((repo: Record<string, unknown>) => ({
+        repositoryFullName: typeof repo.repositoryFullName === 'string' ? repo.repositoryFullName.trim() : '',
+        repositoryUrl: typeof repo.repositoryUrl === 'string' ? repo.repositoryUrl.trim() : ''
+      }))
+    : undefined
+
+  if (!owner) {
+    throw createError({ statusCode: 400, message: 'owner is required' })
+  }
+
+  if (!ownerTeam) {
+    throw createError({ statusCode: 400, message: 'ownerTeam is required' })
+  }
+
+  try {
+    const job = await gitHubOrgImportService.start({
+      organization: owner,
+      filters: {
+        language: typeof filters.language === 'string' ? filters.language.trim() || undefined : undefined,
+        topic: typeof filters.topic === 'string' ? filters.topic.trim() || undefined : undefined,
+        namePattern: typeof filters.namePattern === 'string' ? filters.namePattern.trim() || undefined : undefined
+      },
+      repositories,
+      dryRun: Boolean(body.dryRun),
+      domain: typeof body.domain === 'string' ? body.domain.trim() || undefined : undefined,
+      ownerTeam,
+      businessCriticality: body.businessCriticality,
+      environment: body.environment,
+      userId: user.id,
+      realUserId
+    })
+
+    setResponseStatus(event, 202)
+    return {
+      success: true,
+      data: job
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    const message = error instanceof Error ? error.message : 'GitHub owner import failed'
+    throw createError({ statusCode: 422, statusMessage: message, message })
+  }
+})

--- a/server/api/admin/import/github-org/repositories.post.ts
+++ b/server/api/admin/import/github-org/repositories.post.ts
@@ -1,0 +1,94 @@
+import { gitHubOrgImportService } from '../../../../services/singletons'
+
+/**
+ * @openapi
+ * /admin/import/github-org/repositories:
+ *   post:
+ *     tags:
+ *       - Admin
+ *     summary: Preview GitHub owner repositories
+ *     description: |
+ *       Lists repositories for a GitHub organization or user before starting an import job.
+ *       Superusers can use the returned list to choose which repositories to import.
+ *     security:
+ *       - sessionAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - owner
+ *             properties:
+ *               owner:
+ *                 type: string
+ *                 description: GitHub organization/user login or profile URL
+ *                 example: "https://github.com/localgod"
+ *               organization:
+ *                 type: string
+ *                 deprecated: true
+ *                 description: Backward-compatible alias for owner
+ *               filters:
+ *                 type: object
+ *                 properties:
+ *                   language:
+ *                     type: string
+ *                   topic:
+ *                     type: string
+ *                   namePattern:
+ *                     type: string
+ *     responses:
+ *       200:
+ *         description: Repositories retrieved successfully
+ *       400:
+ *         description: Invalid input
+ *       403:
+ *         description: Superuser access required
+ *       422:
+ *         description: GitHub owner not accessible
+ */
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+  const body = await readBody(event) || {}
+
+  const owner = typeof body.owner === 'string'
+    ? body.owner.trim()
+    : typeof body.organization === 'string' ? body.organization.trim() : ''
+  const filters = body.filters && typeof body.filters === 'object' ? body.filters : {}
+
+  if (!owner) {
+    throw createError({ statusCode: 400, message: 'owner is required' })
+  }
+
+  try {
+    const repositories = await gitHubOrgImportService.previewRepositories(owner, {
+      language: typeof filters.language === 'string' ? filters.language.trim() || undefined : undefined,
+      topic: typeof filters.topic === 'string' ? filters.topic.trim() || undefined : undefined,
+      namePattern: typeof filters.namePattern === 'string' ? filters.namePattern.trim() || undefined : undefined
+    })
+
+    return {
+      success: true,
+      data: repositories.map(repo => ({
+        name: repo.name,
+        fullName: repo.full_name,
+        url: repo.html_url,
+        description: repo.description,
+        language: repo.language,
+        private: repo.private,
+        fork: repo.fork,
+        archived: repo.archived,
+        topics: repo.topics || []
+      })),
+      count: repositories.length
+    }
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error
+    }
+
+    const message = error instanceof Error ? error.message : 'Failed to fetch GitHub repositories'
+    throw createError({ statusCode: 422, statusMessage: message, message })
+  }
+})

--- a/server/api/admin/import/jobs/[jobId].get.ts
+++ b/server/api/admin/import/jobs/[jobId].get.ts
@@ -1,0 +1,43 @@
+import { gitHubOrgImportService } from '../../../../services/singletons'
+
+/**
+ * @openapi
+ * /admin/import/jobs/{jobId}:
+ *   get:
+ *     tags:
+ *       - Admin
+ *     summary: Get import job status
+ *     security:
+ *       - sessionAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: jobId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Import job status
+ *       403:
+ *         description: Superuser access required
+ *       404:
+ *         description: Import job not found
+ */
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+
+  const jobId = getRouterParam(event, 'jobId') || ''
+  if (!jobId) {
+    throw createError({ statusCode: 400, message: 'jobId is required' })
+  }
+
+  const job = await gitHubOrgImportService.findById(jobId)
+  if (!job) {
+    throw createError({ statusCode: 404, message: 'Import job not found' })
+  }
+
+  return {
+    success: true,
+    data: job
+  }
+})

--- a/server/repositories/import-job.repository.ts
+++ b/server/repositories/import-job.repository.ts
@@ -1,0 +1,273 @@
+import { BaseRepository } from './base.repository'
+import type { Record as Neo4jRecord } from 'neo4j-driver'
+
+export type ImportJobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+export type ImportJobItemStatus = 'pending' | 'running' | 'imported' | 'skipped' | 'failed'
+
+export interface ImportJobFilters {
+  language?: string
+  topic?: string
+  namePattern?: string
+}
+
+export interface ImportJob {
+  id: string
+  type: 'github-org'
+  status: ImportJobStatus
+  requestedBy: string
+  organization: string
+  filters: ImportJobFilters
+  dryRun: boolean
+  total: number
+  completed: number
+  failed: number
+  skipped: number
+  createdAt: string
+  startedAt: string | null
+  finishedAt: string | null
+  error: string | null
+  items: ImportJobItem[]
+}
+
+export interface ImportJobItem {
+  id: string
+  repositoryFullName: string
+  repositoryUrl: string
+  status: ImportJobItemStatus
+  message: string | null
+  systemName: string | null
+  manifestsFound: number
+  componentsAdded: number
+  componentsUpdated: number
+  relationshipsCreated: number
+  startedAt: string | null
+  finishedAt: string | null
+}
+
+export interface CreateImportJobParams {
+  type: 'github-org'
+  requestedBy: string
+  organization: string
+  filters: ImportJobFilters
+  dryRun: boolean
+}
+
+export interface CreateImportJobItemParams {
+  repositoryFullName: string
+  repositoryUrl: string
+  status?: ImportJobItemStatus
+  message?: string | null
+  systemName?: string | null
+  manifestsFound?: number
+  componentsAdded?: number
+  componentsUpdated?: number
+  relationshipsCreated?: number
+}
+
+function intValue(value: unknown): number {
+  if (typeof value === 'number') return value
+  if (value && typeof value === 'object' && 'toNumber' in value && typeof value.toNumber === 'function') {
+    return value.toNumber()
+  }
+  return 0
+}
+
+export class ImportJobRepository extends BaseRepository {
+  async create(params: CreateImportJobParams): Promise<ImportJob> {
+    const { records } = await this.executeQuery(`
+      CREATE (job:ImportJob {
+        id: randomUUID(),
+        type: $type,
+        status: 'queued',
+        requestedBy: $requestedBy,
+        organization: $organization,
+        filters: $filters,
+        dryRun: $dryRun,
+        total: 0,
+        completed: 0,
+        failed: 0,
+        skipped: 0,
+        createdAt: datetime(),
+        startedAt: null,
+        finishedAt: null,
+        error: null
+      })
+      WITH job
+      OPTIONAL MATCH (user:User {id: $requestedBy})
+      FOREACH (_ IN CASE WHEN user IS NULL THEN [] ELSE [1] END |
+        MERGE (user)-[:REQUESTED]->(job)
+      )
+      RETURN job, [] AS items
+    `, {
+      ...params,
+      filters: JSON.stringify(params.filters)
+    })
+
+    if (records.length === 0) {
+      throw new Error('Failed to create import job')
+    }
+
+    return this.mapJob(records[0]!)
+  }
+
+  async findById(id: string): Promise<ImportJob | null> {
+    const { records } = await this.executeQuery(`
+      MATCH (job:ImportJob {id: $id})
+      OPTIONAL MATCH (job)-[:HAS_ITEM]->(item:ImportJobItem)
+      WITH job, item
+      ORDER BY item.repositoryFullName ASC
+      RETURN job, collect(item) AS items
+    `, { id })
+
+    if (records.length === 0) return null
+    return this.mapJob(records[0]!)
+  }
+
+  async markRunning(id: string): Promise<void> {
+    await this.executeQuery(`
+      MATCH (job:ImportJob {id: $id})
+      SET job.status = 'running',
+          job.startedAt = coalesce(job.startedAt, datetime()),
+          job.error = null
+    `, { id })
+  }
+
+  async markCompleted(id: string): Promise<void> {
+    await this.executeQuery(`
+      MATCH (job:ImportJob {id: $id})
+      SET job.status = 'completed',
+          job.finishedAt = datetime()
+    `, { id })
+  }
+
+  async markFailed(id: string, error: string): Promise<void> {
+    await this.executeQuery(`
+      MATCH (job:ImportJob {id: $id})
+      SET job.status = 'failed',
+          job.finishedAt = datetime(),
+          job.error = $error
+    `, { id, error })
+  }
+
+  async createItems(jobId: string, items: CreateImportJobItemParams[]): Promise<void> {
+    if (items.length === 0) {
+      await this.executeQuery(`
+        MATCH (job:ImportJob {id: $jobId})
+        SET job.total = 0
+      `, { jobId })
+      return
+    }
+
+    await this.executeQuery(`
+      MATCH (job:ImportJob {id: $jobId})
+      SET job.total = size($items)
+      WITH job
+      UNWIND $items AS item
+      CREATE (job)-[:HAS_ITEM]->(:ImportJobItem {
+        id: randomUUID(),
+        repositoryFullName: item.repositoryFullName,
+        repositoryUrl: item.repositoryUrl,
+        status: coalesce(item.status, 'pending'),
+        message: item.message,
+        systemName: item.systemName,
+        manifestsFound: coalesce(item.manifestsFound, 0),
+        componentsAdded: coalesce(item.componentsAdded, 0),
+        componentsUpdated: coalesce(item.componentsUpdated, 0),
+        relationshipsCreated: coalesce(item.relationshipsCreated, 0),
+        startedAt: null,
+        finishedAt: CASE WHEN coalesce(item.status, 'pending') <> 'pending' THEN datetime() ELSE null END
+      })
+    `, { jobId, items })
+  }
+
+  async markItemRunning(jobId: string, repositoryFullName: string): Promise<void> {
+    await this.executeQuery(`
+      MATCH (:ImportJob {id: $jobId})-[:HAS_ITEM]->(item:ImportJobItem {repositoryFullName: $repositoryFullName})
+      SET item.status = 'running',
+          item.startedAt = coalesce(item.startedAt, datetime()),
+          item.message = null
+    `, { jobId, repositoryFullName })
+  }
+
+  async markItemFinished(
+    jobId: string,
+    repositoryFullName: string,
+    status: Exclude<ImportJobItemStatus, 'pending' | 'running'>,
+    updates: Partial<Omit<ImportJobItem, 'id' | 'repositoryFullName' | 'repositoryUrl' | 'status' | 'startedAt' | 'finishedAt'>>
+  ): Promise<void> {
+    await this.executeQuery(`
+      MATCH (job:ImportJob {id: $jobId})-[:HAS_ITEM]->(item:ImportJobItem {repositoryFullName: $repositoryFullName})
+      SET item.status = $status,
+          item.message = $message,
+          item.systemName = $systemName,
+          item.manifestsFound = $manifestsFound,
+          item.componentsAdded = $componentsAdded,
+          item.componentsUpdated = $componentsUpdated,
+          item.relationshipsCreated = $relationshipsCreated,
+          item.finishedAt = datetime()
+      SET job.completed = job.completed + 1,
+          job.failed = job.failed + CASE WHEN $status = 'failed' THEN 1 ELSE 0 END,
+          job.skipped = job.skipped + CASE WHEN $status = 'skipped' THEN 1 ELSE 0 END
+    `, {
+      jobId,
+      repositoryFullName,
+      status,
+      message: updates.message ?? null,
+      systemName: updates.systemName ?? null,
+      manifestsFound: updates.manifestsFound ?? 0,
+      componentsAdded: updates.componentsAdded ?? 0,
+      componentsUpdated: updates.componentsUpdated ?? 0,
+      relationshipsCreated: updates.relationshipsCreated ?? 0
+    })
+  }
+
+  private mapJob(record: Neo4jRecord): ImportJob {
+    const job = record.get('job')
+    const rawFilters = job.properties.filters
+    let filters: ImportJobFilters = {}
+    if (typeof rawFilters === 'string' && rawFilters) {
+      try { filters = JSON.parse(rawFilters) as ImportJobFilters } catch { filters = {} }
+    }
+
+    const rawItems = (record.get('items') || []) as Array<{ properties?: Record<string, unknown> } | null>
+    const items = rawItems
+      .filter((item): item is { properties: Record<string, unknown> } => Boolean(item?.properties))
+      .map(item => this.mapItem(item.properties))
+
+    return {
+      id: job.properties.id,
+      type: job.properties.type,
+      status: job.properties.status,
+      requestedBy: job.properties.requestedBy,
+      organization: job.properties.organization,
+      filters,
+      dryRun: Boolean(job.properties.dryRun),
+      total: intValue(job.properties.total),
+      completed: intValue(job.properties.completed),
+      failed: intValue(job.properties.failed),
+      skipped: intValue(job.properties.skipped),
+      createdAt: job.properties.createdAt?.toString() || '',
+      startedAt: job.properties.startedAt?.toString() || null,
+      finishedAt: job.properties.finishedAt?.toString() || null,
+      error: job.properties.error || null,
+      items
+    }
+  }
+
+  private mapItem(item: Record<string, unknown>): ImportJobItem {
+    return {
+      id: item.id as string,
+      repositoryFullName: item.repositoryFullName as string,
+      repositoryUrl: item.repositoryUrl as string,
+      status: item.status as ImportJobItemStatus,
+      message: (item.message as string | null | undefined) ?? null,
+      systemName: (item.systemName as string | null | undefined) ?? null,
+      manifestsFound: intValue(item.manifestsFound),
+      componentsAdded: intValue(item.componentsAdded),
+      componentsUpdated: intValue(item.componentsUpdated),
+      relationshipsCreated: intValue(item.relationshipsCreated),
+      startedAt: item.startedAt?.toString() || null,
+      finishedAt: item.finishedAt?.toString() || null
+    }
+  }
+}

--- a/server/services/github-org-import.service.ts
+++ b/server/services/github-org-import.service.ts
@@ -1,0 +1,205 @@
+import { AuditLogRepository } from '../repositories/audit-log.repository'
+import {
+  ImportJobRepository,
+  type ImportJob,
+  type ImportJobFilters,
+  type ImportJobItem,
+  type CreateImportJobItemParams
+} from '../repositories/import-job.repository'
+import { GitHubImportService } from './github-import.service'
+import { listGitHubOwnerRepositories, parseGitHubOwner, type GitHubOrgRepository } from '../utils/github'
+import { logger } from '../utils/logger'
+
+export interface GitHubRepositorySelection {
+  repositoryFullName: string
+  repositoryUrl: string
+}
+
+export interface GitHubOrgImportInput {
+  organization: string
+  filters?: ImportJobFilters
+  repositories?: GitHubRepositorySelection[]
+  dryRun?: boolean
+  domain?: string
+  ownerTeam: string
+  businessCriticality?: string
+  environment?: string
+  userId: string
+  realUserId?: string | null
+}
+
+const activeJobs = new Set<string>()
+
+export class GitHubOrgImportService {
+  private jobRepo: ImportJobRepository
+  private gitHubImportService: GitHubImportService
+  private auditRepo: AuditLogRepository
+
+  constructor(
+    jobRepo = new ImportJobRepository(),
+    gitHubImportService = new GitHubImportService(),
+    auditRepo = new AuditLogRepository()
+  ) {
+    this.jobRepo = jobRepo
+    this.gitHubImportService = gitHubImportService
+    this.auditRepo = auditRepo
+  }
+
+  async start(input: GitHubOrgImportInput): Promise<ImportJob> {
+    const organization = input.organization.trim()
+    if (!organization) {
+      throw createError({ statusCode: 400, message: 'owner is required' })
+    }
+
+    if (!input.ownerTeam?.trim()) {
+      throw createError({ statusCode: 400, message: 'ownerTeam is required' })
+    }
+
+    const owner = parseGitHubOwner(organization)
+    const repositories = this.normalizeSelections(input.repositories)
+    const job = await this.jobRepo.create({
+      type: 'github-org',
+      requestedBy: input.userId,
+      organization: owner,
+      filters: input.filters || {},
+      dryRun: Boolean(input.dryRun)
+    })
+
+    this.runInBackground(job.id, { ...input, organization: owner, repositories, ownerTeam: input.ownerTeam.trim() })
+    return job
+  }
+
+  async previewRepositories(ownerInput: string, filters: ImportJobFilters = {}): Promise<GitHubOrgRepository[]> {
+    const owner = parseGitHubOwner(ownerInput)
+    return await listGitHubOwnerRepositories(owner, filters)
+  }
+
+  async findById(id: string): Promise<ImportJob | null> {
+    return await this.jobRepo.findById(id)
+  }
+
+  private runInBackground(jobId: string, input: GitHubOrgImportInput): void {
+    if (activeJobs.has(jobId)) return
+    activeJobs.add(jobId)
+
+    void this.process(jobId, input)
+      .catch(error => {
+        logger.error({ err: error, jobId }, 'GitHub org import job failed')
+      })
+      .finally(() => {
+        activeJobs.delete(jobId)
+      })
+  }
+
+  async process(jobId: string, input: GitHubOrgImportInput): Promise<void> {
+    await this.jobRepo.markRunning(jobId)
+
+    try {
+      const repositories = input.repositories && input.repositories.length > 0
+        ? input.repositories
+        : (await listGitHubOwnerRepositories(input.organization, input.filters || {})).map(repo => ({
+            repositoryFullName: repo.full_name,
+            repositoryUrl: repo.html_url
+          }))
+      const items = repositories.map(repo => ({
+        repositoryFullName: repo.repositoryFullName,
+        repositoryUrl: repo.repositoryUrl
+      }))
+
+      await this.jobRepo.createItems(jobId, items)
+
+      if (input.dryRun) {
+        await this.finishDryRun(jobId, items)
+        await this.jobRepo.markCompleted(jobId)
+        return
+      }
+
+      for (const item of items) {
+        await this.importRepository(jobId, item, input)
+      }
+
+      await this.jobRepo.markCompleted(jobId)
+      await this.createAuditLog(jobId, input)
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'GitHub owner import failed'
+      await this.jobRepo.markFailed(jobId, message)
+      throw error
+    }
+  }
+
+  private async finishDryRun(jobId: string, items: CreateImportJobItemParams[]): Promise<void> {
+    for (const item of items) {
+      await this.jobRepo.markItemFinished(jobId, item.repositoryFullName, 'skipped', {
+        message: 'Dry run only'
+      })
+    }
+  }
+
+  private async importRepository(
+    jobId: string,
+    item: Pick<ImportJobItem, 'repositoryFullName' | 'repositoryUrl'>,
+    input: GitHubOrgImportInput
+  ): Promise<void> {
+    await this.jobRepo.markItemRunning(jobId, item.repositoryFullName)
+
+    try {
+      const result = await this.gitHubImportService.import({
+        repositoryUrl: item.repositoryUrl,
+        domain: input.domain,
+        ownerTeam: input.ownerTeam,
+        businessCriticality: input.businessCriticality,
+        environment: input.environment,
+        userId: input.userId
+      })
+
+      await this.jobRepo.markItemFinished(jobId, item.repositoryFullName, 'imported', {
+        message: 'Imported',
+        systemName: result.systemName,
+        manifestsFound: result.manifestsFound,
+        componentsAdded: result.componentsAdded,
+        componentsUpdated: result.componentsUpdated,
+        relationshipsCreated: result.relationshipsCreated
+      })
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Import failed'
+      await this.jobRepo.markItemFinished(jobId, item.repositoryFullName, 'failed', { message })
+      logger.warn({ err: error, jobId, repository: item.repositoryFullName }, 'GitHub repository import failed')
+    }
+  }
+
+  private async createAuditLog(jobId: string, input: GitHubOrgImportInput): Promise<void> {
+    const job = await this.jobRepo.findById(jobId)
+    if (!job) return
+
+    await this.auditRepo.create({
+      operation: 'IMPORT',
+      entityType: 'ImportJob',
+      entityId: job.id,
+      entityLabel: `GitHub owner ${job.organization}`,
+      changedFields: ['repositories', 'systems', 'sboms'],
+      source: 'GitHub Owner Import',
+      userId: input.userId,
+      realUserId: input.realUserId ?? null
+    })
+  }
+
+  private normalizeSelections(repositories?: GitHubRepositorySelection[]): GitHubRepositorySelection[] | undefined {
+    if (!repositories) return undefined
+    if (repositories.length === 0) {
+      throw createError({ statusCode: 400, message: 'At least one repository must be selected' })
+    }
+
+    const normalized = repositories
+      .map(repo => ({
+        repositoryFullName: typeof repo.repositoryFullName === 'string' ? repo.repositoryFullName.trim() : '',
+        repositoryUrl: typeof repo.repositoryUrl === 'string' ? repo.repositoryUrl.trim() : ''
+      }))
+      .filter(repo => repo.repositoryFullName && repo.repositoryUrl)
+
+    if (normalized.length === 0) {
+      throw createError({ statusCode: 400, message: 'At least one repository must be selected' })
+    }
+
+    return normalized
+  }
+}

--- a/server/services/github-org-import.service.ts
+++ b/server/services/github-org-import.service.ts
@@ -196,10 +196,17 @@ export class GitHubOrgImportService {
       }))
       .filter(repo => repo.repositoryFullName && repo.repositoryUrl)
 
-    if (normalized.length === 0) {
+    const unique = new Map<string, GitHubRepositorySelection>()
+    for (const repo of normalized) {
+      if (!unique.has(repo.repositoryFullName)) {
+        unique.set(repo.repositoryFullName, repo)
+      }
+    }
+
+    if (unique.size === 0) {
       throw createError({ statusCode: 400, message: 'At least one repository must be selected' })
     }
 
-    return normalized
+    return [...unique.values()]
   }
 }

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -11,6 +11,7 @@ export { TokenService } from './token.service'
 export { UserService } from './user.service'
 export { AuditLogService } from './audit-log.service'
 export { GitHubImportService } from './github-import.service'
+export { GitHubOrgImportService } from './github-org-import.service'
 export { EOLService } from './eol.service'
 export { EOLRollupService } from './eol-rollup.service'
 export { PackageMetadataService } from './package-metadata.service'
@@ -29,6 +30,7 @@ export {
   userService,
   auditLogService,
   gitHubImportService,
+  gitHubOrgImportService,
   eolService,
   eolRollupService,
   packageMetadataService,

--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -239,14 +239,18 @@ export class SBOMService {
 
     if (!rootName) return []
 
-    // Extract the name segment from a purl: pkg:<type>/<name>@<version> → <name>
+    // Extract the name segment from a purl: pkg:<type>/<name>@<version> -> <name>.
+    // Compare case-insensitively because npm package names are normalized to
+    // lowercase in some cdxgen dependency refs while metadata.component may
+    // preserve the package.json casing.
     const nameFromRef = (ref: string): string | null => {
       const m = ref.match(/^pkg:[^/]+\/([^@]+)@/)
-      return m?.[1] ?? null
+      return m?.[1] ? decodeURIComponent(m[1]).toLowerCase() : null
     }
+    const normalizedRootName = rootName.toLowerCase()
 
     const candidates = dependencies
-      .filter(d => nameFromRef(d.ref) === rootName && d.dependsOn.length > 0)
+      .filter(d => nameFromRef(d.ref) === normalizedRootName && d.dependsOn.length > 0)
       .sort((a, b) => b.dependsOn.length - a.dependsOn.length)
 
     return candidates[0]?.dependsOn ?? []

--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -243,9 +243,17 @@ export class SBOMService {
     // Compare case-insensitively because npm package names are normalized to
     // lowercase in some cdxgen dependency refs while metadata.component may
     // preserve the package.json casing.
+    const decodePurlName = (value: string): string => {
+      try {
+        return decodeURIComponent(value)
+      } catch {
+        return value
+      }
+    }
+
     const nameFromRef = (ref: string): string | null => {
       const m = ref.match(/^pkg:[^/]+\/([^@]+)@/)
-      return m?.[1] ? decodeURIComponent(m[1]).toLowerCase() : null
+      return m?.[1] ? decodePurlName(m[1]).toLowerCase() : null
     }
     const normalizedRootName = rootName.toLowerCase()
 

--- a/server/services/singletons.ts
+++ b/server/services/singletons.ts
@@ -23,6 +23,7 @@ import { SBOMService } from './sbom.service'
 import { SourceRepositoryService } from './source-repository.service'
 import { AuditLogService } from './audit-log.service'
 import { GitHubImportService } from './github-import.service'
+import { GitHubOrgImportService } from './github-org-import.service'
 import { EOLService } from './eol.service'
 import { EOLRollupService } from './eol-rollup.service'
 import { PackageMetadataService } from './package-metadata.service'
@@ -42,6 +43,7 @@ export const sbomService = new SBOMService()
 export const sourceRepositoryService = new SourceRepositoryService()
 export const auditLogService = new AuditLogService()
 export const gitHubImportService = new GitHubImportService()
+export const gitHubOrgImportService = new GitHubOrgImportService()
 export const eolService = new EOLService()
 export const eolRollupService = new EOLRollupService()
 export const packageMetadataService = new PackageMetadataService()

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -30,6 +30,38 @@ export interface GitHubFileContent {
   content: string
 }
 
+export interface GitHubOrgRepository {
+  name: string
+  full_name: string
+  html_url: string
+  description: string | null
+  default_branch: string
+  language: string | null
+  private: boolean
+  fork: boolean
+  archived: boolean
+  topics: string[]
+}
+
+export interface GitHubOrgRepositoryFilters {
+  language?: string
+  topic?: string
+  namePattern?: string
+}
+
+type GitHubRepositoryOwnerType = 'organization' | 'user'
+
+class GitHubApiError extends Error {
+  constructor(
+    public status: number,
+    public statusText: string,
+    message: string
+  ) {
+    super(message)
+    this.name = 'GitHubApiError'
+  }
+}
+
 /** Known dependency manifest and lockfile names */
 const MANIFEST_FILENAMES = new Set([
   // Node.js
@@ -95,6 +127,32 @@ export function parseGitHubRepo(input: string): { owner: string; repo: string } 
 }
 
 /**
+ * Parse a GitHub organization/user name or profile URL into an owner login.
+ */
+export function parseGitHubOwner(input: string): string {
+  const value = input.trim()
+  if (/^[A-Za-z0-9_.-]+$/.test(value)) {
+    return value
+  }
+
+  try {
+    const url = new URL(value)
+    if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
+      throw new Error('not github')
+    }
+
+    const segments = url.pathname.split('/').filter(Boolean)
+    if (segments.length === 1 && /^[A-Za-z0-9_.-]+$/.test(segments[0])) {
+      return segments[0]
+    }
+  } catch {
+    // Fall through to the common error below.
+  }
+
+  throw new Error(`Cannot parse GitHub owner from: ${input}`)
+}
+
+/**
  * Build GitHub API request headers.
  * Includes a Bearer token when GITHUB_TOKEN is set in the environment,
  * raising the rate limit from 60 to 5,000 requests/hour.
@@ -118,18 +176,62 @@ function githubHeaders(): Record<string, string> {
  */
 function throwGitHubError(status: number, statusText: string, context: string): never {
   if (status === 404) {
-    throw new Error(`${context} not found`)
+    throw new GitHubApiError(status, statusText, `${context} not found`)
   }
   if (status === 401) {
-    throw new Error(`GitHub API authentication failed for ${context} — check GITHUB_TOKEN`)
+    throw new GitHubApiError(status, statusText, `GitHub API authentication failed for ${context} — check GITHUB_TOKEN`)
   }
   if (status === 403) {
-    throw new Error(`GitHub API rate limit exceeded or access denied for ${context}`)
+    throw new GitHubApiError(status, statusText, `GitHub API rate limit exceeded or access denied for ${context}`)
   }
   if (status === 429) {
-    throw new Error(`GitHub API rate limit exceeded for ${context}`)
+    throw new GitHubApiError(status, statusText, `GitHub API rate limit exceeded for ${context}`)
   }
-  throw new Error(`GitHub API error ${status} ${statusText} for ${context}`)
+  throw new GitHubApiError(status, statusText, `GitHub API error ${status} ${statusText} for ${context}`)
+}
+
+function parseRateLimitReset(response: Response): number | null {
+  const retryAfter = response.headers.get('retry-after')
+  if (retryAfter) {
+    const seconds = Number.parseInt(retryAfter, 10)
+    if (Number.isFinite(seconds) && seconds > 0) return seconds * 1000
+  }
+
+  const remaining = response.headers.get('x-ratelimit-remaining')
+  const reset = response.headers.get('x-ratelimit-reset')
+  if (remaining === '0' && reset) {
+    const resetAt = Number.parseInt(reset, 10) * 1000
+    const delay = resetAt - Date.now()
+    if (Number.isFinite(delay) && delay > 0) return delay
+  }
+
+  return null
+}
+
+async function fetchGitHub(url: string, context: string): Promise<Response> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const response = await fetch(url, { headers: githubHeaders() })
+    if (response.ok) return response
+
+    const delay = parseRateLimitReset(response)
+    if ((response.status === 403 || response.status === 429) && delay && delay <= 60_000 && attempt === 0) {
+      logger.warn({ context, delay }, 'GitHub API rate limited, backing off before retry')
+      await new Promise(resolve => setTimeout(resolve, delay))
+      continue
+    }
+
+    throwGitHubError(response.status, response.statusText, context)
+  }
+
+  throw new Error(`GitHub API request failed for ${context}`)
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return error instanceof GitHubApiError && error.status === 404
+}
+
+function isGitHubApiError(error: unknown, status: number): boolean {
+  return error instanceof GitHubApiError && error.status === status
 }
 
 /**
@@ -137,11 +239,7 @@ function throwGitHubError(status: number, statusText: string, context: string): 
  */
 export async function fetchRepoMetadata(owner: string, repo: string): Promise<GitHubRepoMetadata> {
   const url = `https://api.github.com/repos/${owner}/${repo}`
-  const response = await fetch(url, { headers: githubHeaders() })
-
-  if (!response.ok) {
-    throwGitHubError(response.status, response.statusText, `repository ${owner}/${repo}`)
-  }
+  const response = await fetchGitHub(url, `repository ${owner}/${repo}`)
 
   return await response.json() as GitHubRepoMetadata
 }
@@ -151,10 +249,16 @@ export async function fetchRepoMetadata(owner: string, repo: string): Promise<Gi
  */
 export async function fetchFileTree(owner: string, repo: string, branch: string): Promise<GitHubTreeEntry[]> {
   const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${branch}?recursive=1`
-  const response = await fetch(url, { headers: githubHeaders() })
+  let response: Response
 
-  if (!response.ok) {
-    throwGitHubError(response.status, response.statusText, `file tree for ${owner}/${repo}@${branch}`)
+  try {
+    response = await fetchGitHub(url, `file tree for ${owner}/${repo}@${branch}`)
+  } catch (error: unknown) {
+    if (isGitHubApiError(error, 409)) {
+      logger.warn({ owner, repo, branch }, 'GitHub tree unavailable for repository ref; continuing without manifests')
+      return []
+    }
+    throw error
   }
 
   const data = await response.json() as { tree: GitHubTreeEntry[]; truncated: boolean }
@@ -174,11 +278,7 @@ export async function fetchFileTree(owner: string, repo: string, branch: string)
  */
 export async function fetchFileContent(owner: string, repo: string, path: string, branch: string): Promise<string> {
   const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`
-  const response = await fetch(url, { headers: githubHeaders() })
-
-  if (!response.ok) {
-    throwGitHubError(response.status, response.statusText, path)
-  }
+  const response = await fetchGitHub(url, path)
 
   const data = await response.json() as { content: string; encoding: string }
 
@@ -187,6 +287,95 @@ export async function fetchFileContent(owner: string, repo: string, path: string
   }
 
   return data.content
+}
+
+function compileNamePattern(pattern?: string): RegExp | null {
+  if (!pattern) return null
+  try {
+    return new RegExp(pattern, 'i')
+  } catch {
+    throw new Error('namePattern must be a valid regular expression')
+  }
+}
+
+function matchesOrgRepositoryFilters(
+  repo: GitHubOrgRepository,
+  filters: GitHubOrgRepositoryFilters = {},
+  nameRegex = compileNamePattern(filters.namePattern)
+): boolean {
+  if (filters.language && repo.language?.toLowerCase() !== filters.language.toLowerCase()) {
+    return false
+  }
+
+  if (filters.topic && !(repo.topics || []).some(topic => topic.toLowerCase() === filters.topic!.toLowerCase())) {
+    return false
+  }
+
+  if (nameRegex && !nameRegex.test(repo.name) && !nameRegex.test(repo.full_name)) {
+    return false
+  }
+
+  return true
+}
+
+async function listRepositoriesForOwner(
+  owner: string,
+  ownerType: GitHubRepositoryOwnerType,
+  filters: GitHubOrgRepositoryFilters = {}
+): Promise<GitHubOrgRepository[]> {
+  const nameRegex = compileNamePattern(filters.namePattern)
+  const repos: GitHubOrgRepository[] = []
+  const perPage = 100
+  const basePath = ownerType === 'organization'
+    ? `orgs/${encodeURIComponent(owner)}/repos?type=all`
+    : `users/${encodeURIComponent(owner)}/repos?type=owner`
+  const context = ownerType === 'organization'
+    ? `organization ${owner} repositories`
+    : `user ${owner} repositories`
+
+  for (let page = 1; ; page++) {
+    const url = `https://api.github.com/${basePath}&sort=full_name&per_page=${perPage}&page=${page}`
+    const response = await fetchGitHub(url, context)
+    const data = await response.json() as GitHubOrgRepository[]
+
+    repos.push(...data.filter(repo => matchesOrgRepositoryFilters(repo, filters, nameRegex)))
+
+    if (data.length < perPage) break
+  }
+
+  return repos
+}
+
+/**
+ * List repositories for a GitHub organization or user, following pagination.
+ * Organization listing is attempted first so authenticated tokens can include
+ * private organization repositories. If no organization exists, falls back to
+ * the public user repositories endpoint.
+ */
+export async function listGitHubOwnerRepositories(
+  ownerInput: string,
+  filters: GitHubOrgRepositoryFilters = {}
+): Promise<GitHubOrgRepository[]> {
+  const owner = parseGitHubOwner(ownerInput)
+
+  try {
+    return await listRepositoriesForOwner(owner, 'organization', filters)
+  } catch (error: unknown) {
+    if (!isNotFoundError(error)) throw error
+  }
+
+  return await listRepositoriesForOwner(owner, 'user', filters)
+}
+
+/**
+ * List repositories for a GitHub organisation, following REST API pagination.
+ */
+export async function listOrgRepositories(
+  organization: string,
+  filters: GitHubOrgRepositoryFilters = {}
+): Promise<GitHubOrgRepository[]> {
+  const org = parseGitHubOwner(organization)
+  return await listRepositoriesForOwner(org, 'organization', filters)
 }
 
 /**

--- a/test/server/repositories/import-job.repository.spec.ts
+++ b/test/server/repositories/import-job.repository.spec.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest'
+import { ImportJobRepository } from '../../../server/repositories/import-job.repository'
+import { getTestContext, cleanupTestData, type TestContext } from '../../fixtures/neo4j-test-helper'
+import type { Session } from 'neo4j-driver'
+
+const PREFIX = 'test_import_job_repo_'
+let ctx: TestContext
+let repo: ImportJobRepository
+let session: Session
+
+beforeAll(async () => { ctx = await getTestContext() })
+afterAll(async () => { if (ctx.neo4jAvailable) await cleanupTestData(ctx.driver, { prefix: PREFIX }) })
+
+beforeEach(async () => {
+  if (!ctx.neo4jAvailable) return
+  await cleanupTestData(ctx.driver, { prefix: PREFIX })
+  repo = new ImportJobRepository(ctx.driver)
+  session = ctx.driver.session()
+})
+
+afterEach(async () => { if (session) await session.close() })
+
+describe('ImportJobRepository', () => {
+  it('creates and finds an import job with parsed filters', async () => {
+    if (!ctx.neo4jAvailable) return
+
+    const job = await repo.create({
+      type: 'github-org',
+      requestedBy: `${PREFIX}user`,
+      organization: `${PREFIX}org`,
+      filters: { language: 'TypeScript', topic: 'platform', namePattern: '^service-' },
+      dryRun: false
+    })
+
+    expect(job.id).toBeTruthy()
+    expect(job.status).toBe('queued')
+    expect(job.organization).toBe(`${PREFIX}org`)
+    expect(job.filters).toEqual({ language: 'TypeScript', topic: 'platform', namePattern: '^service-' })
+    expect(job.total).toBe(0)
+    expect(job.items).toEqual([])
+
+    const found = await repo.findById(job.id)
+    expect(found).toMatchObject({
+      id: job.id,
+      status: 'queued',
+      requestedBy: `${PREFIX}user`,
+      organization: `${PREFIX}org`,
+      dryRun: false
+    })
+  })
+
+  it('returns null for unknown jobs', async () => {
+    if (!ctx.neo4jAvailable) return
+
+    await expect(repo.findById(`${PREFIX}missing`)).resolves.toBeNull()
+  })
+
+  it('creates items and tracks item progress counters', async () => {
+    if (!ctx.neo4jAvailable) return
+
+    const job = await repo.create({
+      type: 'github-org',
+      requestedBy: `${PREFIX}user`,
+      organization: `${PREFIX}org`,
+      filters: {},
+      dryRun: true
+    })
+
+    await repo.markRunning(job.id)
+    await repo.createItems(job.id, [
+      { repositoryFullName: `${PREFIX}org/repo-a`, repositoryUrl: `https://github.com/${PREFIX}org/repo-a` },
+      { repositoryFullName: `${PREFIX}org/repo-b`, repositoryUrl: `https://github.com/${PREFIX}org/repo-b` }
+    ])
+    await repo.markItemRunning(job.id, `${PREFIX}org/repo-a`)
+    await repo.markItemFinished(job.id, `${PREFIX}org/repo-a`, 'imported', {
+      message: 'Imported',
+      systemName: `${PREFIX}repo-a`,
+      manifestsFound: 2,
+      componentsAdded: 3,
+      componentsUpdated: 4,
+      relationshipsCreated: 5
+    })
+    await repo.markItemFinished(job.id, `${PREFIX}org/repo-b`, 'failed', {
+      message: 'Import failed'
+    })
+    await repo.markCompleted(job.id)
+
+    const found = await repo.findById(job.id)
+    expect(found).toMatchObject({
+      id: job.id,
+      status: 'completed',
+      dryRun: true,
+      total: 2,
+      completed: 2,
+      failed: 1,
+      skipped: 0
+    })
+    expect(found?.startedAt).not.toBeNull()
+    expect(found?.finishedAt).not.toBeNull()
+    expect(found?.items).toHaveLength(2)
+    expect(found?.items[0]).toMatchObject({
+      repositoryFullName: `${PREFIX}org/repo-a`,
+      status: 'imported',
+      message: 'Imported',
+      systemName: `${PREFIX}repo-a`,
+      manifestsFound: 2,
+      componentsAdded: 3,
+      componentsUpdated: 4,
+      relationshipsCreated: 5
+    })
+    expect(found?.items[1]).toMatchObject({
+      repositoryFullName: `${PREFIX}org/repo-b`,
+      status: 'failed',
+      message: 'Import failed'
+    })
+  })
+
+  it('handles empty item lists and failed jobs', async () => {
+    if (!ctx.neo4jAvailable) return
+
+    const job = await repo.create({
+      type: 'github-org',
+      requestedBy: `${PREFIX}user`,
+      organization: `${PREFIX}empty-org`,
+      filters: {},
+      dryRun: false
+    })
+
+    await repo.createItems(job.id, [])
+    await repo.markFailed(job.id, 'Owner import failed')
+
+    const found = await repo.findById(job.id)
+    expect(found).toMatchObject({
+      id: job.id,
+      status: 'failed',
+      total: 0,
+      error: 'Owner import failed',
+      items: []
+    })
+    expect(found?.finishedAt).not.toBeNull()
+  })
+})

--- a/test/server/services/github-org-import.service.spec.ts
+++ b/test/server/services/github-org-import.service.spec.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { GitHubOrgImportService } from '../../../server/services/github-org-import.service'
+import { listGitHubOwnerRepositories } from '../../../server/utils/github'
+import type { ImportJob } from '../../../server/repositories/import-job.repository'
+
+vi.mock('../../../server/utils/github', () => ({
+  listGitHubOwnerRepositories: vi.fn(),
+  parseGitHubOwner: vi.fn((value: string) => value.replace(/^https:\/\/github\.com\//, ''))
+}))
+
+const baseJob: ImportJob = {
+  id: 'job-1',
+  type: 'github-org',
+  status: 'queued',
+  requestedBy: 'user-1',
+  organization: 'acme',
+  filters: {},
+  dryRun: false,
+  total: 0,
+  completed: 0,
+  failed: 0,
+  skipped: 0,
+  createdAt: '2026-06-18',
+  startedAt: null,
+  finishedAt: null,
+  error: null,
+  items: []
+}
+
+function createRepoMocks() {
+  return {
+    create: vi.fn().mockResolvedValue(baseJob),
+    findById: vi.fn().mockResolvedValue({ ...baseJob, status: 'completed' }),
+    markRunning: vi.fn().mockResolvedValue(undefined),
+    markCompleted: vi.fn().mockResolvedValue(undefined),
+    markFailed: vi.fn().mockResolvedValue(undefined),
+    createItems: vi.fn().mockResolvedValue(undefined),
+    markItemRunning: vi.fn().mockResolvedValue(undefined),
+    markItemFinished: vi.fn().mockResolvedValue(undefined)
+  }
+}
+
+describe('GitHubOrgImportService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('creates a job and starts background processing', async () => {
+    const repo = createRepoMocks()
+    const service = new GitHubOrgImportService(
+      repo as never,
+      { import: vi.fn() } as never,
+      { create: vi.fn() } as never
+    )
+    const processSpy = vi.spyOn(service, 'process').mockResolvedValue(undefined)
+
+    const job = await service.start({
+      organization: 'acme',
+      ownerTeam: 'Platform',
+      userId: 'user-1'
+    })
+
+    expect(job.id).toBe('job-1')
+    expect(repo.create).toHaveBeenCalledWith({
+      type: 'github-org',
+      requestedBy: 'user-1',
+      organization: 'acme',
+      filters: {},
+      dryRun: false
+    })
+    expect(processSpy).toHaveBeenCalledWith('job-1', expect.objectContaining({ organization: 'acme' }))
+  })
+
+  it('marks dry-run repositories as skipped and completes the job', async () => {
+    const repo = createRepoMocks()
+    vi.mocked(listGitHubOwnerRepositories).mockResolvedValue([
+      {
+        name: 'repo-a',
+        full_name: 'acme/repo-a',
+        html_url: 'https://github.com/acme/repo-a',
+        description: null,
+        default_branch: 'main',
+        language: 'TypeScript',
+        private: false,
+        fork: false,
+        archived: false,
+        topics: []
+      }
+    ])
+
+    const service = new GitHubOrgImportService(
+      repo as never,
+      { import: vi.fn() } as never,
+      { create: vi.fn() } as never
+    )
+
+    await service.process('job-1', {
+      organization: 'acme',
+      ownerTeam: 'Platform',
+      dryRun: true,
+      userId: 'user-1'
+    })
+
+    expect(repo.markRunning).toHaveBeenCalledWith('job-1')
+    expect(repo.createItems).toHaveBeenCalledWith('job-1', [
+      { repositoryFullName: 'acme/repo-a', repositoryUrl: 'https://github.com/acme/repo-a' }
+    ])
+    expect(repo.markItemFinished).toHaveBeenCalledWith('job-1', 'acme/repo-a', 'skipped', {
+      message: 'Dry run only'
+    })
+    expect(repo.markCompleted).toHaveBeenCalledWith('job-1')
+  })
+
+  it('previews repositories for an owner without creating a job', async () => {
+    const repo = createRepoMocks()
+    vi.mocked(listGitHubOwnerRepositories).mockResolvedValue([
+      {
+        name: 'repo-a',
+        full_name: 'acme/repo-a',
+        html_url: 'https://github.com/acme/repo-a',
+        description: null,
+        default_branch: 'main',
+        language: 'TypeScript',
+        private: false,
+        fork: false,
+        archived: false,
+        topics: []
+      }
+    ])
+
+    const service = new GitHubOrgImportService(
+      repo as never,
+      { import: vi.fn() } as never,
+      { create: vi.fn() } as never
+    )
+
+    const result = await service.previewRepositories('https://github.com/acme', { language: 'TypeScript' })
+
+    expect(result).toHaveLength(1)
+    expect(listGitHubOwnerRepositories).toHaveBeenCalledWith('acme', { language: 'TypeScript' })
+    expect(repo.create).not.toHaveBeenCalled()
+  })
+
+  it('imports only selected repositories when provided', async () => {
+    const repo = createRepoMocks()
+    const importService = {
+      import: vi.fn().mockResolvedValue({
+        systemName: 'repo-a',
+        repositoryUrl: 'https://github.com/acme/repo-a',
+        description: null,
+        defaultBranch: 'main',
+        language: 'TypeScript',
+        manifestsFound: 1,
+        componentsAdded: 2,
+        componentsUpdated: 0,
+        relationshipsCreated: 1
+      })
+    }
+
+    const service = new GitHubOrgImportService(
+      repo as never,
+      importService as never,
+      { create: vi.fn() } as never
+    )
+
+    await service.process('job-1', {
+      organization: 'acme',
+      ownerTeam: 'Platform',
+      userId: 'user-1',
+      repositories: [
+        { repositoryFullName: 'acme/repo-a', repositoryUrl: 'https://github.com/acme/repo-a' }
+      ]
+    })
+
+    expect(listGitHubOwnerRepositories).not.toHaveBeenCalled()
+    expect(repo.createItems).toHaveBeenCalledWith('job-1', [
+      { repositoryFullName: 'acme/repo-a', repositoryUrl: 'https://github.com/acme/repo-a' }
+    ])
+    expect(importService.import).toHaveBeenCalledTimes(1)
+    expect(importService.import).toHaveBeenCalledWith(expect.objectContaining({
+      repositoryUrl: 'https://github.com/acme/repo-a'
+    }))
+  })
+
+  it('continues importing after a per-repository failure', async () => {
+    const repo = createRepoMocks()
+    const importService = {
+      import: vi.fn()
+        .mockRejectedValueOnce(new Error('repo failed'))
+        .mockResolvedValueOnce({
+          systemName: 'repo-b',
+          repositoryUrl: 'https://github.com/acme/repo-b',
+          description: null,
+          defaultBranch: 'main',
+          language: 'TypeScript',
+          manifestsFound: 2,
+          componentsAdded: 3,
+          componentsUpdated: 4,
+          relationshipsCreated: 5
+        })
+    }
+    vi.mocked(listGitHubOwnerRepositories).mockResolvedValue([
+      {
+        name: 'repo-a',
+        full_name: 'acme/repo-a',
+        html_url: 'https://github.com/acme/repo-a',
+        description: null,
+        default_branch: 'main',
+        language: 'TypeScript',
+        private: false,
+        fork: false,
+        archived: false,
+        topics: []
+      },
+      {
+        name: 'repo-b',
+        full_name: 'acme/repo-b',
+        html_url: 'https://github.com/acme/repo-b',
+        description: null,
+        default_branch: 'main',
+        language: 'TypeScript',
+        private: false,
+        fork: false,
+        archived: false,
+        topics: []
+      }
+    ])
+
+    const service = new GitHubOrgImportService(
+      repo as never,
+      importService as never,
+      { create: vi.fn() } as never
+    )
+
+    await service.process('job-1', {
+      organization: 'acme',
+      ownerTeam: 'Platform',
+      userId: 'user-1'
+    })
+
+    expect(importService.import).toHaveBeenCalledTimes(2)
+    expect(repo.markItemFinished).toHaveBeenCalledWith('job-1', 'acme/repo-a', 'failed', {
+      message: 'repo failed'
+    })
+    expect(repo.markItemFinished).toHaveBeenCalledWith('job-1', 'acme/repo-b', 'imported', expect.objectContaining({
+      systemName: 'repo-b',
+      manifestsFound: 2,
+      componentsAdded: 3
+    }))
+    expect(repo.markCompleted).toHaveBeenCalledWith('job-1')
+  })
+})

--- a/test/server/services/github-org-import.service.spec.ts
+++ b/test/server/services/github-org-import.service.spec.ts
@@ -182,6 +182,32 @@ describe('GitHubOrgImportService', () => {
     }))
   })
 
+  it('deduplicates selected repositories by full name before processing', async () => {
+    const repo = createRepoMocks()
+    const service = new GitHubOrgImportService(
+      repo as never,
+      { import: vi.fn() } as never,
+      { create: vi.fn() } as never
+    )
+    const processSpy = vi.spyOn(service, 'process').mockResolvedValue(undefined)
+
+    await service.start({
+      organization: 'acme',
+      ownerTeam: 'Platform',
+      userId: 'user-1',
+      repositories: [
+        { repositoryFullName: 'acme/repo-a', repositoryUrl: 'https://github.com/acme/repo-a' },
+        { repositoryFullName: 'acme/repo-a', repositoryUrl: 'https://github.com/acme/repo-a' }
+      ]
+    })
+
+    expect(processSpy).toHaveBeenCalledWith('job-1', expect.objectContaining({
+      repositories: [
+        { repositoryFullName: 'acme/repo-a', repositoryUrl: 'https://github.com/acme/repo-a' }
+      ]
+    }))
+  })
+
   it('continues importing after a per-repository failure', async () => {
     const repo = createRepoMocks()
     const importService = {

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -506,6 +506,39 @@ describe('SBOMService', () => {
       expect(persistCall.componentUsage.get('pkg:npm/@slidev/cli@52.0.0')?.isDirect).not.toBe(true)
     })
 
+    it('should not throw when a dependency purl has a malformed encoded name segment', async () => {
+      const sbomWithMalformedPurlName = {
+        ...validCycloneDxSbom,
+        metadata: {
+          component: {
+            type: 'application',
+            name: 'bad%zzname',
+            version: '1.0.0',
+            'bom-ref': 'pkg:application/bad%zzname@1.0.0',
+          }
+        },
+        dependencies: [
+          { ref: 'pkg:application/bad%zzname@1.0.0', dependsOn: [] },
+          { ref: 'pkg:npm/bad%zzname@1.0.0', dependsOn: ['pkg:npm/lodash@4.17.21'] },
+          { ref: 'pkg:npm/lodash@4.17.21', dependsOn: [] },
+        ]
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1, componentsUpdated: 0, relationshipsCreated: 1
+      })
+
+      await service.processSBOM({
+        sbom: sbomWithMalformedPurlName,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.componentUsage.get('pkg:npm/lodash@4.17.21')).toMatchObject({ isDirect: true })
+    })
+
     it('should use exact match directDeps when root bom-ref matches a non-empty dependsOn entry', async () => {
       const sbomWithExactMatch = {
         ...validCycloneDxSbom,

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -459,6 +459,53 @@ describe('SBOMService', () => {
       expect(persistCall.componentUsage.get('pkg:npm/express@4.18.2')).toMatchObject({ isDirect: true })
     })
 
+    it('should resolve directDeps case-insensitively when cdxgen lowercases npm root package refs', async () => {
+      const sbomWithRootNameCasingMismatch = {
+        ...validCycloneDxSbom,
+        metadata: {
+          component: {
+            type: 'application',
+            name: 'AzureMap',
+            version: '1.0.0',
+            'bom-ref': 'pkg:application/AzureMap@1.0.0',
+          }
+        },
+        dependencies: [
+          { ref: 'pkg:application/AzureMap@1.0.0', dependsOn: [] },
+          { ref: 'pkg:npm/AzureMap@1.0.0', dependsOn: ['pkg:npm/@slidev/cli@52.0.0'] },
+          {
+            ref: 'pkg:npm/azuremap@1.0.0',
+            dependsOn: [
+              'pkg:npm/@actions/core@1.11.1',
+              'pkg:npm/@azure/identity@4.10.2',
+              'pkg:npm/commander@14.0.0'
+            ]
+          },
+          { ref: 'pkg:npm/@slidev/cli@52.0.0', dependsOn: [] },
+          { ref: 'pkg:npm/@actions/core@1.11.1', dependsOn: [] },
+          { ref: 'pkg:npm/@azure/identity@4.10.2', dependsOn: [] },
+          { ref: 'pkg:npm/commander@14.0.0', dependsOn: [] },
+        ]
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 3, componentsUpdated: 0, relationshipsCreated: 3
+      })
+
+      await service.processSBOM({
+        sbom: sbomWithRootNameCasingMismatch,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.componentUsage.get('pkg:npm/@actions/core@1.11.1')).toMatchObject({ isDirect: true })
+      expect(persistCall.componentUsage.get('pkg:npm/@azure/identity@4.10.2')).toMatchObject({ isDirect: true })
+      expect(persistCall.componentUsage.get('pkg:npm/commander@14.0.0')).toMatchObject({ isDirect: true })
+      expect(persistCall.componentUsage.get('pkg:npm/@slidev/cli@52.0.0')?.isDirect).not.toBe(true)
+    })
+
     it('should use exact match directDeps when root bom-ref matches a non-empty dependsOn entry', async () => {
       const sbomWithExactMatch = {
         ...validCycloneDxSbom,

--- a/test/server/utils/github.spec.ts
+++ b/test/server/utils/github.spec.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { fetchManifestFiles, listGitHubOwnerRepositories, listOrgRepositories, parseGitHubOwner } from '../../../server/utils/github'
+
+const repo = (name: string, overrides: Record<string, unknown> = {}) => ({
+  name,
+  full_name: `acme/${name}`,
+  html_url: `https://github.com/acme/${name}`,
+  description: null,
+  default_branch: 'main',
+  language: 'TypeScript',
+  private: false,
+  fork: false,
+  archived: false,
+  topics: ['platform'],
+  ...overrides
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('GitHub utilities', () => {
+  describe('parseGitHubOwner()', () => {
+    it('accepts owner names and profile URLs', () => {
+      expect(parseGitHubOwner('localgod')).toBe('localgod')
+      expect(parseGitHubOwner('https://github.com/localgod')).toBe('localgod')
+      expect(parseGitHubOwner('https://www.github.com/localgod/')).toBe('localgod')
+    })
+
+    it('rejects repository URLs for owner imports', () => {
+      expect(() => parseGitHubOwner('https://github.com/localgod/polaris')).toThrow('Cannot parse')
+    })
+  })
+
+  describe('listOrgRepositories()', () => {
+    it('follows pagination and applies filters', async () => {
+      const firstPage = [
+        ...Array.from({ length: 99 }, (_, index) => repo(`service-${index}`)),
+        repo('python-service', { language: 'Python' })
+      ]
+      const secondPage = [repo('service-final', { topics: ['platform', 'catalog'] })]
+
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify(firstPage), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify(secondPage), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await listOrgRepositories('acme', {
+        language: 'TypeScript',
+        topic: 'platform',
+        namePattern: '^service-'
+      })
+
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(result).toHaveLength(100)
+      expect(result.some(item => item.name === 'python-service')).toBe(false)
+      expect(result.at(-1)?.full_name).toBe('acme/service-final')
+    })
+
+    it('rejects invalid organization names', async () => {
+      await expect(listOrgRepositories('bad/org')).rejects.toThrow('Cannot parse')
+    })
+
+    it('rejects invalid name regex filters', async () => {
+      await expect(listOrgRepositories('acme', { namePattern: '[' })).rejects.toThrow('namePattern')
+    })
+  })
+
+  describe('listGitHubOwnerRepositories()', () => {
+    it('falls back to user repositories when the owner is not an organization', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Not Found' }), { status: 404, statusText: 'Not Found' }))
+        .mockResolvedValueOnce(new Response(JSON.stringify([repo('polaris', { full_name: 'localgod/polaris', html_url: 'https://github.com/localgod/polaris' })]), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await listGitHubOwnerRepositories('https://github.com/localgod')
+
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining('/orgs/localgod/repos?type=all'),
+        expect.any(Object)
+      )
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('/users/localgod/repos?type=owner'),
+        expect.any(Object)
+      )
+      expect(result).toHaveLength(1)
+      expect(result[0].full_name).toBe('localgod/polaris')
+    })
+  })
+
+  describe('fetchManifestFiles()', () => {
+    it('treats a 409 tree response as no manifests', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Git Repository is empty.' }), {
+          status: 409,
+          statusText: 'Conflict'
+        }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchManifestFiles('VisualPHPUnit', 'visualphpunit.github.io', 'master')
+
+      expect(result).toEqual([])
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/repos/VisualPHPUnit/visualphpunit.github.io/git/trees/master?recursive=1'),
+        expect.any(Object)
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description

Adds a GitHub owner import flow that fetches repositories for an owner or profile URL, lets the user select repositories to import, and tracks the import as a Neo4j-backed job. Also fixes GitHub import edge cases for unavailable repository trees and SBOM direct dependency resolution when cdxgen emits root package refs with different casing.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Fixes #560

## Changes Made

- Added owner repository preview, selected repository import, Neo4j import job persistence, job polling, and schema migrations.
- Simplified the import UI to owner-first fetch/select/import and removed import-time metadata and dry-run controls.
- Handled GitHub tree `409 Conflict` responses as unavailable manifests so repository imports can continue.
- Fixed CycloneDX root direct-dependency resolution when cdxgen lowercases npm root package refs.
- Added regression coverage for owner parsing/listing, import jobs, GitHub tree 409 handling, and SBOM direct dependency resolution.

## Screenshots

Not applicable.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

Verification run:

- `npx vitest run test/server/utils/github.spec.ts test/server/services/github-org-import.service.spec.ts test/server/services/sbom.service.spec.ts`
- `npm run lint`
- `npm run mdlint`
- `npm run build`
