### PR TITLE
refactor: entity page density — consolidate table/description patterns

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,3 +1,9 @@
 export default defineAppConfig({
-  ui: {}
+  ui: {
+    card: {
+      slots: {
+        body: 'p-4 sm:p-4'
+      }
+    }
+  }
 })

--- a/app/components/EntityDescriptionList.vue
+++ b/app/components/EntityDescriptionList.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="grid grid-cols-1 gap-x-6 gap-y-4" :class="{ 'sm:grid-cols-2': columns === 2 }">
+    <div v-for="item in items" :key="item.key" :class="{ 'sm:col-span-2': item.span === 2 && columns === 2 }">
+      <span class="text-sm text-muted">{{ item.label }}</span>
+      <slot :name="item.key" :item="item">
+        <div v-if="item.tags" class="mt-1 flex flex-wrap gap-2">
+          <template v-for="tag in item.tags" :key="tag.label">
+            <UButton
+              v-if="tag.to"
+              :label="tag.label"
+              :to="tag.to"
+              variant="subtle"
+              :color="tag.color ?? 'neutral'"
+              size="sm"
+            />
+            <UBadge v-else :color="tag.color ?? 'neutral'" variant="subtle">
+              {{ tag.label }}
+            </UBadge>
+          </template>
+          <span v-if="item.tags.length === 0" class="text-muted text-sm">—</span>
+        </div>
+        <p v-else class="font-medium mt-0.5">{{ item.value ?? '—' }}</p>
+      </slot>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+type SemanticColor = 'primary' | 'secondary' | 'success' | 'info' | 'warning' | 'error' | 'neutral'
+
+interface DescriptionTag {
+  label: string
+  to?: string
+  color?: SemanticColor
+}
+
+interface DescriptionItem {
+  key: string
+  label: string
+  value?: string | number | null
+  tags?: DescriptionTag[]
+  span?: 1 | 2
+}
+
+withDefaults(defineProps<{
+  items: DescriptionItem[]
+  columns?: 1 | 2
+}>(), {
+  columns: 2
+})
+</script>

--- a/app/components/EntityStatStrip.vue
+++ b/app/components/EntityStatStrip.vue
@@ -1,0 +1,29 @@
+<template>
+  <div class="rounded-lg overflow-hidden bg-default ring ring-default flex flex-col sm:flex-row divide-y sm:divide-y-0 sm:divide-x divide-default">
+    <component
+      :is="item.to ? NuxtLink : 'div'"
+      v-for="item in items"
+      :key="item.label"
+      :to="item.to"
+      class="flex-1 p-4 text-center"
+      :class="{ 'hover:bg-elevated transition-colors': item.to }"
+    >
+      <p class="text-sm text-muted">{{ item.label }}</p>
+      <p class="text-2xl font-bold mt-1">{{ item.value }}</p>
+    </component>
+  </div>
+</template>
+
+<script setup lang="ts">
+const NuxtLink = resolveComponent('NuxtLink')
+
+interface StatStripItem {
+  label: string
+  value: string | number
+  to?: string
+}
+
+defineProps<{
+  items: StatStripItem[]
+}>()
+</script>

--- a/app/components/PaginatedTable.vue
+++ b/app/components/PaginatedTable.vue
@@ -1,0 +1,67 @@
+<template>
+  <UCard>
+    <template v-if="$slots.header" #header>
+      <slot name="header" />
+    </template>
+
+    <UTable
+      :sorting="sorting"
+      :manual-sorting="manualSorting"
+      :data="data"
+      :columns="columns"
+      :loading="loading"
+      :on-select="onSelect"
+      class="flex-1"
+      @update:sorting="(value: SortingState) => emit('update:sorting', value)"
+    >
+      <template v-if="$slots.empty" #empty>
+        <slot name="empty" />
+      </template>
+    </UTable>
+
+    <div v-if="showPagination" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
+      <UPagination
+        :page="page"
+        :total="total!"
+        :items-per-page="pageSize!"
+        :sibling-count="1"
+        show-edges
+        @update:page="(value: number) => emit('update:page', value)"
+      />
+    </div>
+  </UCard>
+</template>
+
+<script setup lang="ts" generic="T">
+import type { TableColumn } from '@nuxt/ui'
+import type { Row, SortingState } from '@tanstack/vue-table'
+
+const props = withDefaults(defineProps<{
+  columns: TableColumn<T>[]
+  data: T[]
+  loading?: boolean
+  sorting?: SortingState
+  manualSorting?: boolean
+  page?: number
+  total?: number
+  pageSize?: number
+  onSelect?: (event: Event, row: Row<T>) => void
+}>(), {
+  loading: false,
+  manualSorting: false,
+  sorting: undefined,
+  page: undefined,
+  total: undefined,
+  pageSize: undefined,
+  onSelect: undefined
+})
+
+const emit = defineEmits<{
+  'update:sorting': [value: SortingState]
+  'update:page': [value: number]
+}>()
+
+const showPagination = computed(() =>
+  props.total !== undefined && props.page !== undefined && props.total > (props.pageSize ?? 20)
+)
+</script>

--- a/app/components/PaginatedTable.vue
+++ b/app/components/PaginatedTable.vue
@@ -23,7 +23,7 @@
       <UPagination
         :page="page"
         :total="total!"
-        :items-per-page="pageSize!"
+        :items-per-page="pageSize ?? 20"
         :sibling-count="1"
         show-edges
         @update:page="(value: number) => emit('update:page', value)"

--- a/app/composables/usePaginatedSorting.ts
+++ b/app/composables/usePaginatedSorting.ts
@@ -1,0 +1,42 @@
+import type { ComputedRef, Ref } from 'vue'
+import type { SortingState } from '@tanstack/vue-table'
+
+interface UsePaginatedSortingOptions {
+  pageSize?: number
+  resetOn?: Array<Ref<unknown> | ComputedRef<unknown>>
+}
+
+interface UsePaginatedSortingReturn {
+  sorting: Ref<SortingState>
+  page: Ref<number>
+  pageSize: number
+  offset: ComputedRef<number>
+  sortBy: ComputedRef<string | undefined>
+  sortOrder: ComputedRef<'asc' | 'desc' | undefined>
+}
+
+/**
+ * Owns the page/sorting state shared by every server-paginated UTable, and
+ * derives the offset/sortBy/sortOrder query values from it. Does not build
+ * the fetch query itself — pageSize/param naming (offset vs skip) and extra
+ * filters vary per page, so callers assemble their own useFetch query from
+ * the returned refs.
+ */
+export function usePaginatedSorting(options: UsePaginatedSortingOptions = {}): UsePaginatedSortingReturn {
+  const pageSize = options.pageSize ?? 20
+
+  const sorting = ref<SortingState>([])
+  const page = ref(1)
+
+  const offset = computed(() => (page.value - 1) * pageSize)
+  const sortBy = computed(() => sorting.value.length ? sorting.value[0]!.id : undefined)
+  const sortOrder = computed<'asc' | 'desc' | undefined>(() =>
+    sorting.value.length ? (sorting.value[0]!.desc ? 'desc' : 'asc') : undefined
+  )
+
+  watch([sorting, ...(options.resetOn ?? [])], () => {
+    page.value = 1
+  })
+
+  return { sorting, page, pageSize, offset, sortBy, sortOrder }
+}

--- a/app/pages/admin/component-links.vue
+++ b/app/pages/admin/component-links.vue
@@ -40,29 +40,21 @@
       @close="dismissError = ''"
     />
 
-    <UCard v-else>
-      <UTable
-        :data="suggestions"
-        :columns="columns"
-        :loading="pending"
-      >
-        <template #empty>
-          <div class="text-center text-(--ui-text-muted) py-12">
-            No unlinked components — all caught up!
-          </div>
-        </template>
-      </UTable>
-
-      <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-        <UPagination
-          v-model:page="page"
-          :total="total"
-          :items-per-page="pageSize"
-          :sibling-count="1"
-          show-edges
-        />
-      </div>
-    </UCard>
+    <PaginatedTable
+      v-else
+      v-model:page="page"
+      :data="suggestions"
+      :columns="columns"
+      :loading="pending"
+      :total="total"
+      :page-size="pageSize"
+    >
+      <template #empty>
+        <div class="text-center text-(--ui-text-muted) py-12">
+          No unlinked components — all caught up!
+        </div>
+      </template>
+    </PaginatedTable>
 
     <!-- Confirm link / create modal -->
     <UModal v-model:open="confirmModalOpen" :ui="{ footer: 'justify-end' }">
