### PR TITLE
fix(sbom): correctly mark isDirect for Composer and other SPDX SBOMs (#722)

### DIFF
--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -28,6 +28,16 @@ const SPDX_DEPENDENCY_TYPES = new Set([
   'TEST_DEPENDENCY_OF',
 ])
 
+// SPDX relationship types where the direction is inverted relative to the dependency graph:
+// "A DEV_DEPENDENCY_OF B" means B depends on A, so the edge in our graph is B→A.
+const SPDX_INVERSE_RELATIONSHIP_TYPES = new Set([
+  'DEV_DEPENDENCY_OF',
+  'OPTIONAL_DEPENDENCY_OF',
+  'PROVIDED_DEPENDENCY_OF',
+  'RUNTIME_DEPENDENCY_OF',
+  'TEST_DEPENDENCY_OF',
+])
+
 // Maps SPDX relationship types to the scope value stored on the USES edge.
 // Relationship types not present here (e.g. DYNAMIC_LINK, STATIC_LINK) yield null.
 const SPDX_SCOPE_MAP: Record<string, string> = {
@@ -222,11 +232,25 @@ export class SBOMService {
         name: (root?.name as string)?.trim() || null,
       }
     } else {
-      // SPDX: the document itself is the root; its SPDXID is typically SPDXRef-DOCUMENT
-      return {
-        bomRef: (sbom.SPDXID as string)?.trim() || null,
-        name: null,
+      // SPDX: the document node (SPDXRef-DOCUMENT) is not itself a package. Follow the
+      // DESCRIBES relationship to find the root application package, which is the true
+      // parent of all direct dependencies. Fall back to the raw SPDXID only if no
+      // DESCRIBES edge is present (non-standard SBOM layout).
+      const documentId = (sbom.SPDXID as string)?.trim() || null
+      const relationships = sbom.relationships as unknown[] | undefined
+      if (Array.isArray(relationships) && documentId) {
+        for (const rel of relationships) {
+          const r = rel as Record<string, unknown>
+          if (
+            r.relationshipType === 'DESCRIBES' &&
+            (r.spdxElementId as string)?.trim() === documentId
+          ) {
+            const target = (r.relatedSpdxElement as string)?.trim()
+            if (target) return { bomRef: target, name: null }
+          }
+        }
       }
+      return { bomRef: documentId, name: null }
     }
   }
 
@@ -501,9 +525,14 @@ export class SBOMService {
       const r = rel as Record<string, unknown>
       const type = r.relationshipType as string | undefined
       if (!type || !SPDX_DEPENDENCY_TYPES.has(type)) continue
-      const from = (r.spdxElementId as string)?.trim()
-      const to = (r.relatedSpdxElement as string)?.trim()
-      if (!from || !to) continue
+      const elementId = (r.spdxElementId as string)?.trim()
+      const relatedElement = (r.relatedSpdxElement as string)?.trim()
+      if (!elementId || !relatedElement) continue
+      // Inverse types encode the child as spdxElementId and the parent as relatedSpdxElement
+      // (e.g. "phpunit DEV_DEPENDENCY_OF karla" means karla→phpunit in our graph).
+      const [from, to] = SPDX_INVERSE_RELATIONSHIP_TYPES.has(type)
+        ? [relatedElement, elementId]
+        : [elementId, relatedElement]
       edges.push({ from, to, scope: SPDX_SCOPE_MAP[type] ?? null })
     }
     return edges

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -177,10 +177,6 @@ function isNotFoundError(error: unknown): boolean {
   return error instanceof GitHubApiError && error.status === 404
 }
 
-function isGitHubApiError(error: unknown, status: number): boolean {
-  return error instanceof GitHubApiError && error.status === status
-}
-
 /**
  * Fetch repository metadata from the GitHub API.
  */
@@ -331,6 +327,6 @@ export async function cloneRepository(repoUrl: string, targetDir: string, token:
     if (stderr.includes('Authentication failed') || stderr.includes('could not read Username')) {
       throw new GitHubApiError(401, 'Unauthorized', `GitHub authentication failed for ${owner}/${repo} — check your GitHub token scope`)
     }
-    throw new Error(`git clone failed for ${owner}/${repo}: ${stderr || String(error)}`)
+    throw new Error(`git clone failed for ${owner}/${repo}: ${stderr || String(error)}`, { cause: error })
   }
 }

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -506,6 +506,169 @@ describe('SBOMService', () => {
       expect(persistCall.componentUsage.get('pkg:npm/@slidev/cli@52.0.0')?.isDirect).not.toBe(true)
     })
 
