### PR TITLE
feat: guided PURL-to-Technology matching queue for SBOM governance

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -325,6 +325,11 @@ const mainMenuItems = computed<NavigationMenuItem[][]>(() => {
       to: '/users'
     })
     items.push({
+      label: 'Component Links',
+      icon: 'i-lucide-link',
+      to: '/admin/component-links'
+    })
+    items.push({
       label: 'Impersonate User',
       icon: 'i-lucide-eye',
       onSelect: () => openImpersonateModal()

--- a/app/pages/admin/component-links.vue
+++ b/app/pages/admin/component-links.vue
@@ -12,6 +12,16 @@
       icon="i-lucide-circle-x"
     />
 
+    <UAlert
+      v-if="dismissError"
+      color="error"
+      title="Failed to dismiss component"
+      :description="dismissError"
+      icon="i-lucide-circle-x"
+      close
+      @close="dismissError = ''"
+    />
+
     <UCard v-else>
       <UTable
         :data="suggestions"
@@ -270,15 +280,19 @@ async function submitConfirmLink() {
 }
 
 // Dismiss
+const dismissError = ref('')
+
 async function dismissItem(item: LinkSuggestion) {
+  dismissError.value = ''
   try {
     await $fetch('/api/components/dismiss-link', {
       method: 'POST',
       body: { purl: item.purl }
     })
     await refresh()
-  } catch {
-    // silently ignore — the item will still be in the list
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Unknown error'
+    dismissError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
   }
 }
 

--- a/app/pages/admin/component-links.vue
+++ b/app/pages/admin/component-links.vue
@@ -1,0 +1,286 @@
+<template>
+  <div class="space-y-6">
+    <UPageHeader
+      title="Component Link Queue"
+      :description="`${total} component${total === 1 ? '' : 's'} awaiting a Technology link`"
+    />
+
+    <UAlert
+      v-if="fetchError"
+      color="error"
+      :title="fetchError.message || 'Failed to load suggestions'"
+      icon="i-lucide-circle-x"
+    />
+
+    <UCard v-else>
+      <UTable
+        :data="suggestions"
+        :columns="columns"
+        :loading="pending"
+      >
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-12">
+            No unlinked components — all caught up!
+          </div>
+        </template>
+      </UTable>
+
+      <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
+        <UPagination
+          v-model:page="page"
+          :total="total"
+          :items-per-page="pageSize"
+          :sibling-count="1"
+          show-edges
+        />
+      </div>
+    </UCard>
+
+    <!-- Confirm link modal -->
+    <UModal v-model:open="confirmModalOpen" :ui="{ footer: 'justify-end' }">
+      <template #header>
+        <h3 class="text-lg font-semibold">Link to Technology</h3>
+      </template>
+      <template #body>
+        <div class="space-y-4">
+          <div class="text-sm text-(--ui-text-muted)">
+            Component: <code>{{ confirmItem?.purl }}</code>
+          </div>
+
+          <div>
+            <label class="block text-sm font-medium mb-1">Technology</label>
+            <UInput
+              v-model="techSearch"
+              placeholder="Type to search technologies…"
+              icon="i-lucide-search"
+              @input="onTechSearchInput"
+            />
+          </div>
+
+          <div v-if="techSearchResults.length > 0" class="max-h-52 overflow-y-auto border border-(--ui-border) rounded-md divide-y divide-(--ui-border)">
+            <UButton
+              v-for="name in techSearchResults"
+              :key="name"
+              variant="ghost"
+              color="neutral"
+              class="w-full justify-start px-3 py-2"
+              :class="{ 'bg-(--ui-bg-elevated)': selectedTech === name }"
+              @click="selectedTech = name; techSearch = name; techSearchResults = []"
+            >
+              {{ name }}
+            </UButton>
+          </div>
+
+          <div v-if="selectedTech" class="text-sm">
+            Selected technology: <strong>{{ selectedTech }}</strong>
+          </div>
+
+          <UAlert
+            v-if="confirmError"
+            color="error"
+            variant="subtle"
+            icon="i-lucide-alert-circle"
+            :description="confirmError"
+          />
+        </div>
+      </template>
+      <template #footer>
+        <UButton label="Cancel" color="neutral" variant="outline" @click="confirmModalOpen = false" />
+        <UButton
+          :loading="confirmLoading"
+          :label="confirmLoading ? 'Linking…' : 'Confirm Link'"
+          :disabled="!selectedTech"
+          @click="submitConfirmLink"
+        />
+      </template>
+    </UModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+
+interface LinkSuggestion {
+  purl: string
+  name: string
+  version: string
+  packageManager: string | null
+  purlName: string
+  suggestedTechnologies: string[]
+  hasExactMatch: boolean
+}
+
+interface SuggestionsResponse {
+  success: boolean
+  data: LinkSuggestion[]
+  count: number
+  total: number
+}
+
+interface TechnologiesResponse {
+  success: boolean
+  data: Array<{ name: string }>
+  count: number
+}
+
+const UBadge = resolveComponent('UBadge')
+const UButton = resolveComponent('UButton')
+const UTooltip = resolveComponent('UTooltip')
+
+const page = ref(1)
+const pageSize = 50
+
+const queryParams = computed(() => ({
+  skip: (page.value - 1) * pageSize,
+  limit: pageSize
+}))
+
+const { data, pending, error: fetchError, refresh } = await useFetch<SuggestionsResponse>(
+  '/api/components/link-suggestions',
+  { query: queryParams }
+)
+
+const suggestions = computed(() => data.value?.data ?? [])
+const total = computed(() => data.value?.total ?? 0)
+
+const columns: TableColumn<LinkSuggestion>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Component',
+    cell: ({ row }) => {
+      const item = row.original
+      return h('div', { class: 'space-y-0.5' }, [
+        h('div', { class: 'font-medium' }, item.name),
+        h('code', { class: 'text-xs text-(--ui-text-muted)' }, item.version)
+      ])
+    }
+  },
+  {
+    accessorKey: 'packageManager',
+    header: 'Ecosystem',
+    cell: ({ row }) => row.getValue('packageManager') ?? '—'
+  },
+  {
+    accessorKey: 'purl',
+    header: 'PURL',
+    cell: ({ row }) => h('code', { class: 'text-xs break-all' }, row.getValue('purl') as string)
+  },
+  {
+    accessorKey: 'suggestedTechnologies',
+    header: 'Suggestions',
+    cell: ({ row }) => {
+      const item = row.original
+      const techs = item.suggestedTechnologies
+      if (!techs?.length) return h('span', { class: 'text-(--ui-text-muted) text-sm' }, 'None')
+      return h('div', { class: 'flex flex-wrap gap-1' }, techs.slice(0, 3).map(name =>
+        h(UBadge, {
+          key: name,
+          color: item.hasExactMatch && name === techs[0] ? 'success' : 'neutral',
+          variant: 'subtle',
+          size: 'sm'
+        }, () => name)
+      ))
+    }
+  },
+  {
+    id: 'actions',
+    header: 'Actions',
+    enableSorting: false,
+    cell: ({ row }) => {
+      const item = row.original
+      return h('div', { class: 'flex gap-2' }, [
+        h(UButton, {
+          size: 'xs',
+          label: 'Confirm',
+          icon: 'i-lucide-link',
+          onClick: () => openConfirmModal(item)
+        }),
+        h(UTooltip, { text: 'Dismiss from queue' }, () =>
+          h(UButton, {
+            size: 'xs',
+            color: 'neutral',
+            variant: 'outline',
+            icon: 'i-lucide-x',
+            onClick: () => dismissItem(item)
+          })
+        )
+      ])
+    }
+  }
+]
+
+// Confirm modal
+const confirmModalOpen = ref(false)
+const confirmItem = ref<LinkSuggestion | null>(null)
+const selectedTech = ref('')
+const techSearch = ref('')
+const techSearchResults = ref<string[]>([])
+const confirmLoading = ref(false)
+const confirmError = ref('')
+
+let techSearchTimer: ReturnType<typeof setTimeout> | null = null
+
+function openConfirmModal(item: LinkSuggestion) {
+  confirmItem.value = item
+  selectedTech.value = item.suggestedTechnologies[0] ?? ''
+  techSearch.value = selectedTech.value
+  techSearchResults.value = []
+  confirmError.value = ''
+  confirmModalOpen.value = true
+}
+
+function onTechSearchInput() {
+  selectedTech.value = ''
+  if (techSearchTimer) clearTimeout(techSearchTimer)
+  const val = techSearch.value.trim()
+  if (val.length < 2) {
+    techSearchResults.value = []
+    return
+  }
+  techSearchTimer = setTimeout(async () => {
+    try {
+      const res = await $fetch<TechnologiesResponse>('/api/technologies', {
+        query: { search: val, limit: 10 }
+      })
+      techSearchResults.value = (res.data ?? []).map(t => t.name)
+    } catch {
+      techSearchResults.value = []
+    }
+  }, 300)
+}
+
+async function submitConfirmLink() {
+  if (!confirmItem.value || !selectedTech.value) return
+  confirmLoading.value = true
+  confirmError.value = ''
+  try {
+    await $fetch(`/api/technologies/${encodeURIComponent(selectedTech.value)}/components`, {
+      method: 'POST',
+      body: { purl: confirmItem.value.purl }
+    })
+    confirmModalOpen.value = false
+    await refresh()
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Failed to link component'
+    confirmError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
+  } finally {
+    confirmLoading.value = false
+  }
+}
+
+// Dismiss
+async function dismissItem(item: LinkSuggestion) {
+  try {
+    await $fetch('/api/components/dismiss-link', {
+      method: 'POST',
+      body: { purl: item.purl }
+    })
+    await refresh()
+  } catch {
+    // silently ignore — the item will still be in the list
+  }
+}
+
+useHead({ title: 'Component Link Queue - Polaris' })
+</script>

