### PR TITLE
Improve dashboard SSR performance

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -161,125 +161,91 @@
 </template>
 
 <script setup lang="ts">
-import type { ApiResponse, EOLRollupResponse, Technology, System, GroupedComponent, VersionConstraint } from '~~/types/api'
-
-interface LicenseStatsResponse {
+interface DashboardSummaryResponse {
   success: boolean
-  data: Array<{
-    total: number
-    osiApproved: number
-    byCategory: Record<string, number>
-  }>
-}
-
-interface LicenseViolationsResponse {
-  success: boolean
-  data: unknown[]
-  count: number
-}
-
-interface ViolationsResponse {
-  success: boolean
-  count: number
-  summary: {
-    critical: number
-    error: number
-    warning: number
-    info: number
+  data: {
+    counts: {
+      technologies: number
+      systems: number
+      components: number
+      versionConstraints: number
+      violations: number
+      licenseViolations: number
+    }
+    criticality: {
+      critical: number
+      high: number
+      medium: number
+      low: number
+    }
+    licenses: {
+      total: number
+      permissive: number
+      copyleft: number
+      disallowed: number
+    }
+    violations: {
+      total: number
+      critical: number
+      error: number
+      warning: number
+    }
+    lifecycle: {
+      unsupported: number
+      approaching: number
+      systems: number
+    }
   }
 }
 
-interface EOLRollupApiResponse {
-  success: boolean
-  data: EOLRollupResponse
-  count: number
-}
+const { data: dashboardData } = await useFetch<DashboardSummaryResponse>('/api/dashboard')
 
-const [
-  { data: techData },
-  { data: sysData },
-  { data: compData },
-  { data: vcData },
-  { data: licenseStatsData },
-  { data: licenseViolationsData },
-  { data: vcViolationsData },
-  { data: eolApproachingData },
-  { data: eolExpiredData }
-] = await Promise.all([
-  useFetch<ApiResponse<Technology>>('/api/technologies'),
-  useFetch<ApiResponse<System>>('/api/systems'),
-  useFetch<ApiResponse<GroupedComponent>>('/api/components/grouped', {
-    query: { direct: 'true' }
-  }),
-  useFetch<ApiResponse<VersionConstraint>>('/api/version-constraints'),
-  useFetch<LicenseStatsResponse>('/api/licenses/statistics'),
-  useFetch<LicenseViolationsResponse>('/api/licenses/violations'),
-  useFetch<ViolationsResponse>('/api/version-constraints/violations'),
-  useFetch<EOLRollupApiResponse>('/api/eol/approaching'),
-  useFetch<EOLRollupApiResponse>('/api/eol/expired')
-])
+const summary = computed(() => dashboardData.value?.data)
 
-const techCount = useApiCount(techData)
-const sysCount = useApiCount(sysData)
-const compCount = useApiCount(compData)
-const vcCount = useApiCount(vcData)
-const violationsCount = computed(() => vcViolationsData.value?.count || 0)
-const licenseViolationsCount = computed(() => licenseViolationsData.value?.count || 0)
+const counts = computed(() => ({
+  technologies: summary.value?.counts.technologies || 0,
+  systems: summary.value?.counts.systems || 0,
+  components: summary.value?.counts.components || 0,
+  versionConstraints: summary.value?.counts.versionConstraints || 0,
+  violations: summary.value?.counts.violations || 0,
+  licenseViolations: summary.value?.counts.licenseViolations || 0
+}))
 
 const navItems = computed(() => [
-  { title: 'Technologies', value: techCount.value, icon: 'i-lucide-settings', to: '/technologies', valueClass: 'text-(--ui-color-primary-500)' },
-  { title: 'Systems', value: sysCount.value, icon: 'i-lucide-cpu', to: '/systems', valueClass: 'text-(--ui-color-success-500)' },
-  { title: 'Components', value: compCount.value, icon: 'i-lucide-box', to: '/components', valueClass: 'text-(--ui-color-warning-500)' },
-  { title: 'Version Constraints', value: vcCount.value, icon: 'i-lucide-file-text', to: '/version-constraints', valueClass: '' },
-  { title: 'Violations', value: violationsCount.value, icon: 'i-lucide-alert-triangle', to: '/violations', valueClass: 'text-(--ui-color-error-500)' },
-  { title: 'License Violations', value: licenseViolationsCount.value, icon: 'i-lucide-scale', to: '/violations/licenses', valueClass: 'text-(--ui-color-error-500)' }
+  { title: 'Technologies', value: counts.value.technologies, icon: 'i-lucide-settings', to: '/technologies', valueClass: 'text-(--ui-color-primary-500)' },
+  { title: 'Systems', value: counts.value.systems, icon: 'i-lucide-cpu', to: '/systems', valueClass: 'text-(--ui-color-success-500)' },
+  { title: 'Components', value: counts.value.components, icon: 'i-lucide-box', to: '/components', valueClass: 'text-(--ui-color-warning-500)' },
+  { title: 'Version Constraints', value: counts.value.versionConstraints, icon: 'i-lucide-file-text', to: '/version-constraints', valueClass: '' },
+  { title: 'Violations', value: counts.value.violations, icon: 'i-lucide-alert-triangle', to: '/violations', valueClass: 'text-(--ui-color-error-500)' },
+  { title: 'License Violations', value: counts.value.licenseViolations, icon: 'i-lucide-scale', to: '/violations/licenses', valueClass: 'text-(--ui-color-error-500)' }
 ])
 
-const criticalityCounts = computed(() => {
-  const systems = sysData.value?.data || []
-  const counts = { critical: 0, high: 0, medium: 0, low: 0 }
-  systems.forEach((sys: System) => {
-    const criticality = sys.businessCriticality?.toLowerCase()
-    if (criticality === 'critical') counts.critical++
-    else if (criticality === 'high') counts.high++
-    else if (criticality === 'medium') counts.medium++
-    else if (criticality === 'low') counts.low++
-  })
-  return counts
-})
+const criticalityCounts = computed(() => ({
+  critical: summary.value?.criticality.critical || 0,
+  high: summary.value?.criticality.high || 0,
+  medium: summary.value?.criticality.medium || 0,
+  low: summary.value?.criticality.low || 0
+}))
 
-const licenseStats = computed(() => {
-  const statsData = licenseStatsData.value?.data?.[0]
-  return {
-    total: statsData?.total || 0,
-    permissive: statsData?.byCategory?.permissive || 0,
-    copyleft: statsData?.byCategory?.copyleft || 0,
-    disallowed: licenseViolationsCount.value
-  }
-})
+const licenseStats = computed(() => ({
+  total: summary.value?.licenses.total || 0,
+  permissive: summary.value?.licenses.permissive || 0,
+  copyleft: summary.value?.licenses.copyleft || 0,
+  disallowed: summary.value?.licenses.disallowed || 0
+}))
 
-const violationStats = computed(() => {
-  const data = vcViolationsData.value
-  return {
-    total: data?.count || 0,
-    critical: data?.summary?.critical || 0,
-    error: data?.summary?.error || 0,
-    warning: data?.summary?.warning || 0
-  }
-})
+const violationStats = computed(() => ({
+  total: summary.value?.violations.total || 0,
+  critical: summary.value?.violations.critical || 0,
+  error: summary.value?.violations.error || 0,
+  warning: summary.value?.violations.warning || 0
+}))
 
-const lifecycleStats = computed(() => {
-  const approaching = eolApproachingData.value?.data
-  const expired = eolExpiredData.value?.data
-  return {
-    unsupported: expired?.summary.components || 0,
-    approaching: approaching?.summary.components || 0,
-    systems: new Set([
-      ...(approaching?.items || []).flatMap(item => item.systems.map(system => system.name)),
-      ...(expired?.items || []).flatMap(item => item.systems.map(system => system.name))
-    ]).size
-  }
-})
+const lifecycleStats = computed(() => ({
+  unsupported: summary.value?.lifecycle.unsupported || 0,
+  approaching: summary.value?.lifecycle.approaching || 0,
+  systems: summary.value?.lifecycle.systems || 0
+}))
 
 useHead({ title: 'Dashboard - Polaris' })
 </script>

--- a/server/api/dashboard.get.ts
+++ b/server/api/dashboard.get.ts
@@ -35,18 +35,29 @@ async function buildDashboardSummary(
     versionViolationResult
   ] = await Promise.all([
     driver.executeQuery(`
-      MATCH (t:Technology)
-      WITH count(t) AS technologies
-      MATCH (s:System)
-      WITH technologies, count(s) AS systems, collect(toLower(coalesce(s.businessCriticality, ''))) AS criticalities
-      MATCH (vc:VersionConstraint)
+      CALL {
+        MATCH (t:Technology)
+        RETURN count(t) AS technologies
+      }
+      CALL {
+        MATCH (s:System)
+        RETURN count(s) AS systems,
+               sum(CASE WHEN toLower(coalesce(s.businessCriticality, '')) = 'critical' THEN 1 ELSE 0 END) AS critical,
+               sum(CASE WHEN toLower(coalesce(s.businessCriticality, '')) = 'high' THEN 1 ELSE 0 END) AS high,
+               sum(CASE WHEN toLower(coalesce(s.businessCriticality, '')) = 'medium' THEN 1 ELSE 0 END) AS medium,
+               sum(CASE WHEN toLower(coalesce(s.businessCriticality, '')) = 'low' THEN 1 ELSE 0 END) AS low
+      }
+      CALL {
+        MATCH (vc:VersionConstraint)
+        RETURN count(vc) AS versionConstraints
+      }
       RETURN technologies,
              systems,
-             count(vc) AS versionConstraints,
-             size([criticality IN criticalities WHERE criticality = 'critical']) AS critical,
-             size([criticality IN criticalities WHERE criticality = 'high']) AS high,
-             size([criticality IN criticalities WHERE criticality = 'medium']) AS medium,
-             size([criticality IN criticalities WHERE criticality = 'low']) AS low
+             versionConstraints,
+             critical,
+             high,
+             medium,
+             low
     `),
     driver.executeQuery(`
       MATCH (:System)-[u:USES]->(c:Component)
@@ -70,13 +81,25 @@ async function buildDashboardSummary(
         `)
       : Promise.resolve({ records: [] }),
     driver.executeQuery(`
-      MATCH (h:HealthSnapshot)
-      WHERE h.eolStatus IN ['unsupported', 'approaching_eol']
-      OPTIONAL MATCH (c:Component)-[:HAS_HEALTH_SNAPSHOT]->(h)
-      OPTIONAL MATCH (sys:System)-[:USES]->(c)
-      RETURN sum(CASE WHEN h.eolStatus = 'unsupported' THEN 1 ELSE 0 END) AS unsupported,
-             sum(CASE WHEN h.eolStatus = 'approaching_eol' THEN 1 ELSE 0 END) AS approaching,
-             count(DISTINCT sys.name) AS systems
+      CALL {
+        MATCH (c:Component)-[:HAS_HEALTH_SNAPSHOT]->(h:HealthSnapshot)
+        WHERE h.eolStatus = 'unsupported'
+        RETURN count(DISTINCT coalesce(c.purl, h.componentPurl, elementId(c))) AS unsupported
+      }
+      CALL {
+        MATCH (c:Component)-[:HAS_HEALTH_SNAPSHOT]->(h:HealthSnapshot)
+        WHERE h.eolStatus = 'approaching_eol'
+        RETURN count(DISTINCT coalesce(c.purl, h.componentPurl, elementId(c))) AS approaching
+      }
+      CALL {
+        MATCH (c:Component)-[:HAS_HEALTH_SNAPSHOT]->(h:HealthSnapshot)
+        WHERE h.eolStatus IN ['unsupported', 'approaching_eol']
+        OPTIONAL MATCH (sys:System)-[:USES]->(c)
+        RETURN count(DISTINCT sys.name) AS systems
+      }
+      RETURN unsupported,
+             approaching,
+             systems
     `),
     user
       ? versionConstraintService.getViolations({})

--- a/server/api/dashboard.get.ts
+++ b/server/api/dashboard.get.ts
@@ -1,0 +1,131 @@
+import { getCurrentUser } from '../utils/auth'
+import { versionConstraintService } from '../services/singletons'
+import { cachedFetch } from '../utils/cache'
+import type { Driver } from 'neo4j-driver'
+
+function intValue(value: unknown): number {
+  if (typeof value === 'number') return value
+  if (value && typeof value === 'object' && 'toNumber' in value && typeof value.toNumber === 'function') {
+    return value.toNumber()
+  }
+  return 0
+}
+
+export default defineEventHandler(async (event) => {
+  const driver = useDriver()
+  const user = await getCurrentUser(event)
+
+  return await cachedFetch(
+    `dashboard:v1:${user ? 'authenticated' : 'anonymous'}`,
+    () => buildDashboardSummary(driver, user),
+    30
+  )
+})
+
+async function buildDashboardSummary(
+  driver: Driver,
+  user: Awaited<ReturnType<typeof getCurrentUser>>
+) {
+  const [
+    portfolioResult,
+    componentResult,
+    licenseResult,
+    licenseViolationResult,
+    lifecycleResult,
+    versionViolationResult
+  ] = await Promise.all([
+    driver.executeQuery(`
+      MATCH (t:Technology)
+      WITH count(t) AS technologies
+      MATCH (s:System)
+      WITH technologies, count(s) AS systems, collect(toLower(coalesce(s.businessCriticality, ''))) AS criticalities
+      MATCH (vc:VersionConstraint)
+      RETURN technologies,
+             systems,
+             count(vc) AS versionConstraints,
+             size([criticality IN criticalities WHERE criticality = 'critical']) AS critical,
+             size([criticality IN criticalities WHERE criticality = 'high']) AS high,
+             size([criticality IN criticalities WHERE criticality = 'medium']) AS medium,
+             size([criticality IN criticalities WHERE criticality = 'low']) AS low
+    `),
+    driver.executeQuery(`
+      MATCH (:System)-[u:USES]->(c:Component)
+      WHERE u.isDirect = true
+      WITH DISTINCT coalesce(c.packageManager, 'unknown') AS packageManagerKey,
+                    coalesce(c.group, '') AS groupKey,
+                    c.name AS name
+      RETURN count(*) AS components
+    `),
+    driver.executeQuery(`
+      MATCH (l:License)
+      RETURN count(l) AS total,
+             sum(CASE WHEN l.category = 'permissive' THEN 1 ELSE 0 END) AS permissive,
+             sum(CASE WHEN l.category = 'copyleft' THEN 1 ELSE 0 END) AS copyleft
+    `),
+    user
+      ? driver.executeQuery(`
+          MATCH (team:Team)-[:OWNS]->(sys:System)-[u:USES]->(comp:Component)-[:HAS_LICENSE]->(license:License)
+          WHERE license.allowed = false
+          RETURN count(DISTINCT team.name + '\u0000' + sys.name + '\u0000' + coalesce(comp.purl, comp.name + '@' + coalesce(comp.version, 'unknown')) + '\u0000' + license.id) AS violations
+        `)
+      : Promise.resolve({ records: [] }),
+    driver.executeQuery(`
+      MATCH (h:HealthSnapshot)
+      WHERE h.eolStatus IN ['unsupported', 'approaching_eol']
+      OPTIONAL MATCH (c:Component)-[:HAS_HEALTH_SNAPSHOT]->(h)
+      OPTIONAL MATCH (sys:System)-[:USES]->(c)
+      RETURN sum(CASE WHEN h.eolStatus = 'unsupported' THEN 1 ELSE 0 END) AS unsupported,
+             sum(CASE WHEN h.eolStatus = 'approaching_eol' THEN 1 ELSE 0 END) AS approaching,
+             count(DISTINCT sys.name) AS systems
+    `),
+    user
+      ? versionConstraintService.getViolations({})
+      : Promise.resolve({
+          count: 0,
+          summary: { critical: 0, error: 0, warning: 0, info: 0 }
+        })
+  ])
+
+  const portfolio = portfolioResult.records[0]
+  const component = componentResult.records[0]
+  const license = licenseResult.records[0]
+  const licenseViolation = licenseViolationResult.records[0]
+  const lifecycle = lifecycleResult.records[0]
+
+  return {
+    success: true,
+    data: {
+      counts: {
+        technologies: intValue(portfolio?.get('technologies')),
+        systems: intValue(portfolio?.get('systems')),
+        components: intValue(component?.get('components')),
+        versionConstraints: intValue(portfolio?.get('versionConstraints')),
+        violations: versionViolationResult.count,
+        licenseViolations: intValue(licenseViolation?.get('violations'))
+      },
+      criticality: {
+        critical: intValue(portfolio?.get('critical')),
+        high: intValue(portfolio?.get('high')),
+        medium: intValue(portfolio?.get('medium')),
+        low: intValue(portfolio?.get('low'))
+      },
+      licenses: {
+        total: intValue(license?.get('total')),
+        permissive: intValue(license?.get('permissive')),
+        copyleft: intValue(license?.get('copyleft')),
+        disallowed: intValue(licenseViolation?.get('violations'))
+      },
+      violations: {
+        total: versionViolationResult.count,
+        critical: versionViolationResult.summary.critical,
+        error: versionViolationResult.summary.error,
+        warning: versionViolationResult.summary.warning
+      },
+      lifecycle: {
+        unsupported: intValue(lifecycle?.get('unsupported')),
+        approaching: intValue(lifecycle?.get('approaching')),
+        systems: intValue(lifecycle?.get('systems'))
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Replace the dashboard homepage's many SSR data fetches with a single compact dashboard summary endpoint. The new endpoint uses aggregate Neo4j queries and a short cache to avoid blocking initial document rendering on full list and rollup responses.

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

<!-- Link to related issues using #issue_number -->

Fixes #
Relates to #

## Changes Made

<!-- List the specific changes you made -->

- Added `/api/dashboard` to return dashboard counts and summaries from aggregate queries.
- Updated the homepage to fetch the compact dashboard summary instead of nine separate SSR endpoints.
- Cached dashboard summaries for 30 seconds to reduce repeated SSR/backend work.

## Screenshots

<!-- If applicable, add screenshots to demonstrate the changes -->

N/A

## Checklist

<!-- Mark completed items with an "x" -->

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [x] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

<!-- Add any additional information that reviewers should know -->

Verification run:

- `npm test` - 65 files passed, 823 tests passed
- `npm run lint`
- `npm run mdlint`
- `npm run build`

The provided HAR showed the initial `GET /` spending about 116 seconds in server wait time before the HTML response arrived. Local warm server checks after this change returned `/` in about 0.096s and `/api/dashboard` from cache in about 0.003s.