+    it('should mark direct deps correctly for SPDX SBOMs using the DESCRIBES+DEPENDS_ON pattern (Composer/cdxgen)', async () => {
+      // Represents the real cdxgen Composer SBOM layout:
+      // SPDXRef-DOCUMENT --DESCRIBES--> root package --DEPENDS_ON--> direct deps
+      const composerSbom = {
+        spdxVersion: 'SPDX-2.3',
+        dataLicense: 'CC0-1.0',
+        SPDXID: 'SPDXRef-DOCUMENT',
+        name: 'karla-sbom',
+        documentNamespace: 'https://example.com/karla',
+        creationInfo: { created: '2024-01-01T00:00:00Z', creators: ['Tool: cdxgen'] },
+        packages: [
+          {
+            SPDXID: 'SPDXRef-Package-karla',
+            name: 'karla',
+            versionInfo: '1.0.0',
+            downloadLocation: 'NOASSERTION',
+            filesAnalyzed: false,
+            licenseConcluded: 'MIT',
+            licenseDeclared: 'MIT',
+            copyrightText: 'NOASSERTION',
+          },
+          {
+            SPDXID: 'SPDXRef-Package-symfony-console',
+            name: 'symfony/console',
+            versionInfo: '6.0.0',
+            downloadLocation: 'NOASSERTION',
+            filesAnalyzed: false,
+            licenseConcluded: 'MIT',
+            licenseDeclared: 'MIT',
+            copyrightText: 'NOASSERTION',
+            externalRefs: [{ referenceCategory: 'PACKAGE-MANAGER', referenceType: 'purl', referenceLocator: 'pkg:composer/symfony/console@6.0.0' }],
+          },
+          {
+            SPDXID: 'SPDXRef-Package-phpunit',
+            name: 'phpunit/phpunit',
+            versionInfo: '10.0.0',
+            downloadLocation: 'NOASSERTION',
+            filesAnalyzed: false,
+            licenseConcluded: 'BSD-3-Clause',
+            licenseDeclared: 'BSD-3-Clause',
+            copyrightText: 'NOASSERTION',
+            externalRefs: [{ referenceCategory: 'PACKAGE-MANAGER', referenceType: 'purl', referenceLocator: 'pkg:composer/phpunit/phpunit@10.0.0' }],
+          },
+          {
+            SPDXID: 'SPDXRef-Package-php-timer',
+            name: 'phpunit/php-timer',
+            versionInfo: '6.0.0',
+            downloadLocation: 'NOASSERTION',
+            filesAnalyzed: false,
+            licenseConcluded: 'BSD-3-Clause',
+            licenseDeclared: 'BSD-3-Clause',
+            copyrightText: 'NOASSERTION',
+            externalRefs: [{ referenceCategory: 'PACKAGE-MANAGER', referenceType: 'purl', referenceLocator: 'pkg:composer/phpunit/php-timer@6.0.0' }],
+          },
+        ],
+        relationships: [
+          { spdxElementId: 'SPDXRef-DOCUMENT', relationshipType: 'DESCRIBES', relatedSpdxElement: 'SPDXRef-Package-karla' },
+          { spdxElementId: 'SPDXRef-Package-karla', relationshipType: 'DEPENDS_ON', relatedSpdxElement: 'SPDXRef-Package-symfony-console' },
+          { spdxElementId: 'SPDXRef-Package-karla', relationshipType: 'DEPENDS_ON', relatedSpdxElement: 'SPDXRef-Package-phpunit' },
+          { spdxElementId: 'SPDXRef-Package-phpunit', relationshipType: 'DEPENDS_ON', relatedSpdxElement: 'SPDXRef-Package-php-timer' },
+        ],
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 4, componentsUpdated: 0, relationshipsCreated: 4
+      })
+
+      await service.processSBOM({
+        sbom: composerSbom,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'spdx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.componentUsage.get('SPDXRef-Package-symfony-console')).toMatchObject({ isDirect: true })
+      expect(persistCall.componentUsage.get('SPDXRef-Package-phpunit')).toMatchObject({ isDirect: true })
+      // php-timer is only required by phpunit, so it is transitive
+      expect(persistCall.componentUsage.get('SPDXRef-Package-php-timer')).toMatchObject({ isDirect: false })
+    })
+
+    it('should correctly resolve isDirect and scope when SPDX uses inverse *_DEPENDENCY_OF relationship types', async () => {
+      // SPDX inverse types: "A DEV_DEPENDENCY_OF B" means B depends on A (the edge is B→A).
+      // The extractor must flip the direction so BFS and scope propagation work correctly.
+      const sbomWithInverseRels = {
+        spdxVersion: 'SPDX-2.3',
+        dataLicense: 'CC0-1.0',
+        SPDXID: 'SPDXRef-DOCUMENT',
+        name: 'test-sbom',
+        documentNamespace: 'https://example.com/test',
+        creationInfo: { created: '2024-01-01T00:00:00Z', creators: ['Tool: cdxgen'] },
+        packages: [
+          {
+            SPDXID: 'SPDXRef-Package-myapp',
+            name: 'myapp',
+            versionInfo: '1.0.0',
+            downloadLocation: 'NOASSERTION',
+            filesAnalyzed: false,
+            licenseConcluded: 'MIT',
+            licenseDeclared: 'MIT',
+            copyrightText: 'NOASSERTION',
+          },
+          {
+            SPDXID: 'SPDXRef-Package-guzzle',
+            name: 'guzzlehttp/guzzle',
+            versionInfo: '7.0.0',
+            downloadLocation: 'NOASSERTION',
+            filesAnalyzed: false,
+            licenseConcluded: 'MIT',
+            licenseDeclared: 'MIT',
+            copyrightText: 'NOASSERTION',
+            externalRefs: [{ referenceCategory: 'PACKAGE-MANAGER', referenceType: 'purl', referenceLocator: 'pkg:composer/guzzlehttp/guzzle@7.0.0' }],
+          },
+          {
+            SPDXID: 'SPDXRef-Package-phpunit',
+            name: 'phpunit/phpunit',
+            versionInfo: '10.0.0',
+            downloadLocation: 'NOASSERTION',
+            filesAnalyzed: false,
+            licenseConcluded: 'BSD-3-Clause',
+            licenseDeclared: 'BSD-3-Clause',
+            copyrightText: 'NOASSERTION',
+            externalRefs: [{ referenceCategory: 'PACKAGE-MANAGER', referenceType: 'purl', referenceLocator: 'pkg:composer/phpunit/phpunit@10.0.0' }],
+          },
+          {
+            SPDXID: 'SPDXRef-Package-php-timer',
+            name: 'phpunit/php-timer',
+            versionInfo: '6.0.0',
+            downloadLocation: 'NOASSERTION',
+            filesAnalyzed: false,
+            licenseConcluded: 'BSD-3-Clause',
+            licenseDeclared: 'BSD-3-Clause',
+            copyrightText: 'NOASSERTION',
+            externalRefs: [{ referenceCategory: 'PACKAGE-MANAGER', referenceType: 'purl', referenceLocator: 'pkg:composer/phpunit/php-timer@6.0.0' }],
+          },
+        ],
+        relationships: [
+          { spdxElementId: 'SPDXRef-DOCUMENT', relationshipType: 'DESCRIBES', relatedSpdxElement: 'SPDXRef-Package-myapp' },
+          // Inverse types: child is spdxElementId, parent is relatedSpdxElement
+          { spdxElementId: 'SPDXRef-Package-guzzle', relationshipType: 'RUNTIME_DEPENDENCY_OF', relatedSpdxElement: 'SPDXRef-Package-myapp' },
+          { spdxElementId: 'SPDXRef-Package-phpunit', relationshipType: 'DEV_DEPENDENCY_OF', relatedSpdxElement: 'SPDXRef-Package-myapp' },
+          { spdxElementId: 'SPDXRef-Package-php-timer', relationshipType: 'DEV_DEPENDENCY_OF', relatedSpdxElement: 'SPDXRef-Package-phpunit' },
+        ],
+      }
+
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 4, componentsUpdated: 0, relationshipsCreated: 4
+      })
+
+      await service.processSBOM({
+        sbom: sbomWithInverseRels,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'spdx',
+        userId: 'user-1'
+      })
+
+      const persistCall = vi.mocked(SBOMRepository.prototype.persistSBOM).mock.calls[0][0]
+      expect(persistCall.componentUsage.get('SPDXRef-Package-guzzle')).toMatchObject({ isDirect: true, scope: 'runtime' })
+      expect(persistCall.componentUsage.get('SPDXRef-Package-phpunit')).toMatchObject({ isDirect: true, scope: 'dev' })
+      // php-timer is only a dep of phpunit, so it is transitive
+      expect(persistCall.componentUsage.get('SPDXRef-Package-php-timer')).toMatchObject({ isDirect: false })
+    })
+
     it('should not throw when a dependency purl has a malformed encoded name segment', async () => {
       const sbomWithMalformedPurlName = {
         ...validCycloneDxSbom,


### PR DESCRIPTION
## Description

Fixes a bug where all Composer packages were stored with `isDirect: false` after an SBOM import, regardless of whether they appeared in `require` or `require-dev`. The root cause is two bugs in the SPDX processing path (Composer SBOMs are generated in SPDX format by cdxgen).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #722

## Changes Made

- **`extractRootBomRef` (SPDX branch)**: Now follows the `DESCRIBES` relationship from `SPDXRef-DOCUMENT` to find the actual root application package. Previously, `resolveRootDirectDeps` searched for `SPDXRef-DOCUMENT` in the dependency graph, never found it (because `DESCRIBES` was filtered out), and fell back to `inferDirectDepsFromComponentGraph` — which treated the root app package itself as the only direct dep, making all real packages transitive.

- **`extractSPDXScopedEdges`**: Added `SPDX_INVERSE_RELATIONSHIP_TYPES` set and flip logic for inverse relationship types (`DEV_DEPENDENCY_OF`, `RUNTIME_DEPENDENCY_OF`, etc.). In SPDX, these encode the child as `spdxElementId` and the parent as `relatedSpdxElement` — opposite to `DEPENDS_ON`. The extractor was building the adjacency graph with reversed edges, causing BFS scope propagation to walk up the graph instead of down and assigning wrong scopes.

- **New tests**: Two new test cases in `sbom.service.spec.ts`:
  - `should mark direct deps correctly for SPDX SBOMs using the DESCRIBES+DEPENDS_ON pattern (Composer/cdxgen)` — covers the real cdxgen Composer SBOM layout with direct and transitive deps
  - `should correctly resolve isDirect and scope when SPDX uses inverse *_DEPENDENCY_OF relationship types` — covers `RUNTIME_DEPENDENCY_OF` and `DEV_DEPENDENCY_OF` with correct scope assignment

## Screenshots

N/A — server-side data processing fix. Verify after re-importing the `karla` Composer SBOM:

```cypher
MATCH (s:System {name: 'karla'})-[u:USES]->(c:Component)
WHERE c.packageManager = 'composer'
RETURN c.packageManager,
       sum(CASE WHEN u.isDirect = true THEN 1 ELSE 0 END) AS direct,
       sum(CASE WHEN u.isDirect = false OR u.isDirect IS NULL THEN 1 ELSE 0 END) AS transitive
```

Expected: direct > 0 (previously always 0).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues

## Additional Notes

The fix affects all SPDX-format SBOMs, not just Composer. Any package manager whose tooling produces SPDX (rather than CycloneDX) would have hit the same bug. The CycloneDX path (npm, Python, Maven, Gradle, etc.) is unaffected.

Re-submitting the SBOM for affected repositories is required — the fix only applies at import time and there is no background reprocessing job.