### PR TITLE
Fix component migration retry handling

### DIFF
--- a/schema/migrations/common/2025-10-16_100000_create_tech_catalog_schema.up.cypher
+++ b/schema/migrations/common/2025-10-16_100000_create_tech_catalog_schema.up.cypher
@@ -80,10 +80,9 @@ ON (v.releaseDate);
 // COMPONENT NODE
 // ============================================================================
 
-// Composite unique constraint on name, version, and packageManager
-CREATE CONSTRAINT component_name_version_pm_unique IF NOT EXISTS
-FOR (c:Component)
-REQUIRE (c.name, c.version, c.packageManager) IS UNIQUE;
+// Component identity is enforced by purl in the SBOM schema migration.
+// name + version + packageManager is not unique for scoped npm packages because
+// some tools expose the unscoped package name in the name field.
 
 // Index on packageManager for filtering by ecosystem
 CREATE INDEX component_package_manager IF NOT EXISTS

--- a/schema/migrations/common/20251102_180000_enhance_component_for_sbom.up.cypher
+++ b/schema/migrations/common/20251102_180000_enhance_component_for_sbom.up.cypher
@@ -47,11 +47,9 @@ CREATE CONSTRAINT component_purl_unique IF NOT EXISTS
 FOR (c:Component)
 REQUIRE c.purl IS UNIQUE;
 
-// Fallback constraint for components without purl (legacy/internal)
-// Composite: name + version + packageManager
-CREATE CONSTRAINT component_name_version_pm_unique IF NOT EXISTS
-FOR (c:Component)
-REQUIRE (c.name, c.version, c.packageManager) IS UNIQUE;
+// Do not recreate the old name + version + packageManager uniqueness
+// constraint. It is not unique for scoped npm packages when the name field is
+// unscoped; purl is the canonical identity.
 
 // ============================================================================
 // CREATE NEW INDEXES
@@ -172,14 +170,3 @@ ON (v.cvssScore);
 CREATE INDEX vulnerability_published_date IF NOT EXISTS
 FOR (v:Vulnerability)
 ON (v.publishedDate);
-
-// ============================================================================
-// MIGRATION TRACKING
-// ============================================================================
-
-CREATE (m:Migration {
-  version: '20251102_180000',
-  name: 'enhance_component_for_sbom',
-  appliedAt: datetime(),
-  description: 'Enhanced Component schema for full SBOM support (SPDX and CycloneDX)'
-});

--- a/schema/migrations/common/20251201_071900_remove_vulnerability_from_sbom_migration.up.cypher
+++ b/schema/migrations/common/20251201_071900_remove_vulnerability_from_sbom_migration.up.cypher
@@ -43,15 +43,3 @@
 // - INDEX vulnerability_cvss_score
 // - INDEX vulnerability_published_date
 // - All Vulnerability nodes and relationships
-
-// ============================================================================
-// MIGRATION TRACKING
-// ============================================================================
-
-CREATE (m:Migration {
-  version: '20251201_071900',
-  name: 'remove_vulnerability_from_sbom_migration',
-  appliedAt: datetime(),
-  description: 'Consolidates vulnerability schema removal (no-op, already removed by 20251125_074808)',
-  references: 'ADR-0003: Exclude CVE and Vulnerability Management'
-});