--- a/schema/migrations/common/20260701_120000_add_link_dismissed_at_component_index.down.cypher
+++ b/schema/migrations/common/20260701_120000_add_link_dismissed_at_component_index.down.cypher
@@ -1,0 +1,1 @@
+DROP INDEX component_link_dismissed_at IF EXISTS;

--- a/schema/migrations/common/20260701_120000_add_link_dismissed_at_component_index.up.cypher
+++ b/schema/migrations/common/20260701_120000_add_link_dismissed_at_component_index.up.cypher
@@ -1,0 +1,2 @@
+CREATE INDEX component_link_dismissed_at IF NOT EXISTS
+FOR (c:Component) ON (c.linkDismissedAt);

--- a/server/api/components/dismiss-link.post.ts
+++ b/server/api/components/dismiss-link.post.ts
@@ -1,0 +1,44 @@
+import { componentService } from '../../services/singletons'
+
+/**
+ * @openapi
+ * /components/dismiss-link:
+ *   post:
+ *     tags:
+ *       - Components
+ *     summary: Dismiss a component from the link suggestions queue
+ *     description: Marks a component as intentionally not linked to a Technology. Superuser only.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - purl
+ *             properties:
+ *               purl:
+ *                 type: string
+ *                 description: The package URL of the component to dismiss
+ *     responses:
+ *       204:
+ *         description: Component dismissed from queue
+ *       400:
+ *         description: Missing purl
+ *       403:
+ *         description: Superuser access required
+ */
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+
+  const body = await readBody(event)
+  if (!body?.purl) {
+    throw createError({ statusCode: 400, message: 'purl is required' })
+  }
+
+  await componentService.dismissLink(body.purl)
+  setResponseStatus(event, 204)
+  return null
+})