@@ -160,6 +152,7 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
 
 interface LinkSuggestion {
   name: string
@@ -167,13 +160,6 @@ interface LinkSuggestion {
   purlName: string
   suggestedTechnologies: string[]
   hasExactMatch: boolean
-}
-
-interface SuggestionsResponse {
-  success: boolean
-  data: LinkSuggestion[]
-  count: number
-  total: number
 }
 
 interface TechnologiesResponse {
@@ -192,21 +178,15 @@ const UBadge = resolveComponent('UBadge')
 const UButton = resolveComponent('UButton')
 const UTooltip = resolveComponent('UTooltip')
 
-const page = ref(1)
-const pageSize = 50
+const { page, pageSize, offset } = usePaginatedSorting({ pageSize: 50 })
 
-const queryParams = computed(() => ({
-  skip: (page.value - 1) * pageSize,
-  limit: pageSize
-}))
-
-const { data, pending, error: fetchError, refresh } = await useFetch<SuggestionsResponse>(
+const { data, pending, error: fetchError, refresh } = await useFetch<ApiResponse<LinkSuggestion>>(
   '/api/components/link-suggestions',
-  { query: queryParams }
+  { query: { skip: offset, limit: pageSize } }
 )
 
-const suggestions = computed(() => data.value?.data ?? [])
-const total = computed(() => data.value?.total ?? 0)
+const suggestions = useApiData(data)
+const total = useApiCount(data)
 
 // Deep-link support: ComponentVersionsModal's "Create Technology" action
 // links here with ?component=<name> to jump straight into the confirm flow.

--- a/app/pages/admin/licenses.vue
+++ b/app/pages/admin/licenses.vue
@@ -12,38 +12,30 @@
       icon="i-lucide-circle-x"
     />
 
-    <UCard v-else>
-      <UTable
-        v-model:sorting="sorting"
-          :manual-sorting="true"
-        :data="licenses"
-        :columns="columns"
-        :loading="pending"
-        class="flex-1"
-      >
-        <template #empty>
-          <div class="text-center text-(--ui-text-muted) py-12">
-            No licenses found.
-          </div>
-        </template>
-      </UTable>
-
-      <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-        <UPagination
-          v-model:page="page"
-          :total="total"
-          :items-per-page="pageSize"
-          :sibling-count="1"
-          show-edges
-        />
-      </div>
-    </UCard>
+    <PaginatedTable
+      v-else
+      v-model:sorting="sorting"
+      v-model:page="page"
+      :manual-sorting="true"
+      :data="licenses"
+      :columns="columns"
+      :loading="pending"
+      :total="total"
+      :page-size="pageSize"
+    >
+      <template #empty>
+        <div class="text-center text-(--ui-text-muted) py-12">
+          No licenses found.
+        </div>
+      </template>
+    </PaginatedTable>
   </div>
 </template>
 
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
 
 const { getSortableHeader } = useSortableTable()
 
@@ -54,24 +46,8 @@ interface License {
   osiApproved: boolean
 }
 
-interface LicenseResponse {
-  success: boolean
-  data: License[]
-  count: number
-  total?: number
-}
-
 const UBadge = resolveComponent('UBadge')
 const UButton = resolveComponent('UButton')
-
-function getCategoryColor(category: string) {
-  const colors: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-    permissive: 'success',
-    copyleft: 'warning',
-    proprietary: 'error'
-  }
-  return colors[category] || 'neutral'
-}
 
 const columns: TableColumn<License>[] = [
   {
@@ -107,26 +83,14 @@ const columns: TableColumn<License>[] = [
   }
 ]
 
-const sorting = ref([])
-watch(sorting, () => { page.value = 1 })
-const page = ref(1)
-const pageSize = 20
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
 
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = { limit: pageSize, offset: (page.value - 1) * pageSize }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
+const { data, pending, error } = await useFetch<ApiResponse<License>>('/api/licenses', {
+  query: { limit: pageSize, offset, sortBy, sortOrder }
 })
 
-const { data, pending, error } = await useFetch<LicenseResponse>('/api/licenses', {
-  query: queryParams
-})
-
-const licenses = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const licenses = useApiData(data)
+const total = useApiCount(data)
 
 useHead({ title: 'License Administration - Polaris' })
 </script>

--- a/app/pages/components/[key].vue
+++ b/app/pages/components/[key].vue
@@ -39,33 +39,12 @@
         <div class="space-y-6 xl:col-span-2">
           <UCard>
             <template #header>
-              <div>
-                <div>
-                  <h2 class="text-lg font-semibold">Overview</h2>
-                  <p class="text-sm text-(--ui-text-muted)">Canonical component data stored by Polaris.</p>
-                </div>
-              </div>
+              <h2 class="text-lg font-semibold">Overview</h2>
+              <p class="text-sm text-(--ui-text-muted)">Canonical component data stored by Polaris.</p>
             </template>
 
-            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <span class="text-sm text-(--ui-text-muted)">Version</span>
-                <p class="font-medium break-all">{{ component.version }}</p>
-              </div>
-              <div>
-                <span class="text-sm text-(--ui-text-muted)">Package Manager</span>
-                <p class="font-medium">{{ component.packageManager || '—' }}</p>
-              </div>
-              <div>
-                <span class="text-sm text-(--ui-text-muted)">Type</span>
-                <p class="font-medium">{{ component.type || '—' }}</p>
-              </div>
-              <div>
-                <span class="text-sm text-(--ui-text-muted)">Systems</span>
-                <p class="font-medium">{{ component.systemCount }}</p>
-              </div>
-              <div>
-                <span class="text-sm text-(--ui-text-muted)">Licenses</span>
+            <EntityDescriptionList :items="overviewItems">
+              <template #licenses="{ item }">
                 <div v-if="component.licenses.length > 0" class="mt-1 flex flex-wrap gap-2">
                   <UBadge
                     v-for="license in component.licenses"
@@ -76,23 +55,17 @@
                     {{ license.id || license.name }}
                   </UBadge>
                 </div>
-                <p v-else class="font-medium text-(--ui-text-muted)">No license information</p>
-              </div>
-              <div>
-                <span class="text-sm text-(--ui-text-muted)">Direct Dependencies</span>
-                <p class="font-medium">{{ directDependencyCount }}</p>
-              </div>
-              <div>
-                <span class="text-sm text-(--ui-text-muted)">Technology</span>
-                <p v-if="component.technologyName" class="font-medium">
+                <p v-else class="font-medium text-(--ui-text-muted)">{{ item.value }}</p>
+              </template>
+              <template #technology="{ item }">
+                <p v-if="component.technologyName" class="font-medium mt-0.5">
                   <NuxtLink :to="`/technologies/${encodeURIComponent(component.technologyName)}`" class="hover:underline">
                     {{ component.technologyName }}
                   </NuxtLink>
                 </p>
-                <p v-else class="text-(--ui-text-muted)">Not linked</p>
-              </div>
-              <div>
-                <span class="text-sm text-(--ui-text-muted)">External Signals</span>
+                <p v-else class="text-(--ui-text-muted) mt-0.5">{{ item.value }}</p>
+              </template>
+              <template #externalSignals>
                 <div class="mt-1 flex flex-wrap gap-2">
                   <UBadge v-if="component.packageMetadata?.status === 'available'" color="success" variant="subtle">
                     {{ getPackageSourceLabel(component.packageMetadata.source.name) }}
@@ -108,164 +81,175 @@
                   </UBadge>
                   <span v-if="!hasExternalSignals" class="font-medium text-(--ui-text-muted)">None</span>
                 </div>
-              </div>
-            </div>
+              </template>
+              <template #purl="{ item }">
+                <p class="mt-0.5"><code class="break-all">{{ item.value }}</code></p>
+              </template>
+              <template #cpe="{ item }">
+                <p class="mt-0.5"><code class="break-all">{{ item.value }}</code></p>
+              </template>
+              <template #bomRef="{ item }">
+                <p class="mt-0.5"><code class="break-all">{{ item.value }}</code></p>
+              </template>
+              <template #references>
+                <div class="mt-1 space-y-2">
+                  <UButton
+                    v-if="component.homepage"
+                    :to="component.homepage"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    label="Homepage"
+                    icon="i-lucide-external-link"
+                    variant="outline"
+                    size="sm"
+                  />
+                  <div v-if="component.externalReferences.length > 0" class="flex flex-wrap gap-2">
+                    <UButton
+                      v-for="reference in component.externalReferences"
+                      :key="`${reference.type}:${reference.url}`"
+                      :to="reference.url"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      :label="reference.type"
+                      icon="i-lucide-external-link"
+                      variant="outline"
+                      size="sm"
+                    />
+                  </div>
+                </div>
+              </template>
+            </EntityDescriptionList>
           </UCard>
 
-          <UCard v-if="component.purl || component.cpe || component.bomRef">
-            <template #header>
-              <h2 class="text-lg font-semibold">Identifiers</h2>
-            </template>
-            <div class="space-y-3">
-              <div v-if="component.purl">
-                <span class="text-sm text-(--ui-text-muted)">Package URL</span>
-                <p><code class="break-all">{{ component.purl }}</code></p>
-              </div>
-              <div v-if="component.cpe">
-                <span class="text-sm text-(--ui-text-muted)">CPE</span>
-                <p><code class="break-all">{{ component.cpe }}</code></p>
-              </div>
-              <div v-if="component.bomRef && component.bomRef !== component.purl">
-                <span class="text-sm text-(--ui-text-muted)">BOM Reference</span>
-                <p><code class="break-all">{{ component.bomRef }}</code></p>
-              </div>
-            </div>
-          </UCard>
-
-          <div class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-4 gap-6">
-            <UCard>
-              <template #header>
-                <div class="flex items-center justify-between gap-3">
+          <UCard>
+            <div class="divide-y divide-(--ui-border)">
+              <div class="first:pt-0 last:pb-0 py-6">
+                <div class="flex items-center justify-between gap-3 mb-4">
                   <div>
-                    <h2 class="text-lg font-semibold">Maintenance</h2>
+                    <h3 class="text-base font-semibold">Maintenance</h3>
                     <p class="text-xs text-(--ui-text-muted)">Derived from available component and registry data</p>
                   </div>
                   <UBadge :color="getMaintenanceHealthColor(component.maintenanceHealth?.status)" variant="subtle">
                     {{ getMaintenanceHealthLabel(component.maintenanceHealth?.status) }}
                   </UBadge>
                 </div>
-              </template>
 
-              <div class="space-y-4">
-                <UAlert
-                  v-if="!component.maintenanceHealth || component.maintenanceHealth.status === 'unknown'"
-                  color="neutral"
-                  variant="subtle"
-                  icon="i-lucide-circle-help"
-                  title="Maintenance health unknown"
-                  :description="getMaintenanceReasonDescription(component.maintenanceHealth?.reasonCodes[0])"
-                />
+                <div class="space-y-4">
+                  <UAlert
+                    v-if="!component.maintenanceHealth || component.maintenanceHealth.status === 'unknown'"
+                    color="neutral"
+                    variant="subtle"
+                    icon="i-lucide-circle-help"
+                    title="Maintenance health unknown"
+                    :description="getMaintenanceReasonDescription(component.maintenanceHealth?.reasonCodes[0])"
+                  />
 
-                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4">
-                  <div>
-                    <span class="text-sm text-(--ui-text-muted)">Confidence</span>
-                    <p class="font-medium">{{ getMaintenanceConfidenceLabel(component.maintenanceHealth?.confidence) }}</p>
+                  <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                    <div>
+                      <span class="text-sm text-(--ui-text-muted)">Confidence</span>
+                      <p class="font-medium">{{ getMaintenanceConfidenceLabel(component.maintenanceHealth?.confidence) }}</p>
+                    </div>
+                    <div>
+                      <span class="text-sm text-(--ui-text-muted)">Version Age</span>
+                      <p class="font-medium">{{ formatAge(component.maintenanceHealth?.ageInDays) }}</p>
+                    </div>
+                    <div>
+                      <span class="text-sm text-(--ui-text-muted)">Update Status</span>
+                      <p class="font-medium">{{ getMaintenanceUpdateLabel(component.maintenanceHealth?.updateType) }}</p>
+                    </div>
+                    <div>
+                      <span class="text-sm text-(--ui-text-muted)">Recent Activity</span>
+                      <p class="font-medium">{{ formatNullableBoolean(component.maintenanceHealth?.recentActivity) }}</p>
+                    </div>
                   </div>
-                  <div>
-                    <span class="text-sm text-(--ui-text-muted)">Version Age</span>
-                    <p class="font-medium">{{ formatAge(component.maintenanceHealth?.ageInDays) }}</p>
-                  </div>
-                  <div>
-                    <span class="text-sm text-(--ui-text-muted)">Update Status</span>
-                    <p class="font-medium">{{ getMaintenanceUpdateLabel(component.maintenanceHealth?.updateType) }}</p>
-                  </div>
-                  <div>
-                    <span class="text-sm text-(--ui-text-muted)">Recent Activity</span>
-                    <p class="font-medium">{{ formatNullableBoolean(component.maintenanceHealth?.recentActivity) }}</p>
-                  </div>
-                </div>
 
-                <div v-if="component.maintenanceHealth?.reasonCodes.length">
-                  <span class="text-sm text-(--ui-text-muted)">Reasons</span>
-                  <div class="mt-2 flex flex-wrap gap-2">
-                    <UBadge
-                      v-for="reason in component.maintenanceHealth.reasonCodes.slice(0, 3)"
-                      :key="reason"
-                      color="neutral"
-                      variant="subtle"
-                    >
-                      {{ getMaintenanceReasonLabel(reason) }}
-                    </UBadge>
+                  <div v-if="component.maintenanceHealth?.reasonCodes.length">
+                    <span class="text-sm text-(--ui-text-muted)">Reasons</span>
+                    <div class="mt-2 flex flex-wrap gap-2">
+                      <UBadge
+                        v-for="reason in component.maintenanceHealth.reasonCodes.slice(0, 3)"
+                        :key="reason"
+                        color="neutral"
+                        variant="subtle"
+                      >
+                        {{ getMaintenanceReasonLabel(reason) }}
+                      </UBadge>
+                    </div>
                   </div>
                 </div>
               </div>
-            </UCard>
 
-            <UCard>
-              <template #header>
-                <div class="flex items-center justify-between gap-3">
+              <div class="first:pt-0 last:pb-0 py-6">
+                <div class="flex items-center justify-between gap-3 mb-4">
                   <div>
-                    <h2 class="text-lg font-semibold">Lifecycle</h2>
+                    <h3 class="text-base font-semibold">Lifecycle</h3>
                     <p class="text-xs text-(--ui-text-muted)">Source: endoflife.date</p>
                   </div>
                   <UBadge :color="getEolColor(component.eol?.status)" variant="subtle">
                     {{ getEolLabel(component.eol?.status) }}
                   </UBadge>
                 </div>
-              </template>
 
-              <div class="space-y-4">
-                <UAlert
-                  v-if="!component.eol || component.eol.status === 'unknown'"
-                  color="neutral"
-                  variant="subtle"
-                  icon="i-lucide-circle-help"
-                  title="No lifecycle match available"
-                  :description="getEolUnknownDescription(component.eol?.reason)"
-                />
+                <div class="space-y-4">
+                  <UAlert
+                    v-if="!component.eol || component.eol.status === 'unknown'"
+                    color="neutral"
+                    variant="subtle"
+                    icon="i-lucide-circle-help"
+                    title="No lifecycle match available"
+                    :description="getEolUnknownDescription(component.eol?.reason)"
+                  />
 
-                <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4">
-                  <div v-if="showLifecycleProduct">
-                    <span class="text-sm text-(--ui-text-muted)">Matched Product</span>
-                    <p class="font-medium">{{ lifecycleProductLabel }}</p>
+                  <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+                    <div v-if="showLifecycleProduct">
+                      <span class="text-sm text-(--ui-text-muted)">Matched Product</span>
+                      <p class="font-medium">{{ lifecycleProductLabel }}</p>
+                    </div>
+                    <div>
+                      <span class="text-sm text-(--ui-text-muted)">Matched Cycle</span>
+                      <p class="font-medium">{{ component.eol.matchedCycle || '—' }}</p>
+                    </div>
+                    <div>
+                      <span class="text-sm text-(--ui-text-muted)">End of Life</span>
+                      <p class="font-medium">{{ component.eol.eolDate ? formatDate(component.eol.eolDate) : '—' }}</p>
+                    </div>
+                    <div>
+                      <span class="text-sm text-(--ui-text-muted)">Active Support Ends</span>
+                      <p class="font-medium">{{ component.eol.supportEndDate ? formatDate(component.eol.supportEndDate) : '—' }}</p>
+                    </div>
+                    <div>
+                      <span class="text-sm text-(--ui-text-muted)">LTS</span>
+                      <p class="font-medium">{{ component.eol.lts === null ? '—' : component.eol.lts ? 'Yes' : 'No' }}</p>
+                    </div>
+                    <div v-if="showEolLatestVersion">
+                      <span class="text-sm text-(--ui-text-muted)">Latest Version</span>
+                      <p class="font-medium">{{ component.eol.latestVersion || '—' }}</p>
+                    </div>
                   </div>
-                  <div>
-                    <span class="text-sm text-(--ui-text-muted)">Matched Cycle</span>
-                    <p class="font-medium">{{ component.eol.matchedCycle || '—' }}</p>
-                  </div>
-                  <div>
-                    <span class="text-sm text-(--ui-text-muted)">End of Life</span>
-                    <p class="font-medium">{{ component.eol.eolDate ? formatDate(component.eol.eolDate) : '—' }}</p>
-                  </div>
-                  <div>
-                    <span class="text-sm text-(--ui-text-muted)">Active Support Ends</span>
-                    <p class="font-medium">{{ component.eol.supportEndDate ? formatDate(component.eol.supportEndDate) : '—' }}</p>
-                  </div>
-                  <div>
-                    <span class="text-sm text-(--ui-text-muted)">LTS</span>
-                    <p class="font-medium">{{ component.eol.lts === null ? '—' : component.eol.lts ? 'Yes' : 'No' }}</p>
-                  </div>
-                  <div v-if="showEolLatestVersion">
-                    <span class="text-sm text-(--ui-text-muted)">Latest Version</span>
-                    <p class="font-medium">{{ component.eol.latestVersion || '—' }}</p>
-                  </div>
+
+                  <UButton
+                    v-if="component.eol?.source.url"
+                    :to="component.eol.source.url"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    label="Open endoflife.date"
+                    icon="i-lucide-external-link"
+                    variant="outline"
+                    size="sm"
+                  />
                 </div>
-
-                <UButton
-                  v-if="component.eol?.source.url"
-                  :to="component.eol.source.url"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  label="Open endoflife.date"
-                  icon="i-lucide-external-link"
-                  variant="outline"
-                  size="sm"
-                />
               </div>
-            </UCard>
 
-        <UCard>
-          <template #header>
-            <div class="flex items-center justify-between gap-3">
+              <div class="first:pt-0 last:pb-0 py-6">
+                <div class="flex items-center justify-between gap-3 mb-4">
               <div>
-                <h2 class="text-lg font-semibold">Registry</h2>
+                <h3 class="text-base font-semibold">Registry</h3>
                 <p class="text-xs text-(--ui-text-muted)">Source: {{ getPackageSourceLabel(component.packageMetadata?.source.name) }}</p>
               </div>
               <UBadge :color="getPackageMetadataColor(component.packageMetadata?.status)" variant="subtle">
                 {{ getPackageMetadataLabel(component.packageMetadata?.status) }}
               </UBadge>
-            </div>
-          </template>
+                </div>
 
           <div class="space-y-4">
             <UAlert
@@ -287,7 +271,7 @@
                 :description="component.packageMetadata.deprecatedReason || `${getPackageSourceLabel(component.packageMetadata.source.name)} reports this package version as deprecated.`"
               />
 
-              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4">
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                 <div>
                   <span class="text-sm text-(--ui-text-muted)">Ecosystem</span>
                   <p class="font-medium">{{ component.packageMetadata.system || '—' }}</p>
@@ -355,20 +339,18 @@
               size="sm"
             />
           </div>
-        </UCard>
+              </div>
 
-        <UCard>
-          <template #header>
-            <div class="flex items-center justify-between gap-3">
+              <div class="first:pt-0 last:pb-0 py-6">
+                <div class="flex items-center justify-between gap-3 mb-4">
               <div>
-                <h2 class="text-lg font-semibold">Known Vulnerabilities</h2>
+                <h3 class="text-base font-semibold">Known Vulnerabilities</h3>
                 <p class="text-xs text-(--ui-text-muted)">Source: OSV.dev</p>
               </div>
               <UBadge :color="getVulnerabilityColor(component.vulnerabilities?.status, vulnerabilityCount)" variant="subtle">
                 {{ getVulnerabilityLabel(component.vulnerabilities?.status, vulnerabilityCount) }}
               </UBadge>
-            </div>
-          </template>
+                </div>
 
           <div class="space-y-4">
             <UAlert
@@ -446,20 +428,18 @@
               size="sm"
             />
           </div>
-        </UCard>
+              </div>
 
-        <UCard>
-          <template #header>
-            <div class="flex items-center justify-between gap-3">
+              <div class="first:pt-0 last:pb-0 py-6">
+                <div class="flex items-center justify-between gap-3 mb-4">
               <div>
-                <h2 class="text-lg font-semibold">Security</h2>
+                <h3 class="text-base font-semibold">Security</h3>
                 <p class="text-xs text-(--ui-text-muted)">Source: OpenSSF Scorecard</p>
               </div>
               <UBadge :color="getSecurityScorecardColor(component.securityScorecard?.score, component.securityScorecard?.status)" variant="subtle">
                 {{ getSecurityScorecardLabel(component.securityScorecard?.score, component.securityScorecard?.status) }}
               </UBadge>
-            </div>
-          </template>
+                </div>
 
           <div class="space-y-4">
             <UAlert
@@ -472,7 +452,7 @@
             />
 
             <template v-else>
-              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-4">
+              <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 <div>
                   <span class="text-sm text-(--ui-text-muted)">Repository</span>
                   <p class="font-medium break-all">
@@ -520,13 +500,12 @@
               size="sm"
             />
           </div>
-        </UCard>
-      </div>
+              </div>
+            </div>
+          </UCard>
 
-      <UCard v-if="component.systems.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Systems ({{ component.systems.length }})</h2>
-        </template>
+      <div v-if="component.systems.length > 0">
+        <h2 class="text-lg font-semibold mb-3">Systems ({{ component.systems.length }})</h2>
         <div class="flex flex-wrap gap-2">
           <UButton
             v-for="system in component.systems"
@@ -544,43 +523,8 @@
             </template>
           </UButton>
         </div>
-      </UCard>
-
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <UCard>
-          <template #header>
-            <h2 class="text-lg font-semibold">References</h2>
-          </template>
-          <div class="space-y-2">
-            <UButton
-              v-if="component.homepage"
-              :to="component.homepage"
-              target="_blank"
-              rel="noopener noreferrer"
-              label="Homepage"
-              icon="i-lucide-external-link"
-              variant="outline"
-              size="sm"
-            />
-            <div v-if="component.externalReferences.length > 0" class="space-y-2">
-              <UButton
-                v-for="reference in component.externalReferences"
-                :key="`${reference.type}:${reference.url}`"
-                :to="reference.url"
-                target="_blank"
-                rel="noopener noreferrer"
-                :label="reference.type"
-                icon="i-lucide-external-link"
-                variant="outline"
-                size="sm"
-              />
-            </div>
-            <p v-if="!component.homepage && component.externalReferences.length === 0" class="text-(--ui-text-muted)">
-              No references available.
-            </p>
-          </div>
-        </UCard>
       </div>
+
         </div>
 
         <div class="xl:col-span-1">
@@ -705,6 +649,25 @@ const hasExternalSignals = computed(() => Boolean(
   || component.value?.vulnerabilities?.status === 'available'
 ))
 const vulnerabilityCount = computed(() => component.value?.vulnerabilities?.vulnerabilities.length ?? 0)
+
+const overviewItems = computed(() => {
+  if (!component.value) return []
+  const c = component.value
+  return [
+    { key: 'version', label: 'Version', value: c.version },
+    { key: 'packageManager', label: 'Package Manager', value: c.packageManager },
+    { key: 'type', label: 'Type', value: c.type },
+    { key: 'systemCount', label: 'Systems', value: c.systemCount },
+    { key: 'licenses', label: 'Licenses', value: 'No license information' },
+    { key: 'directDependencies', label: 'Direct Dependencies', value: directDependencyCount.value },
+    { key: 'technology', label: 'Technology', value: 'Not linked' },
+    { key: 'externalSignals', label: 'External Signals', value: null },
+    ...(c.purl ? [{ key: 'purl', label: 'Package URL', value: c.purl, span: 2 as const }] : []),
+    ...(c.cpe ? [{ key: 'cpe', label: 'CPE', value: c.cpe, span: 2 as const }] : []),
+    ...(c.bomRef && c.bomRef !== c.purl ? [{ key: 'bomRef', label: 'BOM Reference', value: c.bomRef, span: 2 as const }] : []),
+    ...(c.homepage || c.externalReferences.length > 0 ? [{ key: 'references', label: 'References', value: null, span: 2 as const }] : [])
+  ]
+})
 
 function getEolColor(status?: EOLStatusValue): 'success' | 'warning' | 'error' | 'neutral' {
   const colors: Record<EOLStatusValue, 'success' | 'warning' | 'error' | 'neutral'> = {

--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -34,55 +34,46 @@
     />
 
     <template v-else>
-      <UCard>
-        <div class="flex flex-wrap items-center justify-between gap-3 pb-4 border-b border-(--ui-border) mb-4">
-          <UInput
-            v-model="searchInput"
-            placeholder="Filter by name..."
-            icon="i-lucide-search"
-            class="max-w-sm"
-          />
-          <div class="flex flex-wrap items-center gap-4">
-            <USwitch
-              v-if="systemFilter"
-              v-model="showDirectOnly"
-              label="Direct only"
-              size="sm"
+      <PaginatedTable
+        v-model:sorting="sorting"
+        v-model:page="page"
+        :data="components"
+        :columns="columns"
+        :loading="pending"
+        :manual-sorting="true"
+        :on-select="openGroupedComponent"
+        :total="total"
+        :page-size="pageSize"
+      >
+        <template #header>
+          <div class="flex flex-wrap items-center justify-between gap-3">
+            <UInput
+              v-model="searchInput"
+              placeholder="Filter by name..."
+              icon="i-lucide-search"
+              class="max-w-sm"
             />
-            <USwitch
-              v-model="showDevDependencies"
-              label="Show dev dependencies"
-              size="sm"
-            />
-          </div>
-        </div>
-
-        <UTable
-          v-model:sorting="sorting"
-          :data="components"
-          :columns="columns"
-          :loading="pending"
-          :manual-sorting="true"
-          :on-select="openGroupedComponent"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center text-(--ui-text-muted) py-12">
-              No components found.
+            <div class="flex flex-wrap items-center gap-4">
+              <USwitch
+                v-if="systemFilter"
+                v-model="showDirectOnly"
+                label="Direct only"
+                size="sm"
+              />
+              <USwitch
+                v-model="showDevDependencies"
+                label="Show dev dependencies"
+                size="sm"
+              />
             </div>
-          </template>
-        </UTable>
-
-        <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-          <UPagination
-            v-model:page="page"
-            :total="total"
-            :items-per-page="pageSize"
-            :sibling-count="1"
-            show-edges
-          />
-        </div>
-      </UCard>
+          </div>
+        </template>
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-12">
+            No components found.
+          </div>
+        </template>
+      </PaginatedTable>
 
       <ComponentVersionsModal
         v-model:open="versionsModalOpen"
@@ -262,8 +253,6 @@ const columns: TableColumn<GroupedComponent>[] = [
   }
 ]
 
-const sorting = ref([])
-
 const route = useRoute()
 const licenseFilter = computed(() => route.query.license as string | undefined)
 const systemFilter = computed(() => route.query.system as string | undefined)
@@ -294,25 +283,20 @@ function openGroupedComponent(_event: Event | null, row: { original: GroupedComp
   versionsModalOpen.value = true
 }
 
-const page = ref(1)
-const pageSize = 20
-
 const searchInput = ref('')
 const debouncedSearch = ref('')
-
-// Reset page when any filter changes
-watch([debouncedSearch, licenseFilter, systemFilter, lifecycleRiskFilter, showDevDependencies, showDirectOnly, sorting], () => { page.value = 1 })
 
 const updateSearch = useDebounceFn((value: string) => { debouncedSearch.value = value }, 300)
 watch(searchInput, updateSearch)
 
-const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
-const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
+  resetOn: [debouncedSearch, licenseFilter, systemFilter, lifecycleRiskFilter, showDevDependencies, showDirectOnly]
+})
+
 const includeDev = computed(() => showDevDependencies.value ? undefined : 'false')
 // Global list (no system): always direct-only to keep result count manageable.
 // System list: respect the user toggle; default is to show all components.
 const direct = computed(() => (!systemFilter.value || showDirectOnly.value) ? 'true' : undefined)
-const offset = computed(() => (page.value - 1) * pageSize)
 
 // Pass individual refs/computeds as query values so Nuxt tracks each one
 // as a reactive dependency for the fetch key — passing a computed object
@@ -332,8 +316,8 @@ const { data, pending, error } = await useFetch<ApiResponse<GroupedComponent>>('
   },
 })
 
-const components = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const components = useApiData(data)
+const total = useApiCount(data)
 
 useHead({ title: 'Components - Polaris' })
 </script>

--- a/app/pages/licenses/[id].vue
+++ b/app/pages/licenses/[id].vue
@@ -20,7 +20,7 @@
         <UPageHeader
           :title="license.name || license.id"
           :description="license.name ? license.id : undefined"
-          :links="[{ label: 'Back to Licenses', to: '/licenses', icon: 'i-lucide-arrow-left', variant: 'outline' as const }]"
+          :links="headerLinks"
         />
         <div class="flex gap-2 flex-shrink-0">
           <UBadge v-if="license.category" :color="getCategoryColor(license.category)" variant="subtle">
@@ -39,44 +39,6 @@
             Disallowed
           </UBadge>
         </div>
-      </div>
-
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Components</p>
-            <p class="text-2xl font-bold mt-1">{{ license.componentCount || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Category</p>
-            <p class="text-2xl font-bold mt-1">{{ license.category || '—' }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">OSI Approved</p>
-            <p class="text-2xl font-bold mt-1">{{ license.osiApproved ? 'Yes' : 'No' }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">SPDX URL</p>
-            <p class="text-sm font-medium mt-1 truncate">
-              <a
-                v-if="license.url"
-                :href="license.url"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="hover:underline"
-              >
-                View on SPDX
-              </a>
-              <span v-else class="text-(--ui-text-muted)">—</span>
-            </p>
-          </div>
-        </UCard>
       </div>
 
       <!-- License Text -->
@@ -99,34 +61,23 @@
       </UCard>
 
       <!-- Components Table -->
-      <UCard>
+      <PaginatedTable
+        v-model:page="componentPage"
+        :data="components"
+        :columns="componentColumns"
+        :loading="componentsPending"
+        :total="componentsTotal"
+        :page-size="componentPageSize"
+      >
         <template #header>
-          <h3 class="text-lg font-semibold">Components Using This License</h3>
+          <h3 class="text-lg font-semibold">Components Using This License ({{ license.componentCount || 0 }})</h3>
         </template>
-
-        <UTable
-          :data="components"
-          :columns="componentColumns"
-          :loading="componentsPending"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center text-(--ui-text-muted) py-12">
-              No components found using this license.
-            </div>
-          </template>
-        </UTable>
-
-        <div v-if="componentsTotal > componentPageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-          <UPagination
-            v-model:page="componentPage"
-            :total="componentsTotal"
-            :items-per-page="componentPageSize"
-            :sibling-count="1"
-            show-edges
-          />
-        </div>
-      </UCard>
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-12">
+            No components found using this license.
+          </div>
+        </template>
+      </PaginatedTable>
     </template>
   </div>
 </template>
@@ -134,6 +85,7 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
 
 const route = useRoute()
 
@@ -166,25 +118,6 @@ interface LicenseResponse {
   data: LicenseDetail[]
 }
 
-interface ComponentsResponse {
-  success: boolean
-  data: LicenseComponent[]
-  count: number
-  total: number
-}
-
-function getCategoryColor(category: string): 'success' | 'warning' | 'error' | 'neutral' {
-  const colors: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-    permissive: 'success',
-    'weak-copyleft': 'warning',
-    copyleft: 'warning',
-    'strong-copyleft': 'error',
-    proprietary: 'error',
-    'public-domain': 'success'
-  }
-  return colors[category?.toLowerCase()] || 'neutral'
-}
-
 const showLicenseText = ref(true)
 
 // License detail
@@ -194,22 +127,26 @@ const { data, pending, error } = await useFetch<LicenseResponse>(
 
 const license = computed(() => data.value?.data?.[0] || null)
 
+const headerLinks = computed(() => {
+  const links: { label: string; to: string; icon: string; variant: 'outline'; target?: '_blank' }[] = [
+    { label: 'Back to Licenses', to: '/licenses', icon: 'i-lucide-arrow-left', variant: 'outline' }
+  ]
+  if (license.value?.url) {
+    links.push({ label: 'View on SPDX', to: license.value.url, icon: 'i-lucide-external-link', variant: 'outline', target: '_blank' })
+  }
+  return links
+})
+
 // Components pagination
-const componentPage = ref(1)
-const componentPageSize = 20
+const { page: componentPage, pageSize: componentPageSize, offset: componentOffset } = usePaginatedSorting()
 
-const componentQueryParams = computed(() => ({
-  limit: componentPageSize,
-  offset: (componentPage.value - 1) * componentPageSize
-}))
-
-const { data: componentsData, pending: componentsPending } = await useFetch<ComponentsResponse>(
+const { data: componentsData, pending: componentsPending } = await useFetch<ApiResponse<LicenseComponent>>(
   () => `/api/licenses/${encodeURIComponent(route.params.id as string)}/components`,
-  { query: componentQueryParams }
+  { query: { limit: componentPageSize, offset: componentOffset } }
 )
 
-const components = computed(() => componentsData.value?.data || [])
-const componentsTotal = computed(() => componentsData.value?.total || 0)
+const components = useApiData(componentsData)
+const componentsTotal = useApiCount(componentsData)
 
 const componentColumns: TableColumn<LicenseComponent>[] = [
   {

--- a/app/pages/licenses/index.vue
+++ b/app/pages/licenses/index.vue
@@ -15,32 +15,22 @@
     />
 
     <template v-else>
-      <UCard>
-        <UTable
-          v-model:sorting="sorting"
-          :manual-sorting="true"
-          :data="licenses"
-          :columns="columns"
-          :loading="pending"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center text-(--ui-text-muted) py-12">
-              No licenses found.
-            </div>
-          </template>
-        </UTable>
-
-        <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-          <UPagination
-            v-model:page="page"
-            :total="total"
-            :items-per-page="pageSize"
-            :sibling-count="1"
-            show-edges
-          />
-        </div>
-      </UCard>
+      <PaginatedTable
+        v-model:sorting="sorting"
+        v-model:page="page"
+        :manual-sorting="true"
+        :data="licenses"
+        :columns="columns"
+        :loading="pending"
+        :total="total"
+        :page-size="pageSize"
+      >
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-12">
+            No licenses found.
+          </div>
+        </template>
+      </PaginatedTable>
     </template>
   </div>
 </template>
@@ -48,6 +38,7 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
 
 const { getSortableHeader } = useSortableTable()
 const { isSuperuser: isSuperuserRef } = useEffectiveRole()
@@ -61,25 +52,6 @@ interface License {
   allowed: boolean
   componentCount: number
   url: string | null
-}
-
-interface LicenseResponse {
-  success: boolean
-  data: License[]
-  count: number
-  total?: number
-}
-
-function getCategoryColor(category: string): 'success' | 'warning' | 'error' | 'neutral' {
-  const colors: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-    permissive: 'success',
-    'weak-copyleft': 'warning',
-    copyleft: 'warning',
-    'strong-copyleft': 'error',
-    proprietary: 'error',
-    'public-domain': 'success'
-  }
-  return colors[category?.toLowerCase()] || 'neutral'
 }
 
 const columns: TableColumn<License>[] = [
@@ -165,26 +137,14 @@ const columns: TableColumn<License>[] = [
   }
 ]
 
-const sorting = ref([])
-watch(sorting, () => { page.value = 1 })
-const page = ref(1)
-const pageSize = 20
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
 
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = { limit: pageSize, offset: (page.value - 1) * pageSize }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
+const { data, pending, error } = await useFetch<ApiResponse<License>>('/api/licenses', {
+  query: { limit: pageSize, offset, sortBy, sortOrder }
 })
 
-const { data, pending, error } = await useFetch<LicenseResponse>('/api/licenses', {
-  query: queryParams
-})
-
-const licenses = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const licenses = useApiData(data)
+const total = useApiCount(data)
 
 async function toggleAllowed(license: License) {
   try {

--- a/app/pages/platforms/[name].vue
+++ b/app/pages/platforms/[name].vue
@@ -45,33 +45,24 @@
         <template #header>
           <h2 class="text-lg font-semibold">Basic Information</h2>
         </template>
-        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Type</span>
-            <p class="font-medium">{{ platform.type || '—' }}</p>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Domain</span>
-            <p class="font-medium">{{ platform.domain || '—' }}</p>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Vendor</span>
-            <p class="font-medium">{{ platform.vendor || '—' }}</p>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Steward Team</span>
-            <p class="font-medium">
-              <NuxtLink v-if="platform.stewardTeamName" :to="`/teams/${encodeURIComponent(platform.stewardTeamName)}`" class="hover:underline">
-                {{ platform.stewardTeamName }}
+        <EntityDescriptionList :items="basicInfoItems">
+          <template #stewardTeam="{ item }">
+            <p class="font-medium mt-0.5">
+              <NuxtLink v-if="item.value" :to="`/teams/${encodeURIComponent(String(item.value))}`" class="hover:underline">
+                {{ item.value }}
               </NuxtLink>
               <span v-else>—</span>
             </p>
-          </div>
-        </div>
+          </template>
+        </EntityDescriptionList>
       </UCard>
 
       <!-- Platform Approvals -->
-      <UCard>
+      <PaginatedTable
+        v-model:sorting="approvalSorting"
+        :data="platform.approvals ?? []"
+        :columns="approvalColumns"
+      >
         <template #header>
           <div class="flex justify-between items-center">
             <h2 class="text-lg font-semibold">Approvals ({{ platform.approvals?.length || 0 }})</h2>
@@ -85,17 +76,12 @@
             />
           </div>
         </template>
-        <UTable
-          v-if="platform.approvals && platform.approvals.length > 0"
-          v-model:sorting="approvalSorting"
-          :data="platform.approvals"
-          :columns="approvalColumns"
-          class="flex-1"
-        />
-        <div v-else class="text-center text-(--ui-text-muted) py-8">
-          No approvals yet.
-        </div>
-      </UCard>
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-8">
+            No approvals yet.
+          </div>
+        </template>
+      </PaginatedTable>
 
       <!-- Set TIME Category Modal -->
       <UModal v-model:open="approvalModalOpen">
@@ -202,26 +188,9 @@ interface PlatformResponse {
   data: PlatformDetailData
 }
 
-function getTimeCategoryColor(category: string): 'success' | 'warning' | 'error' | 'neutral' {
-  const colors: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-    invest: 'success',
-    tolerate: 'warning',
-    migrate: 'warning',
-    eliminate: 'error'
-  }
-  return colors[category?.toLowerCase()] || 'neutral'
-}
-
 function formatDate(dateString: string): string {
   if (!dateString) return '—'
   return new Date(dateString).toLocaleDateString()
-}
-
-function getEnvironmentColor(environment: string | null | undefined): 'error' | 'warning' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'neutral'> = {
-    prod: 'error', staging: 'warning', test: 'neutral', dev: 'neutral'
-  }
-  return colors[environment || ''] || 'neutral'
 }
 
 const approvalColumns: TableColumn<TechnologyApproval>[] = [
@@ -282,6 +251,13 @@ const timeCategory = computed(() => {
   const approval = platform.value?.approvals?.[0]
   return approval?.time || null
 })
+
+const basicInfoItems = computed(() => [
+  { key: 'type', label: 'Type', value: platform.value?.type },
+  { key: 'domain', label: 'Domain', value: platform.value?.domain },
+  { key: 'vendor', label: 'Vendor', value: platform.value?.vendor },
+  { key: 'stewardTeam', label: 'Steward Team', value: platform.value?.stewardTeamName }
+])
 
 // Approval modal state
 const approvalModalOpen = ref(false)

--- a/app/pages/platforms/index.vue
+++ b/app/pages/platforms/index.vue
@@ -31,32 +31,23 @@
       :description="error.message"
     />
 
-    <UCard v-else>
-      <UTable
-        v-model:sorting="sorting"
-        :manual-sorting="true"
-        :data="platforms"
-        :columns="columns"
-        :loading="pending"
-        class="flex-1"
-      >
-        <template #empty>
-          <div class="text-center text-(--ui-text-muted) py-12">
-            No platforms found.
-          </div>
-        </template>
-      </UTable>
-
-      <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-        <UPagination
-          v-model:page="page"
-          :total="total"
-          :items-per-page="pageSize"
-          :sibling-count="1"
-          show-edges
-        />
-      </div>
-    </UCard>
+    <PaginatedTable
+      v-else
+      v-model:sorting="sorting"
+      v-model:page="page"
+      :manual-sorting="true"
+      :data="platforms"
+      :columns="columns"
+      :loading="pending"
+      :total="total"
+      :page-size="pageSize"
+    >
+      <template #empty>
+        <div class="text-center text-(--ui-text-muted) py-12">
+          No platforms found.
+        </div>
+      </template>
+    </PaginatedTable>
 
     <!-- Edit Platform Modal -->
     <UModal v-model:open="editModalOpen" :ui="{ footer: 'justify-end' }">
@@ -421,22 +412,14 @@ async function onSetTime(event: FormSubmitEvent<TimeSchema>) {
   }
 }
 
-const sorting = ref([])
-const page = ref(1)
-const pageSize = 20
-
-watch(sorting, () => { page.value = 1 })
-
-const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
-const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
-const offset = computed(() => (page.value - 1) * pageSize)
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
 
 const { data, pending, error } = await useFetch<ApiResponse<Platform>>('/api/platforms', {
   query: { limit: pageSize, offset, sortBy, sortOrder }
 })
 
-const platforms = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const platforms = useApiData(data)
+const total = useApiCount(data)
 
 useHead({ title: 'Platforms - Polaris' })
 </script>

--- a/app/pages/systems/[name]/index.vue
+++ b/app/pages/systems/[name]/index.vue
@@ -23,51 +23,8 @@
 
       <UCard>
         <template #header>
-          <h2 class="text-lg font-semibold">Overview</h2>
-        </template>
-        <div class="grid grid-cols-2 sm:grid-cols-4 gap-x-6 gap-y-4">
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Domain</span>
-            <p class="font-medium mt-0.5">{{ data.data.domain || '—' }}</p>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Environment</span>
-            <p class="font-medium mt-0.5">{{ data.data.environment || '—' }}</p>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Owner</span>
-            <p class="font-medium mt-0.5">
-              <NuxtLink
-                v-if="data.data.ownerTeam"
-                :to="`/teams/${encodeURIComponent(data.data.ownerTeam)}`"
-                class="hover:underline"
-              >
-                {{ data.data.ownerTeam }}
-              </NuxtLink>
-              <span v-else class="text-(--ui-text-muted)">No owner assigned</span>
-            </p>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Criticality</span>
-            <div class="mt-0.5">
-              <UBadge :color="getCriticalityColor(data.data.businessCriticality)" variant="subtle">
-                {{ data.data.businessCriticality || '—' }}
-              </UBadge>
-            </div>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Components</span>
-            <p class="font-medium mt-0.5">{{ data.data.componentCount || 0 }}</p>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Repositories</span>
-            <p class="font-medium mt-0.5">{{ data.data.repositoryCount || 0 }}</p>
-          </div>
-          <div>
-            <span class="text-sm text-(--ui-text-muted)">Last BOM Scan</span>
-            <p class="font-medium mt-0.5">{{ data.data.lastSbomScanAt ? formatDate(data.data.lastSbomScanAt) : '—' }}</p>
-          </div>
-          <div class="flex items-end">
+          <div class="flex justify-between items-center">
+            <h2 class="text-lg font-semibold">Overview</h2>
             <UButton
               label="View All Components"
               :to="`/components?system=${encodeURIComponent(data.data.name)}`"
@@ -75,30 +32,41 @@
               size="sm"
             />
           </div>
-        </div>
+        </template>
+        <EntityDescriptionList :items="overviewItems">
+          <template #owner="{ item }">
+            <p class="font-medium mt-0.5">
+              <NuxtLink v-if="item.value" :to="`/teams/${encodeURIComponent(String(item.value))}`" class="hover:underline">
+                {{ item.value }}
+              </NuxtLink>
+              <span v-else class="text-(--ui-text-muted)">No owner assigned</span>
+            </p>
+          </template>
+          <template #criticality="{ item }">
+            <div class="mt-0.5">
+              <UBadge :color="getCriticalityColor(String(item.value))" variant="subtle">
+                {{ item.value || '—' }}
+              </UBadge>
+            </div>
+          </template>
+        </EntityDescriptionList>
       </UCard>
 
       <SystemIssues v-if="issuesData?.data" :issues="issuesData.data" />
 
-      <UCard v-if="repositories.length > 0">
+      <PaginatedTable
+        v-if="repositories.length > 0"
+        v-model:sorting="repoSorting"
+        :data="repositories"
+        :columns="repositoryColumns"
+      >
         <template #header>
           <div class="flex items-center gap-2">
             <UIcon name="i-lucide-git-branch" class="w-5 h-5 text-(--ui-primary)" />
             <h2 class="text-lg font-semibold">Repositories</h2>
           </div>
         </template>
-        <div class="divide-y divide-(--ui-border)">
-          <div v-for="repo in repositories" :key="repo.url" class="flex items-center justify-between gap-4 py-3">
-            <NuxtLink :to="repo.url" target="_blank" rel="noopener noreferrer" class="flex items-center gap-2 text-sm font-medium hover:underline min-w-0">
-              <UIcon name="i-lucide-github" class="size-4 shrink-0 text-(--ui-text-muted)" />
-              <span class="truncate">{{ repo.name }}</span>
-            </NuxtLink>
-            <span class="text-xs text-(--ui-text-muted) shrink-0">
-              {{ repo.lastSbomScanAt ? formatDate(repo.lastSbomScanAt) : 'Not scanned' }}
-            </span>
-          </div>
-        </div>
-      </UCard>
+      </PaginatedTable>
 
       <UCard v-if="data.data.componentCount > 0">
         <template #header>
@@ -123,9 +91,11 @@
 </template>
 
 <script setup lang="ts">
-import { defineAsyncComponent } from 'vue'
+import { defineAsyncComponent, h } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
 
 const route = useRoute()
+const { getSortableHeader } = useSortableTable()
 
 const AsyncSystemDependencyGraph = defineAsyncComponent(() => import('../../../components/SystemDependencyGraph.vue'))
 
@@ -239,15 +209,45 @@ function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleString()
 }
 
-function getCriticalityColor(criticality: string): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    critical: 'error',
-    high: 'warning',
-    medium: 'success',
-    low: 'neutral'
+const overviewItems = computed(() => {
+  const system = data.value?.data
+  if (!system) return []
+  return [
+    { key: 'domain', label: 'Domain', value: system.domain },
+    { key: 'environment', label: 'Environment', value: system.environment },
+    { key: 'owner', label: 'Owner', value: system.ownerTeam },
+    { key: 'criticality', label: 'Criticality', value: system.businessCriticality },
+    { key: 'components', label: 'Components', value: system.componentCount || 0 },
+    { key: 'repositories', label: 'Repositories', value: system.repositoryCount || 0 },
+    { key: 'lastScan', label: 'Last BOM Scan', value: system.lastSbomScanAt ? formatDate(system.lastSbomScanAt) : null }
+  ]
+})
+
+const repoSorting = ref([])
+
+const repositoryColumns: TableColumn<Repository>[] = [
+  {
+    accessorKey: 'name',
+    header: ({ column }) => getSortableHeader(column, 'Repository'),
+    cell: ({ row }) => h(resolveComponent('NuxtLink'), {
+      to: row.original.url,
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      class: 'flex items-center gap-2 font-medium hover:underline'
+    }, () => [
+      h(resolveComponent('UIcon'), { name: 'i-lucide-github', class: 'size-4 shrink-0 text-(--ui-text-muted)' }),
+      row.original.name
+    ])
+  },
+  {
+    accessorKey: 'lastSbomScanAt',
+    header: ({ column }) => getSortableHeader(column, 'Last Scan'),
+    cell: ({ row }) => {
+      const scanDate = row.original.lastSbomScanAt
+      return scanDate ? formatDate(scanDate) : h('span', { class: 'text-(--ui-text-muted)' }, 'Not scanned')
+    }
   }
-  return colors[criticality?.toLowerCase()] || 'neutral'
-}
+]
 
 useHead({
   title: computed(() => data.value?.data ? `${data.value.data.name} - Polaris` : 'System - Polaris')

--- a/app/pages/systems/index.vue
+++ b/app/pages/systems/index.vue
@@ -33,45 +33,34 @@
     />
 
     <template v-else>
-      <UCard>
-        <div class="pb-4 border-b border-(--ui-border) mb-4">
+      <PaginatedTable
+        v-model:sorting="sorting"
+        v-model:page="page"
+        :manual-sorting="true"
+        :data="systems"
+        :columns="columns"
+        :loading="pending"
+        :total="total"
+        :page-size="pageSize"
+      >
+        <template #header>
           <UInput
             v-model="searchInput"
             placeholder="Filter by name..."
             icon="i-lucide-search"
             class="max-w-sm"
           />
-        </div>
-
-        <UTable
-          v-model:sorting="sorting"
-          :manual-sorting="true"
-          :data="systems"
-          :columns="columns"
-          :loading="pending"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center py-12">
-              <UIcon name="i-lucide-inbox" class="text-5xl text-(--ui-text-muted)" />
-              <h3 class="mt-4">No Systems Found</h3>
-              <p class="text-(--ui-text-muted) mt-2">
-                The database appears to be empty. Try running: <code>npm run seed</code>
-              </p>
-            </div>
-          </template>
-        </UTable>
-
-        <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-          <UPagination
-            v-model:page="page"
-            :total="total"
-            :items-per-page="pageSize"
-            :sibling-count="1"
-            show-edges
-          />
-        </div>
-      </UCard>
+        </template>
+        <template #empty>
+          <div class="text-center py-12">
+            <UIcon name="i-lucide-inbox" class="text-5xl text-(--ui-text-muted)" />
+            <h3 class="mt-4">No Systems Found</h3>
+            <p class="text-(--ui-text-muted) mt-2">
+              The database appears to be empty. Try running: <code>npm run seed</code>
+            </p>
+          </div>
+        </template>
+      </PaginatedTable>
     </template>
 
     <!-- Import from GitHub Modal -->
@@ -357,6 +346,7 @@ import { h } from 'vue'
 import { useDebounceFn } from '@vueuse/core'
 import * as z from 'zod'
 import type { TableColumn, FormSubmitEvent } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
 
 const { status } = useAuth()
 const { isSuperuser } = useEffectiveRole()
@@ -373,13 +363,6 @@ interface System {
 }
 
 const actionInProgress = ref<Set<string>>(new Set())
-
-interface SystemsResponse {
-  success: boolean
-  data: System[]
-  count: number
-  total?: number
-}
 
 async function triggerHealthRefresh(system: System) {
   if (actionInProgress.value.has(system.name)) return
@@ -436,16 +419,6 @@ async function triggerRescan(system: System) {
     next.delete(system.name)
     actionInProgress.value = next
   }
-}
-
-function getCriticalityColor(criticality: string): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    critical: 'error',
-    high: 'warning',
-    medium: 'success',
-    low: 'neutral'
-  }
-  return colors[criticality] || 'neutral'
 }
 
 const columns: TableColumn<System>[] = [
@@ -515,28 +488,20 @@ const columns: TableColumn<System>[] = [
   }
 ]
 
-const sorting = ref([])
-const page = ref(1)
-const pageSize = 20
-
 const searchInput = ref('')
 const debouncedSearch = ref('')
-
-watch([debouncedSearch, sorting], () => { page.value = 1 })
 
 const updateSearch = useDebounceFn((value: string) => { debouncedSearch.value = value }, 300)
 watch(searchInput, updateSearch)
 
-const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
-const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
-const offset = computed(() => (page.value - 1) * pageSize)
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({ resetOn: [debouncedSearch] })
 
-const { data, pending, error } = await useFetch<SystemsResponse>('/api/systems', {
+const { data, pending, error } = await useFetch<ApiResponse<System>>('/api/systems', {
   query: { limit: pageSize, offset, sortBy, sortOrder, search: debouncedSearch }
 })
 
-const systems = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const systems = useApiData(data)
+const total = useApiCount(data)
 
 // --- Import from GitHub ---
 

--- a/app/pages/teams/[name].vue
+++ b/app/pages/teams/[name].vue
@@ -21,60 +21,43 @@
         :description="data.data.description"
         :links="[{ label: 'Back to Teams', to: '/teams', icon: 'i-lucide-arrow-left', variant: 'outline' as const }]"
       />
+      <p v-if="data.data.responsibilityArea" class="text-sm text-(--ui-text-muted) -mt-4">
+        Responsibility: <span class="text-(--ui-text)">{{ data.data.responsibilityArea }}</span>
+      </p>
 
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Technologies Owned</p>
-            <p class="text-2xl font-bold mt-1">{{ data.data.technologyCount || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Systems</p>
-            <p class="text-2xl font-bold mt-1">{{ data.data.systemCount || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Members</p>
-            <p class="text-2xl font-bold mt-1">{{ data.data.memberCount || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Responsibility</p>
-            <p class="text-2xl font-bold mt-1">{{ data.data.responsibilityArea || '—' }}</p>
-          </div>
-        </UCard>
-      </div>
+      <EntityStatStrip :items="statItems" />
 
-      <UCard v-if="data.data.members && data.data.members.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Members ({{ data.data.members.length }})</h2>
-        </template>
-        <UTable v-model:sorting="memberSorting" :data="data.data.members" :columns="memberColumns" class="flex-1" />
-      </UCard>
-
-      <UCard v-if="data.data.technologies && data.data.technologies.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Technologies ({{ data.data.technologies.length }})</h2>
-        </template>
-        <UTable v-model:sorting="technologySorting" :data="data.data.technologies" :columns="technologyColumns" class="flex-1" />
-      </UCard>
-
-      <UCard v-if="data.data.systems && data.data.systems.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Systems ({{ data.data.systems.length }})</h2>
-        </template>
-        <UTable v-model:sorting="systemSorting" :data="data.data.systems" :columns="systemColumns" class="flex-1" />
-      </UCard>
-
-      <UCard v-if="data.data.approvals && data.data.approvals.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Technology Approvals ({{ data.data.approvals.length }})</h2>
-        </template>
-        <UTable v-model:sorting="approvalSorting" :data="data.data.approvals" :columns="approvalColumns" class="flex-1" />
+      <UCard>
+        <UTabs :items="tabItems">
+          <template #members>
+            <UTable v-model:sorting="memberSorting" :data="data.data.members" :columns="memberColumns" class="mt-3">
+              <template #empty>
+                <p class="text-sm text-(--ui-text-muted) py-4 text-center">No members.</p>
+              </template>
+            </UTable>
+          </template>
+          <template #technologies>
+            <UTable v-model:sorting="technologySorting" :data="data.data.technologies" :columns="technologyColumns" class="mt-3">
+              <template #empty>
+                <p class="text-sm text-(--ui-text-muted) py-4 text-center">No technologies owned.</p>
+              </template>
+            </UTable>
+          </template>
+          <template #systems>
+            <UTable v-model:sorting="systemSorting" :data="data.data.systems" :columns="systemColumns" class="mt-3">
+              <template #empty>
+                <p class="text-sm text-(--ui-text-muted) py-4 text-center">No systems.</p>
+              </template>
+            </UTable>
+          </template>
+          <template #approvals>
+            <UTable v-model:sorting="approvalSorting" :data="data.data.approvals" :columns="approvalColumns" class="mt-3">
+              <template #empty>
+                <p class="text-sm text-(--ui-text-muted) py-4 text-center">No technology approvals yet.</p>
+              </template>
+            </UTable>
+          </template>
+        </UTabs>
       </UCard>
     </template>
   </div>
@@ -134,16 +117,6 @@ interface TeamDetail {
 interface TeamResponse {
   success: boolean
   data: TeamDetail
-}
-
-function getTimeCategoryColor(category: string): 'success' | 'warning' | 'error' | 'neutral' {
-  const colors: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-    invest: 'success',
-    tolerate: 'warning',
-    migrate: 'warning',
-    eliminate: 'error'
-  }
-  return colors[category?.toLowerCase()] || 'neutral'
 }
 
 const memberColumns: TableColumn<Member>[] = [
@@ -254,6 +227,19 @@ const approvalColumns: TableColumn<Approval>[] = [
 ]
 
 const { data, pending, error } = await useFetch<TeamResponse>(() => `/api/teams/${encodeURIComponent(route.params.name as string)}`)
+
+const statItems = computed(() => [
+  { label: 'Technologies Owned', value: data.value?.data?.technologyCount || 0 },
+  { label: 'Systems', value: data.value?.data?.systemCount || 0 },
+  { label: 'Members', value: data.value?.data?.memberCount || 0 }
+])
+
+const tabItems = computed(() => [
+  { label: `Members (${data.value?.data?.members?.length ?? 0})`, slot: 'members' as const },
+  { label: `Technologies (${data.value?.data?.technologies?.length ?? 0})`, slot: 'technologies' as const },
+  { label: `Systems (${data.value?.data?.systems?.length ?? 0})`, slot: 'systems' as const },
+  { label: `Approvals (${data.value?.data?.approvals?.length ?? 0})`, slot: 'approvals' as const }
+])
 
 useHead({
   title: computed(() => data.value?.data ? `${data.value.data.name} - Polaris` : 'Team - Polaris')

--- a/app/pages/teams/index.vue
+++ b/app/pages/teams/index.vue
@@ -23,32 +23,22 @@
     />
 
     <template v-else>
-      <UCard>
-        <UTable
-          v-model:sorting="sorting"
-          :manual-sorting="true"
-          :data="teams"
-          :columns="columns"
-          :loading="pending"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center text-(--ui-text-muted) py-12">
-              No teams found.
-            </div>
-          </template>
-        </UTable>
-
-        <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-          <UPagination
-            v-model:page="page"
-            :total="total"
-            :items-per-page="pageSize"
-            :sibling-count="1"
-            show-edges
-          />
-        </div>
-      </UCard>
+      <PaginatedTable
+        v-model:sorting="sorting"
+        v-model:page="page"
+        :manual-sorting="true"
+        :data="teams"
+        :columns="columns"
+        :loading="pending"
+        :total="total"
+        :page-size="pageSize"
+      >
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-12">
+            No teams found.
+          </div>
+        </template>
+      </PaginatedTable>
     </template>
 
     <!-- Create Team Modal -->
@@ -292,26 +282,14 @@ const columns = computed(() => {
   return baseColumns
 })
 
-const sorting = ref([])
-watch(sorting, () => { page.value = 1 })
-const page = ref(1)
-const pageSize = 20
-
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = { limit: pageSize, offset: (page.value - 1) * pageSize }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
-})
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
 
 const { data, pending, error } = await useFetch<ApiResponse<Team>>('/api/teams', {
-  query: queryParams
+  query: { limit: pageSize, offset, sortBy, sortOrder }
 })
 
-const teams = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const teams = useApiData(data)
+const total = useApiCount(data)
 
 // --- Create Team ---
 

--- a/app/pages/technologies/[name].vue
+++ b/app/pages/technologies/[name].vue
@@ -31,86 +31,27 @@
           <UBadge v-if="timeCategory" :color="getTimeCategoryColor(timeCategory)" variant="subtle">
             {{ timeCategory }}
           </UBadge>
+          <UBadge :color="getEolColor(tech.lifecycleSummary?.status)" variant="subtle">
+            {{ getEolLabel(tech.lifecycleSummary?.status) }}
+          </UBadge>
         </div>
       </div>
 
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Versions</p>
-            <p class="text-2xl font-bold mt-1">{{ distinctVersionCount }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Components</p>
-            <p class="text-2xl font-bold mt-1">{{ tech.components?.length || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Systems</p>
-            <p class="text-2xl font-bold mt-1">{{ tech.systems?.length || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Lifecycle</p>
-            <p class="mt-2">
-              <UBadge :color="getEolColor(tech.lifecycleSummary?.status)" variant="subtle">
-                {{ getEolLabel(tech.lifecycleSummary?.status) }}
-              </UBadge>
-            </p>
-          </div>
-        </UCard>
-      </div>
+      <EntityStatStrip :items="statItems" />
 
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <UCard>
-          <template #header>
-            <h2 class="text-lg font-semibold">Basic Information</h2>
-          </template>
-          <div class="space-y-3">
-            <div>
-              <span class="text-sm text-(--ui-text-muted)">Type</span>
-              <p class="font-medium">{{ tech.type || '—' }}</p>
-            </div>
-            <div>
-              <span class="text-sm text-(--ui-text-muted)">Domain</span>
-              <p class="font-medium">{{ tech.domain || '—' }}</p>
-            </div>
-            <div>
-              <span class="text-sm text-(--ui-text-muted)">Vendor</span>
-              <p class="font-medium">{{ tech.vendor || '—' }}</p>
-            </div>
-            <div>
-              <span class="text-sm text-(--ui-text-muted)">Last Reviewed</span>
-              <p class="font-medium">{{ tech.lastReviewed ? formatDate(tech.lastReviewed) : '—' }}</p>
-            </div>
-          </div>
-        </UCard>
-
-        <!-- Version Risk -->
-        <UCard>
-          <template #header>
-            <h2 class="text-lg font-semibold">Version Risk</h2>
-          </template>
-          <UTable
-            v-if="versionRiskData && versionRiskData.length > 0"
-            v-model:sorting="versionRiskSorting"
-            :data="versionRiskData"
-            :columns="versionRiskColumns"
-            class="flex-1"
-          />
-          <div v-else class="text-center text-(--ui-text-muted) py-8">
-            No versions found.
-          </div>
-        </UCard>
-
-      </div>
+      <UCard>
+        <template #header>
+          <h2 class="text-lg font-semibold">Basic Information</h2>
+        </template>
+        <EntityDescriptionList :items="basicInfoItems" />
+      </UCard>
 
       <!-- Technology Approvals -->
-      <UCard>
+      <PaginatedTable
+        v-model:sorting="approvalSorting"
+        :data="tech.technologyApprovals ?? []"
+        :columns="approvalColumns"
+      >
         <template #header>
           <div class="flex justify-between items-center">
             <h2 class="text-lg font-semibold">Approvals ({{ tech.technologyApprovals?.length || 0 }})</h2>
@@ -124,17 +65,12 @@
             />
           </div>
         </template>
-        <UTable
-          v-if="tech.technologyApprovals && tech.technologyApprovals.length > 0"
-          v-model:sorting="approvalSorting"
-          :data="tech.technologyApprovals"
-          :columns="approvalColumns"
-          class="flex-1"
-        />
-        <div v-else class="text-center text-(--ui-text-muted) py-8">
-          No approvals yet.
-        </div>
-      </UCard>
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-8">
+            No approvals yet.
+          </div>
+        </template>
+      </PaginatedTable>
 
       <!-- Set TIME Category Modal -->
       <UModal v-model:open="approvalModalOpen">
@@ -208,27 +144,62 @@
         </template>
       </UModal>
 
-      <!-- Versions -->
-      <UCard v-if="tech.versions && tech.versions.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Versions ({{ tech.versions.length }})</h2>
-        </template>
-        <UTable v-model:sorting="versionSorting" :data="versionRows" :columns="versionColumns" class="flex-1" />
-      </UCard>
+      <!-- Version Risk, Versions, Components, Version Constraints — kept in one card:
+           version rows carry live violation warnings cross-referenced against
+           Components and Version Constraints (see getVersionViolation), so these
+           stay visible together rather than split behind tabs. -->
+      <UCard>
+        <div class="divide-y divide-(--ui-border)">
+          <div class="first:pt-0 last:pb-0 py-6">
+            <h3 class="text-base font-semibold mb-3">Version Risk</h3>
+            <UTable
+              v-if="versionRiskData && versionRiskData.length > 0"
+              v-model:sorting="versionRiskSorting"
+              :data="versionRiskData"
+              :columns="versionRiskColumns"
+              class="flex-1"
+            />
+            <div v-else class="text-center text-(--ui-text-muted) py-8">
+              No versions found.
+            </div>
+          </div>
 
-      <!-- Components -->
-      <UCard v-if="tech.components && tech.components.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Components ({{ tech.components.length }})</h2>
-        </template>
-        <UTable v-model:sorting="componentSorting" :data="tech.components" :columns="componentColumns" class="flex-1" />
+          <div v-if="tech.versions && tech.versions.length > 0" class="first:pt-0 last:pb-0 py-6">
+            <h3 class="text-base font-semibold mb-3">Versions ({{ tech.versions.length }})</h3>
+            <UTable v-model:sorting="versionSorting" :data="versionRows" :columns="versionColumns" class="flex-1" />
+          </div>
+
+          <div v-if="tech.components && tech.components.length > 0" class="first:pt-0 last:pb-0 py-6">
+            <h3 class="text-base font-semibold mb-3">Components ({{ tech.components.length }})</h3>
+            <UTable v-model:sorting="componentSorting" :data="tech.components" :columns="componentColumns" class="flex-1" />
+          </div>
+
+          <div v-if="tech.constraints && tech.constraints.length > 0" class="first:pt-0 last:pb-0 py-6">
+            <h3 class="text-base font-semibold mb-3">Version Constraints ({{ tech.constraints.length }})</h3>
+            <div class="flex flex-wrap gap-2">
+              <UButton
+                v-for="vc in tech.constraints"
+                :key="vc.name"
+                :label="vc.name"
+                :to="`/version-constraints/${encodeURIComponent(vc.name)}`"
+                variant="subtle"
+                color="neutral"
+                size="sm"
+              >
+                <template #trailing>
+                  <UBadge :color="getSeverityColor(vc.severity)" variant="subtle" size="xs">
+                    {{ vc.severity }}
+                  </UBadge>
+                </template>
+              </UButton>
+            </div>
+          </div>
+        </div>
       </UCard>
 
       <!-- Systems -->
-      <UCard v-if="tech.systems && tech.systems.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Systems ({{ tech.systems.length }})</h2>
-        </template>
+      <div v-if="tech.systems && tech.systems.length > 0">
+        <h2 class="text-lg font-semibold mb-3">Systems ({{ tech.systems.length }})</h2>
         <div class="flex flex-wrap gap-2">
           <UButton
             v-for="system in tech.systems"
@@ -240,31 +211,7 @@
             size="sm"
           />
         </div>
-      </UCard>
-
-      <!-- Version Constraints -->
-      <UCard v-if="tech.constraints && tech.constraints.length > 0">
-        <template #header>
-          <h2 class="text-lg font-semibold">Version Constraints ({{ tech.constraints.length }})</h2>
-        </template>
-        <div class="flex flex-wrap gap-2">
-          <UButton
-            v-for="vc in tech.constraints"
-            :key="vc.name"
-            :label="vc.name"
-            :to="`/version-constraints/${encodeURIComponent(vc.name)}`"
-            variant="subtle"
-            color="neutral"
-            size="sm"
-          >
-            <template #trailing>
-              <UBadge :color="getSeverityColor(vc.severity)" variant="subtle" size="xs">
-                {{ vc.severity }}
-              </UBadge>
-            </template>
-          </UButton>
-        </div>
-      </UCard>
+      </div>
     </template>
   </div>
 </template>
@@ -360,26 +307,6 @@ interface TechnologyResponse {
   data: TechnologyDetailData
 }
 
-function getTimeCategoryColor(category: string): 'success' | 'warning' | 'error' | 'neutral' {
-  const colors: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-    invest: 'success',
-    tolerate: 'warning',
-    migrate: 'warning',
-    eliminate: 'error'
-  }
-  return colors[category?.toLowerCase()] || 'neutral'
-}
-
-function getSeverityColor(severity: string): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    critical: 'error',
-    error: 'error',
-    warning: 'warning',
-    info: 'neutral'
-  }
-  return colors[severity?.toLowerCase()] || 'neutral'
-}
-
 function getEolColor(status?: EOLStatusValue): 'success' | 'warning' | 'error' | 'neutral' {
   const colors: Record<EOLStatusValue, 'success' | 'warning' | 'error' | 'neutral'> = {
     active: 'success',
@@ -469,13 +396,6 @@ const versionColumns: TableColumn<VersionDetail>[] = [
     }
   }
 ]
-
-function getEnvironmentColor(environment: string | null | undefined): 'error' | 'warning' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'neutral'> = {
-    prod: 'error', staging: 'warning', test: 'neutral', dev: 'neutral'
-  }
-  return colors[environment || ''] || 'neutral'
-}
 
 const approvalColumns: TableColumn<TechnologyApproval>[] = [
   {
@@ -698,6 +618,19 @@ const timeCategory = computed(() => {
   const approval = tech.value?.technologyApprovals?.[0]
   return approval?.time || null
 })
+
+const statItems = computed(() => [
+  { label: 'Versions', value: distinctVersionCount.value },
+  { label: 'Components', value: tech.value?.components?.length || 0 },
+  { label: 'Systems', value: tech.value?.systems?.length || 0 }
+])
+
+const basicInfoItems = computed(() => [
+  { key: 'type', label: 'Type', value: tech.value?.type },
+  { key: 'domain', label: 'Domain', value: tech.value?.domain },
+  { key: 'vendor', label: 'Vendor', value: tech.value?.vendor },
+  { key: 'lastReviewed', label: 'Last Reviewed', value: tech.value?.lastReviewed ? formatDate(tech.value.lastReviewed) : null }
+])
 
 // Approval modal state
 const approvalModalOpen = ref(false)

--- a/app/pages/technologies/index.vue
+++ b/app/pages/technologies/index.vue
@@ -45,32 +45,23 @@
 
     <template v-else>
       <!-- Table view -->
-      <UCard v-if="viewMode === 'table'">
-        <UTable
-          v-model:sorting="sorting"
-          :manual-sorting="true"
-          :data="technologies"
-          :columns="columns"
-          :loading="pending"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center text-(--ui-text-muted) py-12">
-              No technologies found.
-            </div>
-          </template>
-        </UTable>
-
-        <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-          <UPagination
-            v-model:page="page"
-            :total="total"
-            :items-per-page="pageSize"
-            :sibling-count="1"
-            show-edges
-          />
-        </div>
-      </UCard>
+      <PaginatedTable
+        v-if="viewMode === 'table'"
+        v-model:sorting="sorting"
+        v-model:page="page"
+        :manual-sorting="true"
+        :data="technologies"
+        :columns="columns"
+        :loading="pending"
+        :total="total"
+        :page-size="pageSize"
+      >
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-12">
+            No technologies found.
+          </div>
+        </template>
+      </PaginatedTable>
 
       <!-- Radar view -->
       <template v-if="viewMode === 'radar'">
@@ -724,22 +715,14 @@ async function confirmLinkComponent() {
   }
 }
 
-const sorting = ref([])
-const page = ref(1)
-const pageSize = 20
-
-watch(sorting, () => { page.value = 1 })
-
-const sortBy = computed(() => sorting.value.length ? sorting.value[0].id : undefined)
-const sortOrder = computed(() => sorting.value.length ? (sorting.value[0].desc ? 'desc' : 'asc') : undefined)
-const offset = computed(() => (page.value - 1) * pageSize)
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
 
 const { data, pending, error } = await useFetch<ApiResponse<Technology>>('/api/technologies', {
   query: { limit: pageSize, offset, sortBy, sortOrder }
 })
 
-const technologies = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const technologies = useApiData(data)
+const total = useApiCount(data)
 
 // ── View mode (declared after await so it's bound to the correct component instance) ──
 const LS_KEY = 'polaris:technologies:viewMode'

--- a/app/pages/users/[id].vue
+++ b/app/pages/users/[id].vue
@@ -34,48 +34,20 @@
       </div>
 
       <!-- Stats -->
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-4">
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Teams</p>
-            <p class="text-2xl font-bold mt-1">{{ user.teams?.length || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Can Manage</p>
-            <p class="text-2xl font-bold mt-1">{{ user.canManage?.length || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">API Tokens</p>
-            <p class="text-2xl font-bold mt-1">{{ user.tokens?.length || 0 }}</p>
-          </div>
-        </UCard>
-        <UCard>
-          <div class="text-center">
-            <p class="text-sm text-(--ui-text-muted)">Last Login</p>
-            <p class="text-sm font-medium mt-1">{{ user.lastLogin ? new Date(user.lastLogin).toLocaleDateString() : '—' }}</p>
-          </div>
-        </UCard>
-      </div>
+      <EntityStatStrip :items="statItems" />
 
-      <!-- Teams -->
-      <UCard v-if="user.teams?.length">
+      <!-- Account -->
+      <UCard>
         <template #header>
-          <h3 class="text-lg font-semibold">Team Memberships</h3>
+          <h3 class="text-lg font-semibold">Account</h3>
         </template>
-        <UTable :data="user.teams" :columns="teamColumns" />
+        <EntityDescriptionList :items="accountItems" />
       </UCard>
 
-      <!-- API Tokens (technical users only) -->
-      <UCard v-if="user.provider === 'technical'">
-        <template #header>
-          <div class="flex justify-between items-center">
-            <h3 class="text-lg font-semibold">API Tokens</h3>
+      <UCard>
+        <template v-if="user.provider === 'technical' && isSuperuser" #header>
+          <div class="flex justify-end">
             <UButton
-              v-if="isSuperuser"
               label="Generate Token"
               icon="i-lucide-key"
               size="sm"
@@ -83,21 +55,31 @@
             />
           </div>
         </template>
-        <UTable :data="user.tokens || []" :columns="tokenColumns">
-          <template #empty>
-            <div class="text-center text-(--ui-text-muted) py-8">
-              No API tokens generated yet.
-            </div>
+        <UTabs :items="tabItems">
+          <template #teams>
+            <UTable :data="user.teams" :columns="teamColumns" class="mt-3">
+              <template #empty>
+                <p class="text-sm text-(--ui-text-muted) py-4 text-center">No team memberships.</p>
+              </template>
+            </UTable>
           </template>
-        </UTable>
-      </UCard>
-
-      <!-- Recent Activity -->
-      <UCard v-if="user.recentActivity?.length">
-        <template #header>
-          <h3 class="text-lg font-semibold">Recent Activity</h3>
-        </template>
-        <UTable :data="user.recentActivity" :columns="activityColumns" />
+          <template v-if="user.provider === 'technical'" #tokens>
+            <UTable :data="user.tokens || []" :columns="tokenColumns" class="mt-3">
+              <template #empty>
+                <div class="text-center text-(--ui-text-muted) py-8">
+                  No API tokens generated yet.
+                </div>
+              </template>
+            </UTable>
+          </template>
+          <template #activity>
+            <UTable :data="user.recentActivity" :columns="activityColumns" class="mt-3">
+              <template #empty>
+                <p class="text-sm text-(--ui-text-muted) py-4 text-center">No recent activity.</p>
+              </template>
+            </UTable>
+          </template>
+        </UTabs>
       </UCard>
 
       <!-- Generate Token Modal -->
@@ -217,6 +199,28 @@ const { data, pending, error, refresh } = await useFetch<UserResponse>(
 )
 
 const user = computed(() => data.value?.data || null)
+
+const statItems = computed(() => [
+  { label: 'Teams', value: user.value?.teams?.length || 0 },
+  { label: 'Can Manage', value: user.value?.canManage?.length || 0 },
+  { label: 'API Tokens', value: user.value?.tokens?.length || 0 }
+])
+
+const accountItems = computed(() => [
+  { key: 'lastLogin', label: 'Last Login', value: user.value?.lastLogin ? new Date(user.value.lastLogin).toLocaleDateString() : null },
+  { key: 'createdAt', label: 'Created', value: user.value?.createdAt ? new Date(user.value.createdAt).toLocaleDateString() : null }
+])
+
+const tabItems = computed(() => {
+  const items: { label: string; slot: 'teams' | 'tokens' | 'activity' }[] = [
+    { label: `Teams (${user.value?.teams?.length ?? 0})`, slot: 'teams' }
+  ]
+  if (user.value?.provider === 'technical') {
+    items.push({ label: `API Tokens (${user.value?.tokens?.length ?? 0})`, slot: 'tokens' })
+  }
+  items.push({ label: `Recent Activity (${user.value?.recentActivity?.length ?? 0})`, slot: 'activity' })
+  return items
+})
 
 // Team columns
 const teamColumns: TableColumn<UserTeam>[] = [

--- a/app/pages/users/index.vue
+++ b/app/pages/users/index.vue
@@ -31,32 +31,23 @@
     />
 
     <!-- Users Table -->
-    <UCard v-else>
-      <UTable
-        v-model:sorting="sorting"
-          :manual-sorting="true"
-        :data="users"
-        :columns="columns"
-        :loading="pending"
-        class="flex-1"
-      >
-        <template #empty>
-          <div class="text-center text-(--ui-text-muted) py-12">
-            No users found.
-          </div>
-        </template>
-      </UTable>
-
-      <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-        <UPagination
-          v-model:page="page"
-          :total="total"
-          :items-per-page="pageSize"
-          :sibling-count="1"
-          show-edges
-        />
-      </div>
-    </UCard>
+    <PaginatedTable
+      v-else
+      v-model:sorting="sorting"
+      v-model:page="page"
+      :manual-sorting="true"
+      :data="users"
+      :columns="columns"
+      :loading="pending"
+      :total="total"
+      :page-size="pageSize"
+    >
+      <template #empty>
+        <div class="text-center text-(--ui-text-muted) py-12">
+          No users found.
+        </div>
+      </template>
+    </PaginatedTable>
 
     <!-- Manage Teams Modal -->
     <UModal v-model:open="assignModalOpen" title="Manage Team Memberships" description="Toggle team memberships for this user.">
@@ -283,6 +274,7 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
 
 const { getSortableHeader } = useSortableTable()
 const toast = useToast()
@@ -306,13 +298,6 @@ interface User {
   status?: string
   githubUsername?: string
   inviteToken?: string
-}
-
-interface UsersResponse {
-  success: boolean
-  data: User[]
-  count: number
-  total?: number
 }
 
 interface Team {
@@ -733,26 +718,14 @@ const columns: TableColumn<User>[] = [
   }
 ]
 
-const sorting = ref([])
-watch(sorting, () => { page.value = 1 })
-const page = ref(1)
-const pageSize = 20
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
 
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = { limit: pageSize, offset: (page.value - 1) * pageSize }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
+const { data, pending, error } = await useFetch<ApiResponse<User>>('/api/users', {
+  query: { limit: pageSize, offset, sortBy, sortOrder }
 })
 
-const { data, pending, error } = await useFetch<UsersResponse>('/api/users', {
-  query: queryParams
-})
-
-const users = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const users = useApiData(data)
+const total = useApiCount(data)
 
 function formatDate(dateString: string): string {
   return new Date(dateString).toLocaleDateString()

--- a/app/pages/version-constraints/[name].vue
+++ b/app/pages/version-constraints/[name].vue
@@ -32,71 +32,22 @@
         </div>
       </div>
 
-      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <UCard>
-          <template #header>
-            <h2 class="text-lg font-semibold">Details</h2>
-          </template>
-          <div class="space-y-3">
-            <div>
-              <span class="text-sm text-(--ui-text-muted)">Scope</span>
-              <p class="font-medium">
-                {{ data.data.scope }}
-                <span v-if="data.data.subjectTeam"> — {{ data.data.subjectTeam }}</span>
-              </p>
-            </div>
-            <div v-if="data.data.versionRange">
-              <span class="text-sm text-(--ui-text-muted)">Version Range</span>
-              <p class="font-medium"><code>{{ data.data.versionRange }}</code></p>
-            </div>
-            <div>
-              <span class="text-sm text-(--ui-text-muted)">Severity</span>
-              <p class="font-medium">
-                <UBadge :color="getSeverityColor(data.data.severity)" variant="subtle">
-                  {{ data.data.severity }}
-                </UBadge>
-              </p>
-            </div>
-            <div>
-              <span class="text-sm text-(--ui-text-muted)">Status</span>
-              <p class="font-medium">{{ data.data.status }}</p>
-            </div>
-          </div>
-        </UCard>
-
-        <UCard v-if="data.data.subjectTeams && data.data.subjectTeams.length > 0">
-          <template #header>
-            <h2 class="text-lg font-semibold">Subject Teams ({{ data.data.subjectTeams.length }})</h2>
-          </template>
-          <div class="flex flex-wrap gap-2">
-            <UButton
-              v-for="team in data.data.subjectTeams"
-              :key="team"
-              :label="team"
-              :to="`/teams/${encodeURIComponent(team)}`"
-              variant="subtle"
-              color="neutral"
-              size="sm"
-            />
-          </div>
-        </UCard>
-      </div>
-
-      <UCard v-if="data.data.governedTechnologies && data.data.governedTechnologies.length > 0">
+      <UCard>
         <template #header>
-          <h2 class="text-lg font-semibold">Governed Technologies ({{ data.data.governedTechnologies.length }})</h2>
+          <h2 class="text-lg font-semibold">Details</h2>
         </template>
-        <div class="flex flex-wrap gap-2">
-          <UButton
-            v-for="tech in data.data.governedTechnologies"
-            :key="tech"
-            :label="tech"
-            :to="`/technologies/${encodeURIComponent(tech)}`"
-            variant="subtle"
-            color="neutral"
-            size="sm"
-          />
-        </div>
+        <EntityDescriptionList :items="detailsItems">
+          <template #versionRange="{ item }">
+            <p class="font-medium mt-0.5"><code>{{ item.value }}</code></p>
+          </template>
+          <template #severity="{ item }">
+            <p class="font-medium mt-0.5">
+              <UBadge :color="getSeverityColor(String(item.value))" variant="subtle">
+                {{ item.value }}
+              </UBadge>
+            </p>
+          </template>
+        </EntityDescriptionList>
       </UCard>
     </template>
   </div>
@@ -131,12 +82,32 @@ function getStatusColor(status: string): 'success' | 'warning' | 'error' | 'neut
   return colors[status?.toLowerCase()] || 'neutral'
 }
 
-function getSeverityColor(severity: string): 'success' | 'warning' | 'error' | 'neutral' {
-  const colors: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-    critical: 'error', error: 'error', warning: 'warning', info: 'neutral'
-  }
-  return colors[severity?.toLowerCase()] || 'neutral'
-}
+const detailsItems = computed(() => {
+  const vc = data.value?.data
+  if (!vc) return []
+  return [
+    { key: 'scope', label: 'Scope', value: vc.subjectTeam ? `${vc.scope} — ${vc.subjectTeam}` : vc.scope },
+    ...(vc.versionRange ? [{ key: 'versionRange', label: 'Version Range', value: vc.versionRange }] : []),
+    { key: 'severity', label: 'Severity', value: vc.severity },
+    { key: 'status', label: 'Status', value: vc.status },
+    ...(vc.subjectTeams?.length
+      ? [{
+          key: 'subjectTeams',
+          label: `Subject Teams (${vc.subjectTeams.length})`,
+          tags: vc.subjectTeams.map(team => ({ label: team, to: `/teams/${encodeURIComponent(team)}` })),
+          span: 2 as const
+        }]
+      : []),
+    ...(vc.governedTechnologies?.length
+      ? [{
+          key: 'governedTechnologies',
+          label: `Governed Technologies (${vc.governedTechnologies.length})`,
+          tags: vc.governedTechnologies.map(tech => ({ label: tech, to: `/technologies/${encodeURIComponent(tech)}` })),
+          span: 2 as const
+        }]
+      : [])
+  ]
+})
 
 useHead({
   title: computed(() => data.value?.data ? `${data.value.data.name} - Polaris` : 'Version Constraint - Polaris')

--- a/app/pages/version-constraints/index.vue
+++ b/app/pages/version-constraints/index.vue
@@ -22,32 +22,22 @@
     />
 
     <template v-else>
-      <UCard>
-        <UTable
-          v-model:sorting="sorting"
-          :manual-sorting="true"
-          :data="constraints"
-          :columns="columns"
-          :loading="pending"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center text-(--ui-text-muted) py-12">
-              No version constraints found.
-            </div>
-          </template>
-        </UTable>
-
-        <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-          <UPagination
-            v-model:page="page"
-            :total="total"
-            :items-per-page="pageSize"
-            :sibling-count="1"
-            show-edges
-          />
-        </div>
-      </UCard>
+      <PaginatedTable
+        v-model:sorting="sorting"
+        v-model:page="page"
+        :manual-sorting="true"
+        :data="constraints"
+        :columns="columns"
+        :loading="pending"
+        :total="total"
+        :page-size="pageSize"
+      >
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-12">
+            No version constraints found.
+          </div>
+        </template>
+      </PaginatedTable>
     </template>
 
     <!-- Create Modal -->
@@ -183,6 +173,7 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
 
 const { data: session } = useAuth()
 const { isSuperuser } = useEffectiveRole()
@@ -202,13 +193,6 @@ interface VersionConstraint {
   technologyCount: number
 }
 
-interface ApiResponse {
-  success: boolean
-  data: VersionConstraint[]
-  count: number
-  total?: number
-}
-
 const userTeams = computed(() =>
   (session.value?.user?.teams as { name: string }[] | undefined)?.map(t => t.name) || []
 )
@@ -219,13 +203,6 @@ function canEdit(vc: VersionConstraint): boolean {
     return userTeams.value.includes(vc.subjectTeam)
   }
   return false
-}
-
-function getSeverityColor(severity: string): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    critical: 'error', error: 'error', warning: 'warning', info: 'neutral'
-  }
-  return colors[severity] || 'neutral'
 }
 
 const columns: TableColumn<VersionConstraint>[] = [
@@ -319,26 +296,14 @@ const columns: TableColumn<VersionConstraint>[] = [
   }
 ]
 
-const sorting = ref([])
-watch(sorting, () => { page.value = 1 })
-const page = ref(1)
-const pageSize = 20
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
 
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = { limit: pageSize, offset: (page.value - 1) * pageSize }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
+const { data, pending, error } = await useFetch<ApiResponse<VersionConstraint>>('/api/version-constraints', {
+  query: { limit: pageSize, offset, sortBy, sortOrder }
 })
 
-const { data, pending, error } = await useFetch<ApiResponse>('/api/version-constraints', {
-  query: queryParams
-})
-
-const constraints = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || data.value?.count || 0)
+const constraints = useApiData(data)
+const total = useApiCount(data)
 
 // Create modal
 const showCreateModal = ref(false)

--- a/app/pages/violations/index.vue
+++ b/app/pages/violations/index.vue
@@ -23,60 +23,51 @@
 
     <template v-else>
       <!-- Summary -->
-      <div v-if="summary" class="grid grid-cols-4 gap-4">
-        <UCard v-for="(count, level) in summary" :key="level">
-          <div class="text-center">
-            <p class="text-2xl font-bold">{{ count }}</p>
-            <p class="text-sm text-(--ui-text-muted) capitalize">{{ level }}</p>
+      <EntityStatStrip v-if="summary" :items="summaryStats" />
+
+      <PaginatedTable
+        :data="violations"
+        :columns="columns"
+        :loading="pending"
+      >
+        <template #header>
+          <div class="flex flex-wrap items-center gap-2">
+            <USelect
+              v-model="severityFilter"
+              :items="severityItems"
+              placeholder="All severities"
+              class="w-40"
+            />
+            <UInput
+              v-model="teamFilter"
+              placeholder="Filter by team..."
+              icon="i-lucide-search"
+              class="max-w-xs"
+            />
+            <UInput
+              v-model="technologyFilter"
+              placeholder="Filter by technology..."
+              icon="i-lucide-search"
+              class="max-w-xs"
+            />
+            <UButton
+              v-if="severityFilter || teamFilter || technologyFilter"
+              label="Clear"
+              variant="ghost"
+              color="neutral"
+              icon="i-lucide-x"
+              @click="clearFilters"
+            />
           </div>
-        </UCard>
-      </div>
-
-      <UCard>
-        <div class="flex flex-wrap items-center gap-2 pb-4 border-b border-(--ui-border) mb-4">
-          <USelect
-            v-model="severityFilter"
-            :items="severityItems"
-            placeholder="All severities"
-            class="w-40"
-          />
-          <UInput
-            v-model="teamFilter"
-            placeholder="Filter by team..."
-            icon="i-lucide-search"
-            class="max-w-xs"
-          />
-          <UInput
-            v-model="technologyFilter"
-            placeholder="Filter by technology..."
-            icon="i-lucide-search"
-            class="max-w-xs"
-          />
-          <UButton
-            v-if="severityFilter || teamFilter || technologyFilter"
-            label="Clear"
-            variant="ghost"
-            color="neutral"
-            icon="i-lucide-x"
-            @click="clearFilters"
-          />
-        </div>
-
-        <UTable
-          :data="violations"
-          :columns="columns"
-          :loading="pending"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center py-8">
-              <UIcon name="i-lucide-check-circle" class="text-5xl text-(--ui-color-success-500)" />
-              <h3 class="mt-4">No Version Violations!</h3>
-              <p class="text-(--ui-text-muted) mt-2">All components are within allowed version ranges.</p>
-            </div>
-          </template>
-        </UTable>
-      </UCard>
+        </template>
+        <template #empty>
+          <div class="text-center py-8">
+            <UIcon name="i-lucide-check-circle" class="text-5xl text-(--ui-color-success-500)" />
+            <h3 class="mt-4">No Version Violations!</h3>
+            <p class="text-(--ui-text-muted) mt-2">All components are within allowed version ranges.</p>
+          </div>
+        </template>
+      </PaginatedTable>
     </template>
   </div>
 </template>
@@ -84,6 +75,7 @@
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
 
 definePageMeta({ middleware: 'auth' })
 
@@ -104,43 +96,19 @@ interface Violation {
   }
 }
 
-interface ViolationsResponse {
-  success: boolean
-  data: Violation[]
-  count: number
-  summary: {
-    critical: number
-    error: number
-    warning: number
-    info: number
-  }
+interface ViolationsSummary {
+  critical: number
+  error: number
+  warning: number
+  info: number
 }
+
+type ViolationsResponse = ApiResponse<Violation> & { summary?: ViolationsSummary }
 
 const { getSortableHeader } = useSortableTable()
 
 const UBadge = resolveComponent('UBadge')
 const NuxtLink = resolveComponent('NuxtLink')
-
-function getSeverityColor(severity: string): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    critical: 'error', error: 'error', warning: 'warning', info: 'neutral'
-  }
-  return colors[severity] || 'neutral'
-}
-
-function getCriticalityColor(criticality: string | null): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    critical: 'error', high: 'warning', medium: 'success', low: 'neutral'
-  }
-  return colors[criticality || ''] || 'neutral'
-}
-
-function getEnvironmentColor(environment: string | null): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    prod: 'error', staging: 'warning', test: 'neutral', dev: 'neutral'
-  }
-  return colors[environment || ''] || 'neutral'
-}
 
 const severityItems = ['critical', 'error', 'warning', 'info']
 
@@ -166,8 +134,14 @@ const { data, pending, error } = await useFetch<ViolationsResponse>('/api/versio
   query: queryParams
 })
 
-const violations = computed(() => data.value?.data || [])
+const violations = useApiData(data)
 const summary = computed(() => data.value?.summary)
+const summaryStats = computed(() =>
+  Object.entries(summary.value ?? {}).map(([level, count]) => ({
+    label: level.charAt(0).toUpperCase() + level.slice(1),
+    value: count
+  }))
+)
 
 const columns: TableColumn<Violation>[] = [
   {

--- a/app/pages/violations/licenses.vue
+++ b/app/pages/violations/licenses.vue
@@ -16,49 +16,39 @@
     />
 
     <template v-else>
-      <UCard>
-        <div class="flex items-center gap-2 pb-4 border-b border-(--ui-border) mb-4">
+      <PaginatedTable
+        v-model:sorting="sorting"
+        v-model:page="page"
+        :data="violations"
+        :columns="columns"
+        :loading="pending"
+        :manual-sorting="true"
+        :total="total"
+        :page-size="pageSize"
+      >
+        <template #header>
           <UInput
             v-model="searchInput"
             placeholder="Filter by component, license, system, or team..."
             icon="i-lucide-search"
             class="max-w-sm"
           />
-        </div>
-
-        <UTable
-          v-model:sorting="sorting"
-          :data="violations"
-          :columns="columns"
-          :loading="pending"
-          :manual-sorting="true"
-          class="flex-1"
-        >
-          <template #empty>
-            <div class="text-center py-8">
-              <UIcon name="i-lucide-check-circle" class="text-5xl text-(--ui-color-success-500)" />
-              <h3 class="mt-4">No License Violations!</h3>
-              <p class="text-(--ui-text-muted) mt-2">All components use allowed licenses.</p>
-            </div>
-          </template>
-        </UTable>
-
-        <div v-if="total > pageSize" class="flex justify-center border-t border-(--ui-border) pt-4 mt-4">
-          <UPagination
-            v-model:page="page"
-            :total="total"
-            :items-per-page="pageSize"
-            :sibling-count="1"
-            show-edges
-          />
-        </div>
-      </UCard>
+        </template>
+        <template #empty>
+          <div class="text-center py-8">
+            <UIcon name="i-lucide-check-circle" class="text-5xl text-(--ui-color-success-500)" />
+            <h3 class="mt-4">No License Violations!</h3>
+            <p class="text-(--ui-text-muted) mt-2">All components use allowed licenses.</p>
+          </div>
+        </template>
+      </PaginatedTable>
     </template>
   </div>
 </template>
 
 <script setup lang="ts">
 import { h, resolveComponent } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
 import type { TableColumn } from '@nuxt/ui'
 import type { ApiResponse, LicenseViolation } from '~~/types/api'
 
@@ -68,32 +58,6 @@ const { getSortableHeader } = useSortableTable()
 
 const UBadge = resolveComponent('UBadge')
 const NuxtLink = resolveComponent('NuxtLink')
-
-function getCategoryColor(category: string): 'success' | 'warning' | 'error' | 'neutral' {
-  const colors: Record<string, 'success' | 'warning' | 'error' | 'neutral'> = {
-    permissive: 'success',
-    'weak-copyleft': 'warning',
-    copyleft: 'warning',
-    'strong-copyleft': 'error',
-    proprietary: 'error',
-    'public-domain': 'success'
-  }
-  return colors[category?.toLowerCase()] || 'neutral'
-}
-
-function getCriticalityColor(criticality: string | null): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    critical: 'error', high: 'warning', medium: 'success', low: 'neutral'
-  }
-  return colors[criticality || ''] || 'neutral'
-}
-
-function getEnvironmentColor(environment: string | null): 'error' | 'warning' | 'success' | 'neutral' {
-  const colors: Record<string, 'error' | 'warning' | 'success' | 'neutral'> = {
-    prod: 'error', staging: 'warning', test: 'neutral', dev: 'neutral'
-  }
-  return colors[environment || ''] || 'neutral'
-}
 
 const columns: TableColumn<LicenseViolation>[] = [
   {
@@ -161,50 +125,20 @@ const columns: TableColumn<LicenseViolation>[] = [
   }
 ]
 
-const sorting = ref<{ id: string; desc: boolean }[]>([])
-
-watch(sorting, () => { page.value = 1 })
-
-const page = ref(1)
-const pageSize = 20
-
 const searchInput = ref('')
 const debouncedSearch = ref('')
-let debounceTimer: ReturnType<typeof setTimeout> | null = null
 
-watch(searchInput, (value) => {
-  if (debounceTimer) clearTimeout(debounceTimer)
-  debounceTimer = setTimeout(() => {
-    debouncedSearch.value = value
-    page.value = 1
-  }, 300)
-})
+const updateSearch = useDebounceFn((value: string) => { debouncedSearch.value = value }, 300)
+watch(searchInput, updateSearch)
 
-onBeforeUnmount(() => {
-  if (debounceTimer) clearTimeout(debounceTimer)
-})
-
-const queryParams = computed(() => {
-  const params: Record<string, string | number> = {
-    limit: pageSize,
-    offset: (page.value - 1) * pageSize
-  }
-  if (debouncedSearch.value) {
-    params.search = debouncedSearch.value
-  }
-  if (sorting.value.length) {
-    params.sortBy = sorting.value[0].id
-    params.sortOrder = sorting.value[0].desc ? 'desc' : 'asc'
-  }
-  return params
-})
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({ resetOn: [debouncedSearch] })
 
 const { data, pending, error } = await useFetch<ApiResponse<LicenseViolation>>('/api/licenses/violations', {
-  query: queryParams
+  query: { limit: pageSize, offset, sortBy, sortOrder, search: debouncedSearch }
 })
 
-const violations = computed(() => data.value?.data || [])
-const total = computed(() => data.value?.total || 0)
+const violations = useApiData(data)
+const total = useApiCount(data)
 
 useHead({ title: 'License Violations - Polaris' })
 </script>

--- a/app/utils/badge-colors.ts
+++ b/app/utils/badge-colors.ts
@@ -1,0 +1,58 @@
+export type BadgeColor = 'success' | 'warning' | 'error' | 'neutral'
+
+const CRITICALITY_COLORS: Record<string, BadgeColor> = {
+  critical: 'error',
+  high: 'warning',
+  medium: 'success',
+  low: 'neutral'
+}
+
+export function getCriticalityColor(value: string | null | undefined): BadgeColor {
+  return CRITICALITY_COLORS[value?.toLowerCase() ?? ''] ?? 'neutral'
+}
+
+const SEVERITY_COLORS: Record<string, BadgeColor> = {
+  critical: 'error',
+  error: 'error',
+  warning: 'warning',
+  info: 'neutral'
+}
+
+export function getSeverityColor(value: string | null | undefined): BadgeColor {
+  return SEVERITY_COLORS[value?.toLowerCase() ?? ''] ?? 'neutral'
+}
+
+const CATEGORY_COLORS: Record<string, BadgeColor> = {
+  permissive: 'success',
+  'weak-copyleft': 'warning',
+  copyleft: 'warning',
+  'strong-copyleft': 'error',
+  proprietary: 'error',
+  'public-domain': 'success'
+}
+
+export function getCategoryColor(value: string | null | undefined): BadgeColor {
+  return CATEGORY_COLORS[value?.toLowerCase() ?? ''] ?? 'neutral'
+}
+
+const ENVIRONMENT_COLORS: Record<string, BadgeColor> = {
+  prod: 'error',
+  staging: 'warning',
+  test: 'neutral',
+  dev: 'neutral'
+}
+
+export function getEnvironmentColor(value: string | null | undefined): BadgeColor {
+  return ENVIRONMENT_COLORS[value?.toLowerCase() ?? ''] ?? 'neutral'
+}
+
+const TIME_CATEGORY_COLORS: Record<string, BadgeColor> = {
+  invest: 'success',
+  tolerate: 'warning',
+  migrate: 'warning',
+  eliminate: 'error'
+}
+
+export function getTimeCategoryColor(value: string | null | undefined): BadgeColor {
+  return TIME_CATEGORY_COLORS[value?.toLowerCase() ?? ''] ?? 'neutral'
+}

--- a/test/app/pages/components/index.test.ts
+++ b/test/app/pages/components/index.test.ts
@@ -4,6 +4,8 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { computed, defineComponent, ref, unref, watch } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ComponentsPage from '../../../../app/pages/components/index.vue'
+import { usePaginatedSorting } from '../../../../app/composables/usePaginatedSorting'
+import { useApiCount, useApiData } from '../../../../app/composables/useApiData'
 
 describe('components index page', () => {
   beforeEach(() => {
@@ -27,6 +29,9 @@ describe('components index page', () => {
     vi.stubGlobal('useSortableTable', () => ({
       getSortableHeader: () => 'sortable'
     }))
+    vi.stubGlobal('usePaginatedSorting', usePaginatedSorting)
+    vi.stubGlobal('useApiData', useApiData)
+    vi.stubGlobal('useApiCount', useApiCount)
 
     mount(defineComponent({
       components: { ComponentsPage },
@@ -46,7 +51,8 @@ describe('components index page', () => {
           UPagination: true,
           USwitch: true,
           UTable: { props: ['data'], template: '<div><slot name="empty" /></div>' },
-          UTooltip: { template: '<span><slot /><slot name="content" /></span>' }
+          UTooltip: { template: '<span><slot /><slot name="content" /></span>' },
+          PaginatedTable: { template: '<section><slot name="header" /><slot name="empty" /></section>' }
         }
       }
     })


### PR DESCRIPTION
## Description

Refactor entity pages to improve information density and reduce code duplication. Introduces reusable components for common UI patterns across entity detail pages and admin tables.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Configuration or build changes

## Changes Made

- **New components:**
  - `EntityDescriptionList` — reusable grid layout for entity metadata display with slots for customization
  - `EntityStatStrip` — visual stat display (clickable or static)
  - `PaginatedTable` — unified server-paginated table with sorting and pagination controls

- **New composable:**
  - `usePaginatedSorting` — shared state management for page/sort/offset across paginated tables

- **New utility:**
  - `badge-colors.ts` — centralized badge color mapping

- **Refactored pages:** 
  - 15+ entity and admin pages now use reusable components instead of inline markup
  - Extracted common table/pagination patterns into PaginatedTable
  - Replaced manual grid layouts with EntityDescriptionList
  - Used `useApiData()` and `useApiCount()` helpers consistently

- **UI config:** Updated card padding settings in app.config.ts

**Result:** 1,125 insertions (+), 1,453 deletions (-). Cleaner, more maintainable code with consistent patterns.

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review of my changes
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings or errors
- [ ] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [ ] I have updated documentation if needed

## Additional Notes

All changes are backward-compatible and purely refactoring internal component structure. No API changes or schema updates.