--- a/schema/scripts/migrationRunner.ts
+++ b/schema/scripts/migrationRunner.ts
@@ -108,6 +108,19 @@ export class MigrationRunner {
   }
 
   /**
+   * Check whether a migration has already been applied successfully.
+   */
+  async hasSuccessfulMigration(session: Session, filename: string): Promise<boolean> {
+    const result = await session.run(
+      'MATCH (m:Migration {filename: $filename, status: "SUCCESS"}) RETURN count(m) AS count',
+      { filename }
+    )
+
+    const count = result.records[0]?.get('count')
+    return typeof count?.toNumber === 'function' ? count.toNumber() > 0 : count > 0
+  }
+
+  /**
    * Parse migration metadata from file header
    */
   parseMigrationMetadata(content: string, filename: string): Partial<MigrationMetadata> {
@@ -254,15 +267,21 @@ export class MigrationRunner {
       const executionTime = Date.now() - startTime
       const errorMessage = error instanceof Error ? error.message : String(error)
 
-      // Record failed migration
-      await this.recordMigration(session, {
-        filename,
-        version: metadata.version || 'unknown',
-        checksum,
-        executionTime,
-        status: 'FAILED',
-        description: `FAILED: ${errorMessage}`
-      })
+      const alreadySucceeded = await this.hasSuccessfulMigration(session, filename)
+
+      if (!alreadySucceeded) {
+        // Record failed migration attempts only for migrations that have not
+        // already succeeded. A modified applied migration must keep its
+        // SUCCESS row so checksum validation remains protective.
+        await this.recordMigration(session, {
+          filename,
+          version: metadata.version || 'unknown',
+          checksum,
+          executionTime,
+          status: 'FAILED',
+          description: `FAILED: ${errorMessage}`
+        })
+      }
 
       if (options.verbose) {
         console.error(`❌ Failed migration: ${filename}`)

--- a/schema/scripts/migrationRunner.ts
+++ b/schema/scripts/migrationRunner.ts
@@ -1,4 +1,4 @@
-import type { Driver, Session } from 'neo4j-driver'
+import type { Driver, ManagedTransaction, Session } from 'neo4j-driver'
 import { createHash } from 'crypto'
 import { readFileSync, readdirSync, existsSync } from 'fs'
 import { join, resolve } from 'path'
@@ -49,7 +49,11 @@ export class MigrationRunner {
    * Get list of pending migrations from filesystem
    */
   getPendingMigrations(applied: MigrationMetadata[], environment: string = 'common'): string[] {
-    const appliedFiles = new Set(applied.map(m => m.filename))
+    const appliedFiles = new Set(
+      applied
+        .filter(m => m.status === 'SUCCESS')
+        .map(m => m.filename)
+    )
     const dirs = [join(this.migrationsDir, 'common')]
     
     if (environment !== 'common') {
@@ -88,7 +92,7 @@ export class MigrationRunner {
   ): Promise<void> {
     const checksum = this.calculateChecksum(content)
     const result = await session.run(
-      'MATCH (m:Migration {filename: $filename}) RETURN m.checksum AS stored',
+      'MATCH (m:Migration {filename: $filename, status: "SUCCESS"}) RETURN m.checksum AS stored',
       { filename }
     )
 
@@ -148,16 +152,14 @@ export class MigrationRunner {
   ): Promise<void> {
     await sessionOrTx.run(
       `
-      CREATE (m:Migration {
-        filename: $filename,
-        version: $version,
-        checksum: $checksum,
-        appliedAt: datetime(),
-        appliedBy: $appliedBy,
-        executionTime: $executionTime,
-        status: $status,
-        description: $description
-      })
+      MERGE (m:Migration {filename: $filename})
+      SET m.version = $version,
+          m.checksum = $checksum,
+          m.appliedAt = datetime(),
+          m.appliedBy = $appliedBy,
+          m.executionTime = $executionTime,
+          m.status = $status,
+          m.description = $description
       `,
       {
         filename: metadata.filename,

--- a/test/schema/migrations/migration-runner.feature
+++ b/test/schema/migrations/migration-runner.feature
@@ -52,6 +52,13 @@ Feature: Database Migration Runner
     And an error message should be recorded
     And the migration status should be "FAILED"
 
+  Scenario: Retry a failed migration after fixing it
+    Given a migration file failed previously
+    When I fix and retry the migration
+    Then the migration should succeed
+    And the migration status should be "SUCCESS"
+    And the failed migration should not be pending
+
   Scenario: Apply multiple migrations in order
     Given three migration files exist in sequence
     When I run all pending migrations

--- a/test/schema/migrations/migration-runner.feature
+++ b/test/schema/migrations/migration-runner.feature
@@ -59,6 +59,13 @@ Feature: Database Migration Runner
     And the migration status should be "SUCCESS"
     And the failed migration should not be pending
 
+  Scenario: Preserve successful migration when modified file is retried
+    Given a migration has already succeeded
+    When I modify and retry the migration
+    Then the retry should fail checksum validation
+    And the successful migration status should be preserved
+    And the successful migration should not be pending
+
   Scenario: Apply multiple migrations in order
     Given three migration files exist in sequence
     When I run all pending migrations

--- a/test/schema/migrations/migration-runner.spec.ts
+++ b/test/schema/migrations/migration-runner.spec.ts
@@ -282,6 +282,66 @@ INVALID CYPHER SYNTAX`
     })
   })
 
+  Scenario('Retry a failed migration after fixing it', ({ Given, When, Then, And }) => {
+    Given('a migration file failed previously', async () => {
+      migrationFile = join(testMigrationsDir, 'common', '2025-10-15_120008_retry.up.cypher')
+      const invalidContent = `/*
+ * Migration: Retry Migration
+ * Version: 2025.10.15.120008
+ */
+INVALID CYPHER SYNTAX`
+      writeFileSync(migrationFile, invalidContent)
+
+      const session = driver.session()
+      try {
+        applyResult = await runner.applyMigration(session, migrationFile, { verbose: false })
+      } finally {
+        await session.close()
+      }
+
+      expect(applyResult.success).toBe(false)
+    })
+
+    When('I fix and retry the migration', async () => {
+      const validContent = `/*
+ * Migration: Retry Migration
+ * Version: 2025.10.15.120008
+ */
+CREATE (n:TestNode {name: 'retry'})`
+      writeFileSync(migrationFile, validContent)
+
+      const session = driver.session()
+      try {
+        applyResult = await runner.applyMigration(session, migrationFile, { verbose: false })
+      } finally {
+        await session.close()
+      }
+    })
+
+    Then('the migration should succeed', () => {
+      expect(applyResult.success).toBe(true)
+    })
+
+    And('the migration status should be "SUCCESS"', async () => {
+      const session = driver.session()
+      try {
+        const result = await session.run(
+          'MATCH (m:Migration {filename: $filename}) RETURN m.status AS status, count(m) AS count',
+          { filename: migrationFile }
+        )
+        expect(result.records[0].get('status')).toBe('SUCCESS')
+        expect(result.records[0].get('count').toNumber()).toBe(1)
+      } finally {
+        await session.close()
+      }
+    })
+
+    And('the failed migration should not be pending', async () => {
+      status = await runner.getStatus()
+      expect(status.pending).not.toContain(migrationFile)
+    })
+  })
+
   Scenario('Apply multiple migrations in order', ({ Given, When, Then, And }) => {
     let runResult: { success: boolean; applied: string[]; failed: string[] }
 

--- a/test/schema/migrations/migration-runner.spec.ts
+++ b/test/schema/migrations/migration-runner.spec.ts
@@ -342,6 +342,67 @@ CREATE (n:TestNode {name: 'retry'})`
     })
   })
 
+  Scenario('Preserve successful migration when modified file is retried', ({ Given, When, Then, And }) => {
+    Given('a migration has already succeeded', async () => {
+      migrationFile = join(testMigrationsDir, 'common', '2025-10-15_120009_preserve_success.up.cypher')
+      const content = `/*
+ * Migration: Preserve Success Migration
+ * Version: 2025.10.15.120009
+ */
+CREATE (n:TestNode {name: 'preserve-success'})`
+      writeFileSync(migrationFile, content)
+
+      const session = driver.session()
+      try {
+        applyResult = await runner.applyMigration(session, migrationFile, { verbose: false })
+      } finally {
+        await session.close()
+      }
+
+      expect(applyResult.success).toBe(true)
+    })
+
+    When('I modify and retry the migration', async () => {
+      const modifiedContent = `/*
+ * Migration: Preserve Success Migration
+ * Version: 2025.10.15.120009
+ */
+CREATE (n:TestNode {name: 'preserve-success-modified'})`
+      writeFileSync(migrationFile, modifiedContent)
+
+      const session = driver.session()
+      try {
+        applyResult = await runner.applyMigration(session, migrationFile, { verbose: false })
+      } finally {
+        await session.close()
+      }
+    })
+
+    Then('the retry should fail checksum validation', () => {
+      expect(applyResult.success).toBe(false)
+      expect(applyResult.error).toContain('has been modified after application')
+    })
+
+    And('the successful migration status should be preserved', async () => {
+      const session = driver.session()
+      try {
+        const result = await session.run(
+          'MATCH (m:Migration {filename: $filename}) RETURN m.status AS status, count(m) AS count',
+          { filename: migrationFile }
+        )
+        expect(result.records[0].get('status')).toBe('SUCCESS')
+        expect(result.records[0].get('count').toNumber()).toBe(1)
+      } finally {
+        await session.close()
+      }
+    })
+
+    And('the successful migration should not be pending', async () => {
+      status = await runner.getStatus()
+      expect(status.pending).not.toContain(migrationFile)
+    })
+  })
+
   Scenario('Apply multiple migrations in order', ({ Given, When, Then, And }) => {
     let runResult: { success: boolean; applied: string[]; failed: string[] }
 


### PR DESCRIPTION
## Description

Fixes database migrations so existing distinct scoped npm components do not fail the historical `Component(name, version, packageManager)` uniqueness constraint, and makes failed migrations retryable after their files are corrected.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made

<!-- List the specific changes you made -->

- Removed the obsolete component `name/version/packageManager` uniqueness constraint from historical migrations so `purl` remains the canonical component identity.
- Removed manual `Migration` node creation from migrations that are already recorded by the migration runner.
- Updated the migration runner to retry failed migrations and update the existing tracking row on success or failure.
- Added a regression scenario covering retry after a failed migration is fixed.

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

Not applicable.

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed

## Additional Notes

Validation performed:

- `NEO4J_TEST_URI=bolt://localhost:17687 NEO4J_URI=bolt://localhost:17687 npm run test:schema -- test/schema/migrations/migration-runner.spec.ts`
- `gitpod automations task start run-migrations`
- `npm run migrate:status`
- `npm run migrate:up`
- `npm run lint`
- `npm run mdlint`

The focused migration-runner spec was run against a temporary Neo4j container on alternate ports so the workspace database migration history was not modified by the test cleanup hooks.