### PR TITLE
Improve frontpage performance

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -6,3 +6,11 @@
     </NuxtLayout>
   </UApp>
 </template>
+
+<script setup lang="ts">
+useHead({
+  htmlAttrs: {
+    lang: 'en'
+  }
+})
+</script>

--- a/app/pages/components/[key].vue
+++ b/app/pages/components/[key].vue
@@ -622,7 +622,7 @@
               </div>
             </template>
 
-            <ComponentDependencyTree
+            <AsyncComponentDependencyTree
               :component-key="route.params.key as string"
               :system-name="activeDependencySystem"
             />
@@ -634,10 +634,13 @@
 </template>
 
 <script setup lang="ts">
+import { defineAsyncComponent } from 'vue'
 import type { ComponentDetail, EOLStatusValue, ComponentSystemUsage, KnownVulnerability, MaintenanceHealthConfidence, MaintenanceHealthReasonCode, MaintenanceHealthStatus, PackageMetadataSource, PackageMetadataStatus, SecurityScorecardStatus, VulnerabilityStatus } from '~~/types/api'
 
 const route = useRoute()
 const router = useRouter()
+
+const AsyncComponentDependencyTree = defineAsyncComponent(() => import('../../components/ComponentDependencyTree.vue'))
 
 type DependencyView = 'global' | 'system'
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -195,17 +195,29 @@ interface EOLRollupApiResponse {
   count: number
 }
 
-const { data: techData } = await useFetch<ApiResponse<Technology>>('/api/technologies')
-const { data: sysData } = await useFetch<ApiResponse<System>>('/api/systems')
-const { data: compData } = await useFetch<ApiResponse<GroupedComponent>>('/api/components/grouped', {
-  query: { direct: 'true' }
-})
-const { data: vcData } = await useFetch<ApiResponse<VersionConstraint>>('/api/version-constraints')
-const { data: licenseStatsData } = await useFetch<LicenseStatsResponse>('/api/licenses/statistics')
-const { data: licenseViolationsData } = await useFetch<LicenseViolationsResponse>('/api/licenses/violations')
-const { data: vcViolationsData } = await useFetch<ViolationsResponse>('/api/version-constraints/violations')
-const { data: eolApproachingData } = await useFetch<EOLRollupApiResponse>('/api/eol/approaching')
-const { data: eolExpiredData } = await useFetch<EOLRollupApiResponse>('/api/eol/expired')
+const [
+  { data: techData },
+  { data: sysData },
+  { data: compData },
+  { data: vcData },
+  { data: licenseStatsData },
+  { data: licenseViolationsData },
+  { data: vcViolationsData },
+  { data: eolApproachingData },
+  { data: eolExpiredData }
+] = await Promise.all([
+  useFetch<ApiResponse<Technology>>('/api/technologies'),
+  useFetch<ApiResponse<System>>('/api/systems'),
+  useFetch<ApiResponse<GroupedComponent>>('/api/components/grouped', {
+    query: { direct: 'true' }
+  }),
+  useFetch<ApiResponse<VersionConstraint>>('/api/version-constraints'),
+  useFetch<LicenseStatsResponse>('/api/licenses/statistics'),
+  useFetch<LicenseViolationsResponse>('/api/licenses/violations'),
+  useFetch<ViolationsResponse>('/api/version-constraints/violations'),
+  useFetch<EOLRollupApiResponse>('/api/eol/approaching'),
+  useFetch<EOLRollupApiResponse>('/api/eol/expired')
+])
 
 const techCount = useApiCount(techData)
 const sysCount = useApiCount(sysData)

--- a/app/pages/systems/[name]/index.vue
+++ b/app/pages/systems/[name]/index.vue
@@ -127,7 +127,7 @@
           </p>
         </template>
         <ClientOnly>
-          <SystemDependencyGraph
+          <AsyncSystemDependencyGraph
             :system-name="data.data.name"
             :nodes="graphData?.data?.nodes ?? []"
             :edges="graphData?.data?.edges ?? []"
@@ -139,7 +139,11 @@
 </template>
 
 <script setup lang="ts">
+import { defineAsyncComponent } from 'vue'
+
 const route = useRoute()
+
+const AsyncSystemDependencyGraph = defineAsyncComponent(() => import('../../../components/SystemDependencyGraph.vue'))
 
 interface System {
   name: string

--- a/app/pages/technologies/index.vue
+++ b/app/pages/technologies/index.vue
@@ -83,7 +83,7 @@
           <UBadge v-if="radarPending" color="neutral" variant="subtle">Loading…</UBadge>
         </div>
         <UCard>
-          <TechnologyRadar :data="radarData" />
+          <AsyncTechnologyRadar :data="radarData" />
         </UCard>
       </template>
     </template>
@@ -275,7 +275,7 @@
 </template>
 
 <script setup lang="ts">
-import { h } from 'vue'
+import { defineAsyncComponent, h } from 'vue'
 import * as z from 'zod'
 import type { TableColumn, FormSubmitEvent } from '@nuxt/ui'
 import type { ApiResponse, Technology } from '~~/types/api'
@@ -285,7 +285,7 @@ const { getSortableHeader } = useSortableTable()
 const { data: session } = useAuth()
 const { isSuperuser } = useEffectiveRole()
 
-
+const AsyncTechnologyRadar = defineAsyncComponent(() => import('../../components/TechnologyRadar.vue'))
 
 const userTeams = computed(() =>
   (session.value?.user?.teams as { name: string }[] | undefined)?.map(t => t.name) || []

--- a/test/app/pages/components/key.test.ts
+++ b/test/app/pages/components/key.test.ts
@@ -83,7 +83,7 @@ function mountPage(options: {
   }), {
     global: {
       stubs: {
-        ComponentDependencyTree: {
+        AsyncComponentDependencyTree: {
           props: ['componentKey', 'systemName'],
           template: '<div data-test="dependency-tree" :data-component-key="componentKey" :data-system-name="systemName || \'\'" />'
         },


### PR DESCRIPTION
## Summary

- Fetch dashboard data concurrently during SSR to reduce frontpage TTFB
- Async-load graph/radar components so D3-heavy UI is split out of initial page bundles
- Add the missing `html` language attribute

## Verification

- `npm run lint`
- `npm run test:app`
- `npm run build`

Related to #693