--- a/server/api/components/link-suggestions.get.ts
+++ b/server/api/components/link-suggestions.get.ts
@@ -1,0 +1,46 @@
+import { componentService } from '../../services/singletons'
+
+/**
+ * @openapi
+ * /components/link-suggestions:
+ *   get:
+ *     tags:
+ *       - Components
+ *     summary: Get pending PURL-to-Technology link suggestions
+ *     description: Returns unlinked, non-dismissed components with fuzzy Technology name suggestions. Superuser only.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: skip
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *           maximum: 200
+ *     responses:
+ *       200:
+ *         description: Link suggestions returned
+ *       403:
+ *         description: Superuser access required
+ */
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+
+  const query = getQuery(event)
+  const skip = Math.max(0, parseInt(String(query.skip ?? '0'), 10) || 0)
+  const limit = Math.min(200, Math.max(1, parseInt(String(query.limit ?? '50'), 10) || 50))
+
+  const result = await componentService.getLinkSuggestions(skip, limit)
+
+  return {
+    success: true,
+    data: result.data,
+    count: result.count,
+    total: result.total
+  }
+})

--- a/server/api/technologies/[name]/components.post.ts
+++ b/server/api/technologies/[name]/components.post.ts
@@ -7,7 +7,12 @@ import { technologyService } from '../../../services/singletons'
  *     tags:
  *       - Technologies
  *     summary: Link a component to a technology
- *     description: Creates an IS_VERSION_OF relationship between a component and a technology.
+ *     description: >
+ *       Creates an IS_VERSION_OF relationship between a component and a technology.
+ *       Accepts either `purl` (PURL-based, preferred for SBOM-sourced components) or
+ *       `componentName` + `componentVersion` (legacy, name+version match).
+ *       When `purl` is provided the call requires superuser access and also refreshes
+ *       Team→Technology USES edges for all affected systems.
  *     security:
  *       - bearerAuth: []
  *     parameters:
@@ -22,26 +27,28 @@ import { technologyService } from '../../../services/singletons'
  *         application/json:
  *           schema:
  *             type: object
- *             required:
- *               - componentName
- *               - componentVersion
- *             properties:
- *               componentName:
- *                 type: string
- *               componentVersion:
- *                 type: string
+ *             oneOf:
+ *               - required: [purl]
+ *                 properties:
+ *                   purl:
+ *                     type: string
+ *               - required: [componentName, componentVersion]
+ *                 properties:
+ *                   componentName:
+ *                     type: string
+ *                   componentVersion:
+ *                     type: string
  *     responses:
  *       200:
  *         description: Component linked
  *       400:
  *         description: Missing required fields
