### PR TITLE
feat: systems name filter + fix health refresh false failures

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,8 @@
 	"features": {
 		"ghcr.io/wxw-matt/devcontainer-features/command_runner:0": {},
 		"ghcr.io/postfinance/devcontainer-features/docker-out:1": {},
-		"ghcr.io/srzstephen/devcontainer-features/act:1": {}
+		"ghcr.io/srzstephen/devcontainer-features/act:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 
 	// Use 'postCreateCommand' to run commands after the container is created.

--- a/app/pages/systems/index.vue
+++ b/app/pages/systems/index.vue
@@ -34,6 +34,15 @@
 
     <template v-else>
       <UCard>
+        <div class="pb-4 border-b border-(--ui-border) mb-4">
+          <UInput
+            v-model="searchInput"
+            placeholder="Filter by name..."
+            icon="i-lucide-search"
+            class="max-w-sm"
+          />
+        </div>
+
         <UTable
           v-model:sorting="sorting"
           :manual-sorting="true"
@@ -345,6 +354,7 @@
 
 <script setup lang="ts">
 import { h } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
 import * as z from 'zod'
 import type { TableColumn, FormSubmitEvent } from '@nuxt/ui'
 
@@ -509,14 +519,20 @@ const sorting = ref([])
 const page = ref(1)
 const pageSize = 20
 
-watch(sorting, () => { page.value = 1 })
+const searchInput = ref('')
+const debouncedSearch = ref('')
+
+watch([debouncedSearch, sorting], () => { page.value = 1 })
+
+const updateSearch = useDebounceFn((value: string) => { debouncedSearch.value = value }, 300)
+watch(searchInput, updateSearch)
 
 const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
 const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
 const offset = computed(() => (page.value - 1) * pageSize)
 
 const { data, pending, error } = await useFetch<SystemsResponse>('/api/systems', {
-  query: { limit: pageSize, offset, sortBy, sortOrder }
+  query: { limit: pageSize, offset, sortBy, sortOrder, search: debouncedSearch }
 })
 
 const systems = computed(() => data.value?.data || [])

--- a/server/api/systems.get.ts
+++ b/server/api/systems.get.ts
@@ -59,7 +59,8 @@ export default defineEventHandler(async (event): Promise<ApiResponse<System>> =>
     const limit = Math.min(Math.max(1, rawLimit), 200)
     const offset = Math.max(0, rawOffset)
 
-    const search = (query.search as string | undefined)?.trim() || undefined
+    const rawSearch = query.search
+    const search = (Array.isArray(rawSearch) ? rawSearch[0] : rawSearch as string | undefined)?.trim() || undefined
 
     const result = await systemService.findAll(
       {

--- a/server/api/systems.get.ts
+++ b/server/api/systems.get.ts
@@ -59,13 +59,16 @@ export default defineEventHandler(async (event): Promise<ApiResponse<System>> =>
     const limit = Math.min(Math.max(1, rawLimit), 200)
     const offset = Math.max(0, rawOffset)
 
+    const search = (query.search as string | undefined)?.trim() || undefined
+
     const result = await systemService.findAll(
       {
         sortBy: query.sortBy as string | undefined,
         sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
       },
       limit,
-      offset
+      offset,
+      search
     )
 
     return {

--- a/server/database/queries/systems/find-all.cypher
+++ b/server/database/queries/systems/find-all.cypher
@@ -1,4 +1,5 @@
 MATCH (s:System)
+{{WHERE_CONDITIONS}}
 OPTIONAL MATCH (team:Team)-[:OWNS]->(s)
 CALL {
   WITH s

--- a/server/database/queries/systems/find-all.cypher
+++ b/server/database/queries/systems/find-all.cypher
@@ -20,6 +20,6 @@ RETURN s.name as name,
        componentCount,
        repositoryCount,
        total
-ORDER BY s.businessCriticality DESC, s.name ASC
+ORDER BY {{ORDER_BY}}
 SKIP toInteger($offset)
 LIMIT toInteger($limit)

--- a/server/repositories/system.repository.ts
+++ b/server/repositories/system.repository.ts
@@ -2,6 +2,7 @@ import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
 import type { Repository } from '~~/types/api'
 import { buildOrderByClause, type SortParams, type SortConfig } from '../utils/sorting'
+import { injectWhereConditions } from '../utils/query-loader'
 import { buildCreateChanges } from '../utils/audit-diff'
 
 const systemSortConfig: SortConfig = {
@@ -74,11 +75,15 @@ export class SystemRepository extends BaseRepository {
    * 
    * @returns Array of systems
    */
-  async findAll(sort?: SortParams, limit = 50, offset = 0): Promise<{ data: System[]; total: number }> {
+  async findAll(sort?: SortParams, limit = 50, offset = 0, search?: string): Promise<{ data: System[]; total: number }> {
     const query = await loadQuery('systems/find-all.cypher')
     const orderBy = buildOrderByClause(sort || {}, systemSortConfig)
-    const finalQuery = injectOrderBy(query, orderBy)
-    const { records } = await this.executeQuery(finalQuery, { limit, offset })
+    const conditions = search ? [`toLower(s.name) CONTAINS toLower($search)`] : []
+    const withWhere = injectWhereConditions(query, conditions)
+    const finalQuery = injectOrderBy(withWhere, orderBy)
+    const params: Record<string, unknown> = { limit, offset }
+    if (search) params.search = search
+    const { records } = await this.executeQuery(finalQuery, params)
 
     const total = records.length > 0 ? records[0]!.get('total').toNumber() : 0
     return { data: records.map(record => this.mapToSystem(record)), total }

--- a/server/services/eol.service.ts
+++ b/server/services/eol.service.ts
@@ -20,7 +20,7 @@ interface CacheStorage {
   setItem<T>(key: string, value: T): Promise<void>
 }
 
-type JsonFetcher = <T>(url: string) => Promise<T>
+type JsonFetcher = <T>(url: string) => Promise<T | null>
 
 interface EOLProductResponse {
   result?: EOLProduct
@@ -152,7 +152,7 @@ export class EOLService {
     const data = await this.fetcher<EOLProductResponse>(
       `https://endoflife.date/api/v1/products/${encodeURIComponent(productName)}/`
     )
-    const product = data.result || null
+    const product = data?.result ?? null
     await storage.setItem(key, {
       expiresAt: Date.now() + CACHE_TTL_MS,
       value: product
@@ -309,8 +309,9 @@ export class EOLService {
   }
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
+async function fetchJson<T>(url: string): Promise<T | null> {
   const response = await fetch(url)
+  if (response.status === 404) return null
   if (!response.ok) {
     throw new Error(`Request failed with status ${response.status}`)
   }

--- a/server/services/system.service.ts
+++ b/server/services/system.service.ts
@@ -45,8 +45,8 @@ export class SystemService {
    * 
    * @returns Array of systems with count
    */
-  async findAll(sort?: SortParams, limit = 50, offset = 0): Promise<{ data: System[]; count: number; total: number }> {
-    const { data, total } = await this.systemRepo.findAll(sort, limit, offset)
+  async findAll(sort?: SortParams, limit = 50, offset = 0, search?: string): Promise<{ data: System[]; count: number; total: number }> {
+    const { data, total } = await this.systemRepo.findAll(sort, limit, offset, search)
     return { data, count: data.length, total }
   }
 

--- a/test/server/api/systems.spec.ts
+++ b/test/server/api/systems.spec.ts
@@ -70,7 +70,7 @@ describeFeature(feature, ({ Background, Scenario }) => {
       getResult = await getHandler(mockEvent())
     })
     Then('the service should be called with limit 50 and offset 0', () => {
-      expect(systemService.findAll).toHaveBeenCalledWith(expect.any(Object), 50, 0)
+      expect(systemService.findAll).toHaveBeenCalledWith(expect.any(Object), 50, 0, undefined)
     })
   })
 
@@ -80,7 +80,7 @@ describeFeature(feature, ({ Background, Scenario }) => {
       getResult = await getHandler(mockEvent({ query: { limit: '9999' } }))
     })
     Then('the service should be called with limit 200 and offset 0', () => {
-      expect(systemService.findAll).toHaveBeenCalledWith(expect.any(Object), 200, 0)
+      expect(systemService.findAll).toHaveBeenCalledWith(expect.any(Object), 200, 0, undefined)
     })
   })
 
@@ -90,7 +90,7 @@ describeFeature(feature, ({ Background, Scenario }) => {
       getResult = await getHandler(mockEvent({ query: { limit: '0' } }))
     })
     Then('the service should be called with limit 1 and offset 0', () => {
-      expect(systemService.findAll).toHaveBeenCalledWith(expect.any(Object), 1, 0)
+      expect(systemService.findAll).toHaveBeenCalledWith(expect.any(Object), 1, 0, undefined)
     })
   })
 


### PR DESCRIPTION
## Summary

- **feat(systems):** Add name filter input to `/systems` list page, matching the existing UX on `/components`. Debounced `UInput` wired through the full stack (API handler → service → repository → Cypher `WHERE toLower(s.name) CONTAINS toLower($search)`). Total count reflects the filtered result.
- **fix(health):** `endoflife.date` returns HTTP 404 for packages it doesn't track (virtually all npm/composer packages). `fetchJson` was throwing on any non-2xx, propagating as `fetch_failed` and marking every such `HealthRefreshJobItem` as `failed`. Fix: return `null` on 404 so it falls through to the existing `no_data` path, which is not counted as a failure.

## Test plan

- [ ] Visit `/systems` and confirm the name filter input appears and filters results as you type
- [ ] Confirm pagination resets to page 1 on search
- [ ] Confirm sorting still works with an active search
- [ ] Trigger a health refresh for a system with generic npm packages; confirm items complete as `refreshed` not `failed`
- [ ] All 825 unit tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)