+ *       403:
+ *         description: Superuser access required (purl path only)
  *       404:
  *         description: Technology not found
  */
 export default defineEventHandler(async (event) => {
-  const user = await requireAuth(event)
-  const realUserId = await getImpersonatorId(event)
-
   const rawName = getRouterParam(event, 'name')
   if (!rawName) {
     throw createError({ statusCode: 400, message: 'Technology name is required' })
@@ -49,8 +56,26 @@ export default defineEventHandler(async (event) => {
   const technologyName = decodeURIComponent(rawName)
 
   const body = await readBody(event)
+
+  if (body?.purl) {
+    const user = await requireSuperuser(event)
+    const realUserId = await getImpersonatorId(event)
+
+    const result = await technologyService.linkComponentByPurl({
+      technologyName,
+      purl: body.purl,
+      userId: user.id,
+      realUserId
+    })
+
+    return { success: true, data: result }
+  }
+
+  const user = await requireAuth(event)
+  const realUserId = await getImpersonatorId(event)
+
   if (!body?.componentName || !body?.componentVersion) {
-    throw createError({ statusCode: 400, message: 'componentName and componentVersion are required' })
+    throw createError({ statusCode: 400, message: 'componentName and componentVersion are required (or provide purl)' })
   }
 
   const result = await technologyService.linkComponent({

--- a/server/database/queries/components/dismiss-link.cypher
+++ b/server/database/queries/components/dismiss-link.cypher
@@ -1,0 +1,3 @@
+MATCH (c:Component {purl: $purl})
+SET c.linkDismissedAt = datetime()
+RETURN c.purl AS purl

--- a/server/database/queries/components/link-suggestions-count.cypher
+++ b/server/database/queries/components/link-suggestions-count.cypher
@@ -1,0 +1,5 @@
+MATCH (c:Component)
+WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
+  AND c.linkDismissedAt IS NULL
+  AND c.purl IS NOT NULL
+RETURN count(c) AS total

--- a/server/database/queries/components/link-suggestions.cypher
+++ b/server/database/queries/components/link-suggestions.cypher
@@ -10,27 +10,27 @@
 //   partialMatches — Technology names that contain the purlName (up to 4)
 //
 // Results ordered: exact matches first, then alphabetically by component name.
+// Total count is fetched separately via link-suggestions-count.cypher to avoid
+// collecting all matching nodes into memory before paginating.
 MATCH (c:Component)
 WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND c.linkDismissedAt IS NULL
   AND c.purl IS NOT NULL
-WITH collect(c) AS allComponents, count(c) AS total
-UNWIND allComponents AS c
-WITH total, c, toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
+WITH c, toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
 WHERE size(purlName) > 0
 OPTIONAL MATCH (t:Technology)
-  WHERE toLower(t.name) = purlName
-WITH total, c, purlName, collect(t.name) AS exactMatches
+  WHERE toLower(t.name) = purlName AND t IS NOT NULL
+WITH c, purlName, [x IN collect(t.name) WHERE x IS NOT NULL] AS exactMatches
 OPTIONAL MATCH (t2:Technology)
-  WHERE toLower(t2.name) CONTAINS purlName AND NOT toLower(t2.name) = purlName
-WITH total, c, purlName, exactMatches, collect(t2.name)[0..4] AS partialMatches
-WITH total, c, purlName,
+  WHERE toLower(t2.name) CONTAINS purlName AND NOT toLower(t2.name) = purlName AND t2 IS NOT NULL
+WITH c, purlName, exactMatches,
+     [x IN collect(t2.name) WHERE x IS NOT NULL][0..4] AS partialMatches
+WITH c, purlName,
      exactMatches + partialMatches AS suggestedTechnologies,
      size(exactMatches) > 0 AS hasExactMatch
 ORDER BY hasExactMatch DESC, c.name ASC
 SKIP $skip LIMIT $limit
 RETURN
-  total,
   c.purl           AS purl,
   c.name           AS name,
   c.version        AS version,

--- a/server/database/queries/components/link-suggestions.cypher
+++ b/server/database/queries/components/link-suggestions.cypher
@@ -1,0 +1,40 @@
+// Returns unlinked, non-dismissed components with fuzzy Technology name suggestions.
+//
+// PURL name extraction: last path segment before the first '@'
+//   pkg:npm/react@18.2.0           → react
+//   pkg:npm/%40scope/react-dom@18  → react-dom
+//   pkg:maven/org.spring/core@5    → core
+//
+// Suggestions:
+//   exactMatches   — Technology names whose toLower equals the extracted purlName
+//   partialMatches — Technology names that contain the purlName (up to 4)
+//
+// Results ordered: exact matches first, then alphabetically by component name.
+MATCH (c:Component)
+WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
+  AND c.linkDismissedAt IS NULL
+  AND c.purl IS NOT NULL
+WITH collect(c) AS allComponents, count(c) AS total
+UNWIND allComponents AS c
+WITH total, c, toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
+WHERE size(purlName) > 0
+OPTIONAL MATCH (t:Technology)
+  WHERE toLower(t.name) = purlName
+WITH total, c, purlName, collect(t.name) AS exactMatches
+OPTIONAL MATCH (t2:Technology)
+  WHERE toLower(t2.name) CONTAINS purlName AND NOT toLower(t2.name) = purlName
+WITH total, c, purlName, exactMatches, collect(t2.name)[0..4] AS partialMatches
+WITH total, c, purlName,
+     exactMatches + partialMatches AS suggestedTechnologies,
+     size(exactMatches) > 0 AS hasExactMatch
+ORDER BY hasExactMatch DESC, c.name ASC
+SKIP $skip LIMIT $limit
+RETURN
+  total,
+  c.purl           AS purl,
+  c.name           AS name,
+  c.version        AS version,
+  c.packageManager AS packageManager,
+  purlName,
+  suggestedTechnologies,
+  hasExactMatch

--- a/server/database/queries/technologies/link-component-by-purl.cypher
+++ b/server/database/queries/technologies/link-component-by-purl.cypher
@@ -1,0 +1,19 @@
+MATCH (t:Technology {name: $technologyName})
+MATCH (c:Component {purl: $purl})
+MERGE (c)-[:IS_VERSION_OF]->(t)
+WITH t, c
+OPTIONAL MATCH (s:System)-[:USES]->(c)
+WITH t, c, collect(DISTINCT s.name) AS affectedSystems
+CREATE (al:AuditLog {
+  id: randomUUID(),
+  timestamp: datetime(),
+  operation: 'LINK',
+  entityType: 'TechnologyComponent',
+  entityId: t.name,
+  entityLabel: c.purl + ' -> ' + t.name,
+  source: 'API',
+  userId: $userId,
+  realUserId: $realUserId
+})
+CREATE (al)-[:AUDITS]->(t)
+RETURN t.name AS technologyName, c.name AS name, c.purl AS purl, affectedSystems

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -376,9 +376,13 @@ export class ComponentRepository extends BaseRepository {
   }
 
   async getLinkSuggestions(skip: number, limit: number): Promise<{ data: LinkSuggestion[]; total: number }> {
-    const query = await loadQuery('components/link-suggestions.cypher')
-    const { records } = await this.executeQuery(query, { skip, limit })
-    const total = records.length > 0 ? records[0]!.get('total').toNumber() : 0
+    const countQuery = await loadQuery('components/link-suggestions-count.cypher')
+    const dataQuery = await loadQuery('components/link-suggestions.cypher')
+
+    const { records: countRecords } = await this.executeQuery(countQuery, {})
+    const total = countRecords.length > 0 ? countRecords[0]!.get('total').toNumber() : 0
+
+    const { records } = await this.executeQuery(dataQuery, { skip, limit })
     return {
       data: records.map(record => ({
         purl: record.get('purl') as string,
@@ -386,7 +390,7 @@ export class ComponentRepository extends BaseRepository {
         version: record.get('version') as string,
         packageManager: record.get('packageManager') as string | null,
         purlName: record.get('purlName') as string,
-        suggestedTechnologies: record.get('suggestedTechnologies') as string[],
+        suggestedTechnologies: (record.get('suggestedTechnologies') as string[]).filter(Boolean),
         hasExactMatch: record.get('hasExactMatch') as boolean
       })),
       total

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -42,6 +42,16 @@ export interface ComponentDependencyTree {
   systemExists: boolean
 }
 
+export interface LinkSuggestion {
+  purl: string
+  name: string
+  version: string
+  packageManager: string | null
+  purlName: string
+  suggestedTechnologies: string[]
+  hasExactMatch: boolean
+}
+
 export interface ComponentEOLCandidate {
   name: string
   version: string
@@ -363,6 +373,29 @@ export class ComponentRepository extends BaseRepository {
       maxDepth: filters.maxDepth,
       systemExists: record.get('systemExists') as boolean
     }
+  }
+
+  async getLinkSuggestions(skip: number, limit: number): Promise<{ data: LinkSuggestion[]; total: number }> {
+    const query = await loadQuery('components/link-suggestions.cypher')
+    const { records } = await this.executeQuery(query, { skip, limit })
+    const total = records.length > 0 ? records[0]!.get('total').toNumber() : 0
+    return {
+      data: records.map(record => ({
+        purl: record.get('purl') as string,
+        name: record.get('name') as string,
+        version: record.get('version') as string,
+        packageManager: record.get('packageManager') as string | null,
+        purlName: record.get('purlName') as string,
+        suggestedTechnologies: record.get('suggestedTechnologies') as string[],
+        hasExactMatch: record.get('hasExactMatch') as boolean
+      })),
+      total
+    }
+  }
+
+  async dismissLink(purl: string): Promise<void> {
+    const query = await loadQuery('components/dismiss-link.cypher')
+    await this.executeQuery(query, { purl })
   }
 
   async findEOLCandidates(): Promise<ComponentEOLCandidate[]> {

--- a/server/repositories/technology.repository.ts
+++ b/server/repositories/technology.repository.ts
@@ -266,6 +266,27 @@ export class TechnologyRepository extends BaseRepository {
   }
 
   /**
+   * Link a component to a technology via IS_VERSION_OF, matched by PURL.
+   *
+   * Returns the affected system names so the caller can refresh Team→Technology usage.
+   */
+  async linkComponentByPurl(params: { technologyName: string; purl: string; userId: string; realUserId?: string | null }): Promise<{ technologyName: string; name: string; purl: string; affectedSystems: string[] }> {
+    const query = await loadQuery('technologies/link-component-by-purl.cypher')
+    const { records } = await this.executeQuery(query, { ...params, realUserId: params.realUserId ?? null })
+
+    if (records.length === 0) {
+      throw new Error('Failed to link component — technology or component not found')
+    }
+
+    return {
+      technologyName: records[0]!.get('technologyName'),
+      name: records[0]!.get('name'),
+      purl: records[0]!.get('purl'),
+      affectedSystems: (records[0]!.get('affectedSystems') as string[]).filter(Boolean)
+    }
+  }
+
+  /**
    * Create or update a team's APPROVES relationship on a technology
    */
   /**

--- a/server/repositories/technology.repository.ts
+++ b/server/repositories/technology.repository.ts
@@ -275,7 +275,7 @@ export class TechnologyRepository extends BaseRepository {
     const { records } = await this.executeQuery(query, { ...params, realUserId: params.realUserId ?? null })
 
     if (records.length === 0) {
-      throw new Error('Failed to link component — technology or component not found')
+      throw createError({ statusCode: 404, message: `Component with purl '${params.purl}' not found` })
     }
 
     return {

--- a/server/services/component.service.ts
+++ b/server/services/component.service.ts
@@ -1,9 +1,9 @@
 import { ComponentRepository } from '../repositories/component.repository'
-import type { ComponentDependencyFilters, ComponentDependencyTree, ComponentFilters } from '../repositories/component.repository'
+import type { ComponentDependencyFilters, ComponentDependencyTree, ComponentFilters, LinkSuggestion } from '../repositories/component.repository'
 import type { Component, ComponentDetail, GroupedComponent } from '~~/types/api'
 import type { ComponentIdentity } from '~~/utils/component-identity'
 
-export type { ComponentFilters }
+export type { ComponentFilters, LinkSuggestion }
 
 /**
  * Service for component-related business logic
@@ -75,6 +75,15 @@ export class ComponentService {
     filters: ComponentDependencyFilters
   ): Promise<ComponentDependencyTree | null> {
     return await this.componentRepo.findDependencies(identity, filters)
+  }
+
+  async getLinkSuggestions(skip: number, limit: number): Promise<{ data: LinkSuggestion[]; count: number; total: number }> {
+    const { data, total } = await this.componentRepo.getLinkSuggestions(skip, limit)
+    return { data, count: data.length, total }
+  }
+
+  async dismissLink(purl: string): Promise<void> {
+    await this.componentRepo.dismissLink(purl)
   }
 
 }

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -316,7 +316,9 @@ export class TechnologyService {
       throw createError({ statusCode: 404, message: `Technology '${input.technologyName}' not found` })
     }
     const result = await this.techRepo.linkComponentByPurl(input)
-    await Promise.all(result.affectedSystems.map(systemName => this.sbomRepo.upsertTeamUsesTechnology(systemName)))
+    for (const systemName of result.affectedSystems) {
+      await this.sbomRepo.upsertTeamUsesTechnology(systemName)
+    }
     return { technologyName: result.technologyName, name: result.name, purl: result.purl }
   }
 

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -1,4 +1,5 @@
 import { TechnologyRepository, type TechnologyDetail, type CreateTechnologyParams, type UpdateTechnologyParams, type UpsertApprovalParams } from '../repositories/technology.repository'
+import { SBOMRepository } from '../repositories/sbom.repository'
 import type { EOLStatus, EOLStatusValue, Technology, ComponentType, TechnologyDomain, TimeValue, TechnologyLifecycleSummary, TechnologyVersionLifecycle } from '~~/types/api'
 import type { SortParams } from '../utils/sorting'
 import { buildAuditChanges, buildDeleteChanges } from '../utils/audit-diff'
@@ -59,7 +60,8 @@ export interface UpdateTechnologyInput {
 export class TechnologyService {
   constructor(
     private readonly techRepo = new TechnologyRepository(),
-    private readonly eolService = new EOLService()
+    private readonly eolService = new EOLService(),
+    private readonly sbomRepo = new SBOMRepository()
   ) {
   }
 
@@ -299,6 +301,23 @@ export class TechnologyService {
       throw createError({ statusCode: 404, message: `Technology '${input.technologyName}' not found` })
     }
     return await this.techRepo.linkComponent(input)
+  }
+
+  /**
+   * Link a component to a technology via IS_VERSION_OF, matched by PURL.
+   *
+   * After linking, refreshes Team→Technology USES edges for every system
+   * that uses the component so that compliance and version-constraint queries
+   * reflect the new relationship immediately.
+   */
+  async linkComponentByPurl(input: { technologyName: string; purl: string; userId: string; realUserId?: string | null }): Promise<{ technologyName: string; name: string; purl: string }> {
+    const exists = await this.techRepo.exists(input.technologyName)
+    if (!exists) {
+      throw createError({ statusCode: 404, message: `Technology '${input.technologyName}' not found` })
+    }
+    const result = await this.techRepo.linkComponentByPurl(input)
+    await Promise.all(result.affectedSystems.map(systemName => this.sbomRepo.upsertTeamUsesTechnology(systemName)))
+    return { technologyName: result.technologyName, name: result.name, purl: result.purl }
   }
 
   /**

--- a/test/server/api/component-link-suggestions.spec.ts
+++ b/test/server/api/component-link-suggestions.spec.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import linkSuggestionsHandler from '../../../server/api/components/link-suggestions.get'
+import dismissLinkHandler from '../../../server/api/components/dismiss-link.post'
+import { componentService } from '../../../server/services/singletons'
+
+vi.mock('../../../server/services/singletons', () => ({
+  componentService: {
+    getLinkSuggestions: vi.fn(),
+    dismissLink: vi.fn()
+  }
+}))
+
+const { mockRequireSuperuser, mockGetImpersonatorId } = vi.hoisted(() => ({
+  mockRequireSuperuser: vi.fn(),
+  mockGetImpersonatorId: vi.fn().mockResolvedValue(null)
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('requireSuperuser', mockRequireSuperuser)
+  vi.stubGlobal('getImpersonatorId', mockGetImpersonatorId)
+})
+
+const superuser = { id: 'admin-1', email: 'admin@example.com', role: 'superuser' as const, teams: [] }
+
+const mockSuggestion = {
+  purl: 'pkg:npm/react@18.2.0',
+  name: 'react',
+  version: '18.2.0',
+  packageManager: 'npm',
+  purlName: 'react',
+  suggestedTechnologies: ['React'],
+  hasExactMatch: true
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRequireSuperuser.mockResolvedValue(superuser)
+})
+
+describe('GET /api/components/link-suggestions', () => {
+  it('should return suggestions with count and total', async () => {
+    vi.mocked(componentService.getLinkSuggestions).mockResolvedValue({
+      data: [mockSuggestion], count: 1, total: 1
+    })
+
+    const result = await linkSuggestionsHandler(mockEvent())
+
+    expect(result.success).toBe(true)
+    expect(result.data).toHaveLength(1)
+    expect(result.total).toBe(1)
+  })
+
+  it('should pass skip and limit query params to service', async () => {
+    vi.mocked(componentService.getLinkSuggestions).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await linkSuggestionsHandler(mockEvent({ query: { skip: '50', limit: '25' } }))
+
+    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(50, 25)
+  })
+
+  it('should clamp limit to 200 maximum', async () => {
+    vi.mocked(componentService.getLinkSuggestions).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await linkSuggestionsHandler(mockEvent({ query: { limit: '999' } }))
+
+    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(0, 200)
+  })
+
+  it('should clamp skip to 0 minimum', async () => {
+    vi.mocked(componentService.getLinkSuggestions).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await linkSuggestionsHandler(mockEvent({ query: { skip: '-10' } }))
+
+    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(0, 50)
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(linkSuggestionsHandler(mockEvent())).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+describe('POST /api/components/dismiss-link', () => {
+  it('should dismiss a component by purl and return 204', async () => {
+    vi.mocked(componentService.dismissLink).mockResolvedValue(undefined)
+
+    const result = await dismissLinkHandler(mockEvent({
+      method: 'POST',
+      body: { purl: 'pkg:npm/react@18.2.0' }
+    }))
+
+    expect(result).toBeNull()
+    expect(componentService.dismissLink).toHaveBeenCalledWith('pkg:npm/react@18.2.0')
+  })
+
+  it('should return 400 when purl is missing', async () => {
+    await expect(
+      dismissLinkHandler(mockEvent({ method: 'POST', body: {} }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(
+      dismissLinkHandler(mockEvent({ method: 'POST', body: { purl: 'pkg:npm/react@18.2.0' } }))
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})

--- a/test/server/api/technology-component-link.spec.ts
+++ b/test/server/api/technology-component-link.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import handler from '../../../server/api/technologies/[name]/components.post'
+import { technologyService } from '../../../server/services/singletons'
+
+vi.mock('../../../server/services/singletons', () => ({
+  technologyService: {
+    linkComponent: vi.fn(),
+    linkComponentByPurl: vi.fn()
+  }
+}))
+
+const { mockRequireAuth, mockRequireSuperuser, mockGetImpersonatorId } = vi.hoisted(() => ({
+  mockRequireAuth: vi.fn(),
+  mockRequireSuperuser: vi.fn(),
+  mockGetImpersonatorId: vi.fn().mockResolvedValue(null)
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('requireAuth', mockRequireAuth)
+  vi.stubGlobal('requireSuperuser', mockRequireSuperuser)
+  vi.stubGlobal('getImpersonatorId', mockGetImpersonatorId)
+})
+
+const user = { id: 'user-1', email: 'user@example.com', role: 'user' as const, teams: [] }
+const superuser = { id: 'admin-1', email: 'admin@example.com', role: 'superuser' as const, teams: [] }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRequireAuth.mockResolvedValue(user)
+  mockRequireSuperuser.mockResolvedValue(superuser)
+  mockGetImpersonatorId.mockResolvedValue(null)
+})
+
+describe('POST /api/technologies/{name}/components — legacy (name+version)', () => {
+  it('should link component by name+version', async () => {
+    vi.mocked(technologyService.linkComponent).mockResolvedValue({
+      technologyName: 'React', componentName: 'react', componentVersion: '18.2.0'
+    })
+
+    const result = await handler(mockEvent({
+      method: 'POST',
+      params: { name: 'React' },
+      body: { componentName: 'react', componentVersion: '18.2.0' }
+    }))
+
+    expect(result.success).toBe(true)
+    expect(technologyService.linkComponent).toHaveBeenCalledWith(
+      expect.objectContaining({ technologyName: 'React', componentName: 'react', componentVersion: '18.2.0' })
+    )
+  })
+
+  it('should return 400 when componentName and componentVersion are missing (no purl either)', async () => {
+    await expect(
+      handler(mockEvent({ method: 'POST', params: { name: 'React' }, body: {} }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should return 400 when technology name is missing', async () => {
+    await expect(
+      handler(mockEvent({ method: 'POST', body: { componentName: 'react', componentVersion: '18.2.0' } }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+})
+
+describe('POST /api/technologies/{name}/components — PURL-based', () => {
+  it('should link component by purl and require superuser', async () => {
+    vi.mocked(technologyService.linkComponentByPurl).mockResolvedValue({
+      technologyName: 'React', name: 'react', purl: 'pkg:npm/react@18.2.0'
+    })
+
+    const result = await handler(mockEvent({
+      method: 'POST',
+      params: { name: 'React' },
+      body: { purl: 'pkg:npm/react@18.2.0' }
+    }))
+
+    expect(result.success).toBe(true)
+    expect(technologyService.linkComponentByPurl).toHaveBeenCalledWith(
+      expect.objectContaining({ technologyName: 'React', purl: 'pkg:npm/react@18.2.0' })
+    )
+    expect(technologyService.linkComponent).not.toHaveBeenCalled()
+  })
+
+  it('should enforce superuser access for purl path', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(
+      handler(mockEvent({
+        method: 'POST',
+        params: { name: 'React' },
+        body: { purl: 'pkg:npm/react@18.2.0' }
+      }))
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})

--- a/test/server/services/technology.service.spec.ts
+++ b/test/server/services/technology.service.spec.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { TechnologyService } from '../../../server/services/technology.service'
 import { TechnologyRepository } from '../../../server/repositories/technology.repository'
+import { SBOMRepository } from '../../../server/repositories/sbom.repository'
 import type { TechnologyDetail } from '../../../server/repositories/technology.repository'
 import '../../fixtures/service-test-helper'
 
 vi.mock('../../../server/repositories/technology.repository')
+vi.mock('../../../server/repositories/sbom.repository')
 
 const mockTech: TechnologyDetail = {
   name: 'React', type: 'framework', domain: 'framework', vendor: 'Meta',
@@ -286,6 +288,45 @@ describe('TechnologyService', () => {
       const result = await service.findForRadar()
       expect(result.find(r => r.name === 'React')?.approvalCount).toBe(2)
       expect(result.find(r => r.name === 'Svelte')?.approvalCount).toBe(0)
+    })
+  })
+
+  describe('linkComponentByPurl()', () => {
+    const input = { technologyName: 'React', purl: 'pkg:npm/react@18.2.0', userId: 'user-1', realUserId: null }
+
+    it('should link component by purl and refresh affected systems', async () => {
+      vi.mocked(TechnologyRepository.prototype.exists).mockResolvedValue(true)
+      vi.mocked(TechnologyRepository.prototype.linkComponentByPurl).mockResolvedValue({
+        technologyName: 'React', name: 'react', purl: 'pkg:npm/react@18.2.0',
+        affectedSystems: ['my-service', 'other-service']
+      })
+      vi.mocked(SBOMRepository.prototype.upsertTeamUsesTechnology).mockResolvedValue(undefined)
+
+      const result = await service.linkComponentByPurl(input)
+
+      expect(result).toEqual({ technologyName: 'React', name: 'react', purl: 'pkg:npm/react@18.2.0' })
+      expect(SBOMRepository.prototype.upsertTeamUsesTechnology).toHaveBeenCalledTimes(2)
+      expect(SBOMRepository.prototype.upsertTeamUsesTechnology).toHaveBeenCalledWith('my-service')
+      expect(SBOMRepository.prototype.upsertTeamUsesTechnology).toHaveBeenCalledWith('other-service')
+    })
+
+    it('should not call upsertTeamUsesTechnology when no systems use the component', async () => {
+      vi.mocked(TechnologyRepository.prototype.exists).mockResolvedValue(true)
+      vi.mocked(TechnologyRepository.prototype.linkComponentByPurl).mockResolvedValue({
+        technologyName: 'React', name: 'react', purl: 'pkg:npm/react@18.2.0', affectedSystems: []
+      })
+      vi.mocked(SBOMRepository.prototype.upsertTeamUsesTechnology).mockResolvedValue(undefined)
+
+      await service.linkComponentByPurl(input)
+
+      expect(SBOMRepository.prototype.upsertTeamUsesTechnology).not.toHaveBeenCalled()
+    })
+
+    it('should throw 404 when technology does not exist', async () => {
+      vi.mocked(TechnologyRepository.prototype.exists).mockResolvedValue(false)
+
+      await expect(service.linkComponentByPurl(input)).rejects.toMatchObject({ statusCode: 404 })
+      expect(TechnologyRepository.prototype.linkComponentByPurl).not.toHaveBeenCalled()
     })
   })
 })

--- a/test/server/services/technology.service.spec.ts
+++ b/test/server/services/technology.service.spec.ts
@@ -328,5 +328,13 @@ describe('TechnologyService', () => {
       await expect(service.linkComponentByPurl(input)).rejects.toMatchObject({ statusCode: 404 })
       expect(TechnologyRepository.prototype.linkComponentByPurl).not.toHaveBeenCalled()
     })
+
+    it('should propagate 404 when component purl is not found', async () => {
+      vi.mocked(TechnologyRepository.prototype.exists).mockResolvedValue(true)
+      const notFound = Object.assign(new Error('Component not found'), { statusCode: 404 })
+      vi.mocked(TechnologyRepository.prototype.linkComponentByPurl).mockRejectedValue(notFound)
+
+      await expect(service.linkComponentByPurl(input)).rejects.toMatchObject({ statusCode: 404 })
+    })
   })
 })


### PR DESCRIPTION
## Description

Implements the pending PURL-to-Technology link queue described in #551. SBOM components arrive with full PURL data but lack an `IS_VERSION_OF` link to a `Technology` node — without this link, TIME policies and version constraints cannot apply. This PR adds a guided workflow: after ingestion, unlinked components are surfaced in an admin queue with fuzzy Technology name suggestions; a superuser confirms or dismisses each item.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Schema update (changes to database schemas)

## Related Issues

Fixes #551

## Changes Made

- **Migration**: sparse index on `Component.linkDismissedAt` (new property for dismissal persistence)
- **Cypher queries**: `link-suggestions.cypher` (PURL name extraction + fuzzy Technology match), `dismiss-link.cypher`, `link-component-by-purl.cypher` (PURL-based IS_VERSION_OF + returns affected systems for usage refresh)
- **Repositories**: `ComponentRepository.getLinkSuggestions()` / `dismissLink()`; `TechnologyRepository.linkComponentByPurl()` 
- **Services**: `ComponentService.getLinkSuggestions()` / `dismissLink()`; `TechnologyService.linkComponentByPurl()` — creates the link then calls `SBOMRepository.upsertTeamUsesTechnology()` for every affected system so Team→Technology USES edges stay current
- **API endpoints**: `GET /api/components/link-suggestions` (superuser), `POST /api/components/dismiss-link` (superuser), extended `POST /api/technologies/{name}/components` to accept optional `purl` body field (superuser path, replaces legacy name+version path for SBOM-sourced components)
- **Admin UI**: new page `app/pages/admin/component-links.vue` — table of pending components, confidence badges, confirm modal with technology search, dismiss button; linked from superuser nav
- **Tests**: 16 new test cases covering the two new API handlers and `TechnologyService.linkComponentByPurl()`

## Screenshots

_Admin queue page (no screenshot — run `npm run dev` and navigate to `/admin/component-links` as a superuser after ingesting SBOMs)_

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues

## Additional Notes

Addresses all four gaps raised in the owner's review comment on #551:
1. **Dismissal persistence** — `linkDismissedAt` property on `Component`, filtered in the queue query
2. **PURL-based confirm-link** — new `link-component-by-purl.cypher` avoids name/version ecosystem collisions
3. **Permission boundary** — all queue/confirm/dismiss actions require `requireSuperuser`
4. **Derived usage refresh** — `linkComponentByPurl` calls `upsertTeamUsesTechnology` for each system that uses the component