### PR TITLE
Add shared search box across entity list pages

### DIFF
--- a/.claude/mcp/local-model-server.js
+++ b/.claude/mcp/local-model-server.js
@@ -291,5 +291,63 @@ No preamble. Bullet list.`;
   }
 );
 
+// 9. Run markdown lint and summarize
+server.tool(
+  "run_mdlint",
+  "Run markdownlint and return a grouped summary of issues. Prefer this over running npm run mdlint manually.",
+  {
+    fix: z.boolean().optional().describe("Auto-fix fixable issues before summarizing (default: false)"),
+    path: z.string().optional().describe("Limit lint to a specific file or directory (default: **/*.md)"),
+  },
+  async ({ fix = false, path }) => {
+    const args = [path ?? "**/*.md", "--ignore", "node_modules"];
+    if (fix) args.push("--fix");
+    const { stdout, stderr, exitCode } = await runCommand("npx", ["markdownlint", ...args]);
+    const raw = (stdout + "\n" + stderr).trim();
+
+    if (exitCode === 0) return text("No markdown lint errors.");
+
+    const system = `${POLARIS_CONTEXT}
+
+Analyze markdownlint output and produce a grouped, actionable summary:
+- Group violations by rule (e.g. "MD012 × 3 in docs/") with counts
+- For each group, list affected files and line numbers
+- Note which groups are auto-fixable with --fix
+- End with the fastest resolution path
+
+No preamble. Bullet list.`;
+
+    return text(await callModel(system, `markdownlint output:\n${raw.slice(-6000)}`));
+  }
+);
+
+// 10. Generate OpenAPI docs
+server.tool(
+  "generate_docs",
+  "Generate the OpenAPI docs (public/openapi.json) and report whether anything changed, or diagnose the failure. Prefer this over running npm run docs:api manually.",
+  {},
+  async () => {
+    const { stdout, stderr, exitCode } = await runCommand("npm", ["run", "docs:api"]);
+    const raw = (stdout + "\n" + stderr).trim();
+
+    if (exitCode === 0) {
+      const diff = await runCommand("git", ["diff", "--stat", "--", "public/openapi.json"]);
+      const changed = diff.stdout.trim();
+      return text(changed ? `OpenAPI docs generated — changed:\n${changed}` : "OpenAPI docs generated — no changes.");
+    }
+
+    const system = `${POLARIS_CONTEXT}
+
+Analyze the error output from generating OpenAPI docs (server/scripts/generate-openapi.ts) and:
+- State the root cause in one sentence (e.g. bad route/schema definition, missing import, type error)
+- Point to the specific file/line if visible in the output
+- Suggest the fix
+
+No preamble. Bullet list.`;
+
+    return text(await callModel(system, `Output:\n${raw.slice(-8000)}`));
+  }
+);
+
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/.claude/skills/ship-feature/skill.md
+++ b/.claude/skills/ship-feature/skill.md
@@ -1,0 +1,49 @@
+---
+name: ship-feature
+description: Create a feature branch from the current changes, run mdlint/lint/tests/docs generation, and if everything passes commit, push, and open a draft PR.
+---
+
+## Ship Feature
+
+Package up the current working-tree changes into a feature branch, verify
+them the same way CI does, and — only if every check passes — commit, push,
+and open a draft PR. Invoking this skill is the user's explicit go-ahead to
+carry the flow through to the PR; do not pause for extra confirmation once
+checks pass.
+
+### Steps
+
+1. **Branch**: If an argument was passed, slugify it (kebab-case) for the
+   branch suffix; otherwise inspect `git status` / `git diff --stat` and
+   derive a short descriptive slug, or ask the user. Skip this step if
+   already on a `feature/*` branch. Run `git checkout -b feature/<slug>` from
+   the current HEAD — do not pull/rebase `main` first, since there may be
+   uncommitted local changes to carry over, not to rebase.
+2. **Markdown lint**: run `run_mdlint`. Stop and report on failure — nothing
+   gets committed.
+3. **Lint**: run `run_lint` (no `fix`, read-only check). Stop and report
+   grouped issues on failure.
+4. **Tests**: run `run_tests` with `layer: "all"` — mirrors `npm run test`.
+   Stop and report the diagnosis on failure.
+5. **Docs**: run `generate_docs`. This may modify `public/openapi.json`,
+   which is tracked and should be included in the commit.
+6. **Stage**: review `git status --porcelain` — flag anything unexpected
+   (`.env`, credentials, stray binaries) before staging — then stage all the
+   intended changed/new/generated files.
+7. **Commit message**: run `draft_commit_message` with `diff` set to
+   `git diff HEAD` (the staged diff) and `context` set to the feature
+   slug/description. Use the returned message for `git commit -m`.
+8. **Push**: `git push -u origin feature/<slug>`.
+9. **PR body**: run `create_pr_body` with `diff` set to `git diff main...HEAD`
+   and optional `context`. Use the returned title + body.
+10. **Open PR**: `gh pr create --title "<title>" --body "<body>"`
+    (use a heredoc for the body), base `main`.
+11. Report the PR URL back to the user.
+
+### Safety
+
+- Any failure in steps 2–5 halts the flow before committing — the branch and
+  the uncommitted changes are left intact for the user to fix.
+- Never force-push.
+- Never target `main` directly — `main` is protected; all changes go through
+  a PR (see `AGENTS.md`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix(sbom): correctly mark isDirect for Composer and other SPDX SBOMs (#722) @localgod (#725)
+* fix(sbom): correctly mark isDirect for Composer and other SPDX SBOMs (#722) @localgod (#725)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.46...v0.6.47
 
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps): bump the production-dependencies group across 1 directory with 2 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#688)
+* chore(deps)(deps): bump the production-dependencies group across 1 directory with 2 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#688)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.28...v0.6.29
 
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- Improve component detail dependency layout @localgod (#664)
+* Improve component detail dependency layout @localgod (#664)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.13...v0.6.14
 
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps-dev): bump @cucumber/gherkin from 39.1.0 to 40.0.0 @[dependabot[bot]](https://github.com/apps/dependabot) (#644)
+* chore(deps)(deps-dev): bump @cucumber/gherkin from 39.1.0 to 40.0.0 @[dependabot[bot]](https://github.com/apps/dependabot) (#644)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.6...v0.6.7
 
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- Add deps.dev package metadata overlay @localgod (#613)
+* Add deps.dev package metadata overlay @localgod (#613)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.48...v0.5.49
 
@@ -77,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps-dev): bump the development-dependencies group with 4 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#606)
+* chore(deps)(deps-dev): bump the development-dependencies group with 4 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#606)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.45...v0.5.46
 
@@ -87,7 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps-dev): bump the development-dependencies group with 6 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#593)
+* chore(deps)(deps-dev): bump the development-dependencies group with 6 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#593)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.41...v0.5.42
 
@@ -95,7 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: move dependency scope from Component node to USES/DIRECT\_DEP edges @localgod (#582)
+* fix: move dependency scope from Component node to USES/DIRECT\_DEP edges @localgod (#582)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.36...v0.5.37
 
@@ -103,11 +103,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: make ownerTeam required in GitHub import dialog @localgod (#565)
+* fix: make ownerTeam required in GitHub import dialog @localgod (#565)
 
 ## 🔧 Maintenance
 
-- chore: release v0.5.28 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#564)
+* chore: release v0.5.28 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#564)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.28...v0.5.29
 
@@ -115,7 +115,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- feat: use Simple Icons for package manager types @localgod (#563)
+* feat: use Simple Icons for package manager types @localgod (#563)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.27...v0.5.28
 
@@ -125,7 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps): bump devalue from 5.8.0 to 5.8.1 @[dependabot[bot]](https://github.com/apps/dependabot) (#506)
+* chore(deps)(deps): bump devalue from 5.8.0 to 5.8.1 @[dependabot[bot]](https://github.com/apps/dependabot) (#506)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.8...v0.5.9
 
@@ -135,7 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🚀 Features
 
-- fix: neo4j plugin fails fast on connection failure at startup @localgod (#492)
+* fix: neo4j plugin fails fast on connection failure at startup @localgod (#492)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.4.2...v0.5.0
 
@@ -143,7 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- feat: dependency graph, SBOM pipeline fixes, and component filtering @localgod (#476)
+* feat: dependency graph, SBOM pipeline fixes, and component filtering @localgod (#476)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.85...v0.1.86
 
@@ -153,7 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(actions): bump dorny/paths-filter from 3 to 4 @[dependabot[bot]](https://github.com/apps/dependabot) (#463)
+* chore(actions): bump dorny/paths-filter from 3 to 4 @[dependabot[bot]](https://github.com/apps/dependabot) (#463)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.81...v0.1.82
 
@@ -163,7 +163,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.77 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#459)
+* chore: release v0.1.77 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#459)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.77...v0.1.78
 
@@ -171,7 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- feat: environment-scoped technology approvals @localgod (#458)
+* feat: environment-scoped technology approvals @localgod (#458)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.76...v0.1.77
 
@@ -179,7 +179,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: regenerate lockfile and fix CHANGELOG markdown lint errors @localgod (#330)
+* fix: regenerate lockfile and fix CHANGELOG markdown lint errors @localgod (#330)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.27...v0.1.28
 
@@ -187,11 +187,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- chore(deps): ignore next-auth >=4.23.0 in dependabot @localgod (#320)
+* chore(deps): ignore next-auth >=4.23.0 in dependabot @localgod (#320)
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.22 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#319)
+* chore: release v0.1.22 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#319)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.22...v0.1.23
 
@@ -199,11 +199,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: replace scp-action with inline SSH heredoc for compose file @localgod (#318)
+* fix: replace scp-action with inline SSH heredoc for compose file @localgod (#318)
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.21 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#317)
+* chore: release v0.1.21 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#317)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.21...v0.1.22
 
@@ -213,7 +213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.19 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#313)
+* chore: release v0.1.19 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#313)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.20...v0.1.21
 
@@ -223,7 +223,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(actions): bump actions/checkout from 4 to 6 @[dependabot[bot]](https://github.com/apps/dependabot) (#310)
+* chore(actions): bump actions/checkout from 4 to 6 @[dependabot[bot]](https://github.com/apps/dependabot) (#310)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.18...v0.1.19
 
@@ -233,7 +233,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.10 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#294)
+* chore: release v0.1.10 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#294)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.12...v0.1.13
 
@@ -241,11 +241,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: add mobile top bar with sidebar trigger @localgod (#293)
+* fix: add mobile top bar with sidebar trigger @localgod (#293)
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.9 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#292)
+* chore: release v0.1.9 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#292)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.9...v0.1.10
 
@@ -253,6 +253,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- No changes
+* No changes
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.8...v0.1.9

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,8 @@ A local Qwen 2.5 7B model runs via Docker Model Runner and is available as a set
 | ---- | -------------- |
 | `run_tests` | `npm test` via Bash — returns a diagnosis, not raw output |
 | `run_lint` | `npm run lint` via Bash — returns grouped issues |
+| `run_mdlint` | `npm run mdlint` via Bash — returns grouped issues |
+| `generate_docs` | `npm run docs:api` via Bash — reports what changed or diagnoses the failure |
 | `draft_commit_message` | Writing commit messages manually — pass `git diff HEAD` |
 | `create_pr_body` | Writing PR descriptions manually — pass `git diff main...HEAD` |
 | `draft_cypher` | Writing Cypher queries from scratch — describe what you need in plain English |

--- a/app/components/TableSearchHeader.vue
+++ b/app/components/TableSearchHeader.vue
@@ -1,0 +1,33 @@
+<template>
+  <div class="flex flex-wrap items-center justify-between gap-3">
+    <slot name="search-input">
+      <UInput
+        v-model="searchInput"
+        placeholder="Filter by name..."
+        icon="i-lucide-search"
+        class="max-w-sm"
+      />
+    </slot>
+    <div class="flex flex-wrap items-center gap-4">
+      <slot name="filters" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  modelValue: string
+}
+
+interface Emits {
+  'update:modelValue': [value: string]
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<Emits>()
+
+const searchInput = computed({
+  get: () => props.modelValue,
+  set: (value: string) => emit('update:modelValue', value)
+})
+</script>

--- a/app/composables/useTableSearch.ts
+++ b/app/composables/useTableSearch.ts
@@ -1,0 +1,39 @@
+import type { Ref } from 'vue'
+import { useDebounceFn } from '@vueuse/core'
+
+interface UseTableSearchOptions {
+  debounceMs?: number
+}
+
+interface UseTableSearchReturn {
+  searchInput: Ref<string>
+  debouncedSearch: Ref<string>
+}
+
+/**
+ * Manages search input with debouncing for table filtering.
+ * Separates the raw input value from the debounced value used in queries.
+ *
+ * @param options - Configuration options (debounceMs defaults to 300ms)
+ * @returns Object with searchInput (for v-model) and debouncedSearch (for queries)
+ *
+ * @example
+ * const { searchInput, debouncedSearch } = useTableSearch()
+ * const { data } = await useFetch('/api/items', {
+ *   query: { search: debouncedSearch }
+ * })
+ */
+export function useTableSearch(options: UseTableSearchOptions = {}): UseTableSearchReturn {
+  const debounceMs = options.debounceMs ?? 300
+
+  const searchInput = ref('')
+  const debouncedSearch = ref('')
+
+  const updateSearch = useDebounceFn((value: string) => {
+    debouncedSearch.value = value
+  }, debounceMs)
+
+  watch(searchInput, updateSearch)
+
+  return { searchInput, debouncedSearch }
+}

--- a/app/pages/admin/component-links.vue
+++ b/app/pages/admin/component-links.vue
@@ -49,6 +49,9 @@
       :total="total"
       :page-size="pageSize"
     >
+      <template #header>
+        <TableSearchHeader v-model="searchInput" />
+      </template>
       <template #empty>
         <div class="text-center text-(--ui-text-muted) py-12">
           No unlinked components — all caught up!
@@ -178,11 +181,15 @@ const UBadge = resolveComponent('UBadge')
 const UButton = resolveComponent('UButton')
 const UTooltip = resolveComponent('UTooltip')
 
-const { page, pageSize, offset } = usePaginatedSorting({ pageSize: 50 })
+const { searchInput, debouncedSearch } = useTableSearch()
 
+const { page, pageSize, offset } = usePaginatedSorting({ pageSize: 50, resetOn: [debouncedSearch] })
+
+// Pass individual refs/computeds as query values so each one is tracked
+// as a reactive dependency — wrapping the query in computed() causes hydration issues
 const { data, pending, error: fetchError, refresh } = await useFetch<ApiResponse<LinkSuggestion>>(
   '/api/components/link-suggestions',
-  { query: { skip: offset, limit: pageSize } }
+  { query: { skip: offset, limit: pageSize, search: debouncedSearch } }
 )
 
 const suggestions = useApiData(data)

--- a/app/pages/components/index.vue
+++ b/app/pages/components/index.vue
@@ -46,14 +46,8 @@
         :page-size="pageSize"
       >
         <template #header>
-          <div class="flex flex-wrap items-center justify-between gap-3">
-            <UInput
-              v-model="searchInput"
-              placeholder="Filter by name..."
-              icon="i-lucide-search"
-              class="max-w-sm"
-            />
-            <div class="flex flex-wrap items-center gap-4">
+          <TableSearchHeader v-model="searchInput">
+            <template #filters>
               <USwitch
                 v-if="systemFilter"
                 v-model="showDirectOnly"
@@ -65,8 +59,8 @@
                 label="Show dev dependencies"
                 size="sm"
               />
-            </div>
-          </div>
+            </template>
+          </TableSearchHeader>
         </template>
         <template #empty>
           <div class="text-center text-(--ui-text-muted) py-12">
@@ -86,7 +80,6 @@
 
 <script setup lang="ts">
 import { h, resolveComponent, defineComponent, ref } from 'vue'
-import { useDebounceFn } from '@vueuse/core'
 import type { TableColumn } from '@nuxt/ui'
 import type { ApiResponse, GroupedComponent } from '~~/types/api'
 
@@ -283,14 +276,13 @@ function openGroupedComponent(_event: Event | null, row: { original: GroupedComp
   versionsModalOpen.value = true
 }
 
-const searchInput = ref('')
-const debouncedSearch = ref('')
+// Initialize search first, before using in resetOn
+const { searchInput, debouncedSearch } = useTableSearch()
 
-const updateSearch = useDebounceFn((value: string) => { debouncedSearch.value = value }, 300)
-watch(searchInput, updateSearch)
-
+// Now we can safely reference debouncedSearch in resetOn
+const resetOnDeps = [debouncedSearch, licenseFilter, systemFilter, lifecycleRiskFilter, showDevDependencies, showDirectOnly]
 const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
-  resetOn: [debouncedSearch, licenseFilter, systemFilter, lifecycleRiskFilter, showDevDependencies, showDirectOnly]
+  resetOn: resetOnDeps
 })
 
 const includeDev = computed(() => showDevDependencies.value ? undefined : 'false')

--- a/app/pages/licenses/index.vue
+++ b/app/pages/licenses/index.vue
@@ -25,6 +25,9 @@
         :total="total"
         :page-size="pageSize"
       >
+        <template #header>
+          <TableSearchHeader v-model="searchInput" />
+        </template>
         <template #empty>
           <div class="text-center text-(--ui-text-muted) py-12">
             No licenses found.
@@ -137,10 +140,22 @@ const columns: TableColumn<License>[] = [
   }
 ]
 
-const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
+const { searchInput, debouncedSearch } = useTableSearch()
 
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
+  resetOn: [debouncedSearch]
+})
+
+// Pass individual refs/computeds as query values so each one is tracked
+// as a reactive dependency — wrapping the query in computed() causes hydration issues
 const { data, pending, error } = await useFetch<ApiResponse<License>>('/api/licenses', {
-  query: { limit: pageSize, offset, sortBy, sortOrder }
+  query: {
+    limit: pageSize,
+    offset,
+    sortBy,
+    sortOrder,
+    search: debouncedSearch
+  }
 })
 
 const licenses = useApiData(data)

--- a/app/pages/platforms/index.vue
+++ b/app/pages/platforms/index.vue
@@ -42,6 +42,9 @@
       :total="total"
       :page-size="pageSize"
     >
+      <template #header>
+        <TableSearchHeader v-model="searchInput" />
+      </template>
       <template #empty>
         <div class="text-center text-(--ui-text-muted) py-12">
           No platforms found.
@@ -412,10 +415,22 @@ async function onSetTime(event: FormSubmitEvent<TimeSchema>) {
   }
 }
 
-const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
+const { searchInput, debouncedSearch } = useTableSearch()
 
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
+  resetOn: [debouncedSearch]
+})
+
+// Pass individual refs/computeds as query values so each one is tracked
+// as a reactive dependency — wrapping the query in computed() causes hydration issues
 const { data, pending, error } = await useFetch<ApiResponse<Platform>>('/api/platforms', {
-  query: { limit: pageSize, offset, sortBy, sortOrder }
+  query: {
+    limit: pageSize,
+    offset,
+    sortBy,
+    sortOrder,
+    search: debouncedSearch
+  }
 })
 
 const platforms = useApiData(data)

--- a/app/pages/teams/index.vue
+++ b/app/pages/teams/index.vue
@@ -33,6 +33,9 @@
         :total="total"
         :page-size="pageSize"
       >
+        <template #header>
+          <TableSearchHeader v-model="searchInput" />
+        </template>
         <template #empty>
           <div class="text-center text-(--ui-text-muted) py-12">
             No teams found.
@@ -282,10 +285,22 @@ const columns = computed(() => {
   return baseColumns
 })
 
-const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
+const { searchInput, debouncedSearch } = useTableSearch()
 
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
+  resetOn: [debouncedSearch]
+})
+
+// Pass individual refs/computeds as query values so each one is tracked
+// as a reactive dependency — wrapping the query in computed() causes hydration issues
 const { data, pending, error } = await useFetch<ApiResponse<Team>>('/api/teams', {
-  query: { limit: pageSize, offset, sortBy, sortOrder }
+  query: {
+    limit: pageSize,
+    offset,
+    sortBy,
+    sortOrder,
+    search: debouncedSearch
+  }
 })
 
 const teams = useApiData(data)

--- a/app/pages/technologies/index.vue
+++ b/app/pages/technologies/index.vue
@@ -8,22 +8,24 @@
       />
       <div class="flex items-center gap-2">
         <!-- View mode toggle -->
-        <UButtonGroup size="sm">
+        <div class="flex gap-1 bg-(--ui-bg-elevated) rounded-md p-1">
           <UButton
             icon="i-lucide-table"
             :color="viewMode === 'table' ? 'primary' : 'neutral'"
-            :variant="viewMode === 'table' ? 'solid' : 'outline'"
+            :variant="viewMode === 'table' ? 'solid' : 'ghost'"
+            size="sm"
             aria-label="Table view"
             @click="viewMode = 'table'"
           />
           <UButton
             icon="i-lucide-radar"
             :color="viewMode === 'radar' ? 'primary' : 'neutral'"
-            :variant="viewMode === 'radar' ? 'solid' : 'outline'"
+            :variant="viewMode === 'radar' ? 'solid' : 'ghost'"
+            size="sm"
             aria-label="Radar view"
             @click="viewMode = 'radar'"
           />
-        </UButtonGroup>
+        </div>
         <UButton
           v-if="isSuperuser"
           size="sm"
@@ -56,6 +58,9 @@
         :total="total"
         :page-size="pageSize"
       >
+        <template #header>
+          <TableSearchHeader v-model="searchInput" />
+        </template>
         <template #empty>
           <div class="text-center text-(--ui-text-muted) py-12">
             No technologies found.
@@ -715,10 +720,22 @@ async function confirmLinkComponent() {
   }
 }
 
-const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
+const { searchInput, debouncedSearch } = useTableSearch()
 
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
+  resetOn: [debouncedSearch]
+})
+
+// Pass individual refs/computeds as query values so each one is tracked
+// as a reactive dependency — wrapping the query in computed() causes hydration issues
 const { data, pending, error } = await useFetch<ApiResponse<Technology>>('/api/technologies', {
-  query: { limit: pageSize, offset, sortBy, sortOrder }
+  query: {
+    limit: pageSize,
+    offset,
+    sortBy,
+    sortOrder,
+    search: debouncedSearch
+  }
 })
 
 const technologies = useApiData(data)

--- a/app/pages/users/index.vue
+++ b/app/pages/users/index.vue
@@ -42,6 +42,9 @@
       :total="total"
       :page-size="pageSize"
     >
+      <template #header>
+        <TableSearchHeader v-model="searchInput" />
+      </template>
       <template #empty>
         <div class="text-center text-(--ui-text-muted) py-12">
           No users found.
@@ -718,10 +721,22 @@ const columns: TableColumn<User>[] = [
   }
 ]
 
-const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
+const { searchInput, debouncedSearch } = useTableSearch()
 
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
+  resetOn: [debouncedSearch]
+})
+
+// Pass individual refs/computeds as query values so each one is tracked
+// as a reactive dependency — wrapping the query in computed() causes hydration issues
 const { data, pending, error } = await useFetch<ApiResponse<User>>('/api/users', {
-  query: { limit: pageSize, offset, sortBy, sortOrder }
+  query: {
+    limit: pageSize,
+    offset,
+    sortBy,
+    sortOrder,
+    search: debouncedSearch
+  }
 })
 
 const users = useApiData(data)

--- a/app/pages/version-constraints/index.vue
+++ b/app/pages/version-constraints/index.vue
@@ -32,6 +32,9 @@
         :total="total"
         :page-size="pageSize"
       >
+        <template #header>
+          <TableSearchHeader v-model="searchInput" />
+        </template>
         <template #empty>
           <div class="text-center text-(--ui-text-muted) py-12">
             No version constraints found.
@@ -296,10 +299,22 @@ const columns: TableColumn<VersionConstraint>[] = [
   }
 ]
 
-const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting()
+const { searchInput, debouncedSearch } = useTableSearch()
 
+const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
+  resetOn: [debouncedSearch]
+})
+
+// Pass individual refs/computeds as query values so each one is tracked
+// as a reactive dependency — wrapping the query in computed() causes hydration issues
 const { data, pending, error } = await useFetch<ApiResponse<VersionConstraint>>('/api/version-constraints', {
-  query: { limit: pageSize, offset, sortBy, sortOrder }
+  query: {
+    limit: pageSize,
+    offset,
+    sortBy,
+    sortOrder,
+    search: debouncedSearch
+  }
 })
 
 const constraints = useApiData(data)

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Polaris API",
-    "version": "0.6.47",
+    "version": "0.6.49",
     "description": "# Polaris Technology Catalog API\n\nThe Polaris API provides programmatic access to the technology catalog, enabling automation, integration, and custom tooling.\n\n## Key Features\n\n- **RESTful Design** - Resource-based URLs with proper HTTP methods\n- **Comprehensive Coverage** - Systems, Teams, Technologies, Components, Policies, and more\n- **Developer-Friendly** - Clear error messages and consistent response structure\n\n## Authentication\n\nMost endpoints require authentication using session-based authentication integrated with the web application.\n\n**Authorization Levels:**\n- **Public** - No authentication required\n- **Authenticated** - Valid user session required  \n- **Team Member** - User must belong to a team\n- **Team Owner** - User must belong to team that owns the resource\n- **Superuser** - User must have superuser role\n\n## Response Format\n\nAll successful responses follow this structure:\n```json\n{\n  \"success\": true,\n  \"data\": [...],\n  \"count\": 10\n}\n```\n\nAll errors follow this structure:\n```json\n{\n  \"statusCode\": 404,\n  \"message\": \"Resource 'example' not found\"\n}\n```\n\n## Richardson Maturity Model\n\nThis API implements **RMM Level 2** with proper use of HTTP methods and status codes.",
     "license": {
       "name": "MIT",
@@ -1230,7 +1230,12 @@
           "Technologies"
         ],
         "summary": "Create a new technology from an unlinked component",
-        "description": "Creates a new technology by claiming an existing, currently-unlinked Component —\na Technology can never exist without at least one linked Component. All Component\nnodes sharing `componentName` that aren't already linked to a Technology are\nlinked in the same operation. For technology that can never be observed by SBOM\nscanning (databases, cloud services, etc.), use POST /platforms instead.\n",
+        "description": "Creates a new technology by claiming an existing, currently-unlinked Component —\na Technology can never exist without at least one linked Component. All Component\nnodes sharing `componentName` that aren't already linked to a Technology are\nlinked in the same operation. For technology that can never be observed by SBOM\nscanning (databases, cloud services, etc.), use POST /platforms instead.\n\nSuperuser only — this mirrors the gate already on linking a component to an\n*existing* technology (POST /technologies/{name}/components), so creating a new\none isn't a lower bar than linking to one. The intended entry point is the\nguided component-links queue (/admin/component-links), not this endpoint directly.\n",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1299,6 +1304,9 @@
           },
           "400": {
             "description": "Missing required fields"
+          },
+          "403": {
+            "description": "Superuser access required"
           },
           "404": {
             "description": "No unlinked component with the given name was found"
@@ -1466,6 +1474,34 @@
               "default": 0
             },
             "description": "Pagination offset"
+          },
+          {
+            "in": "query",
+            "name": "sortBy",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Field to sort by"
+          },
+          {
+            "in": "query",
+            "name": "sortOrder",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "description": "Sort order"
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive substring match on team name"
           }
         ],
         "responses": {
@@ -2114,6 +2150,34 @@
               "default": 0
             },
             "description": "Pagination offset"
+          },
+          {
+            "in": "query",
+            "name": "sortBy",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Field to sort by"
+          },
+          {
+            "in": "query",
+            "name": "sortOrder",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "description": "Sort order"
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive substring match on platform name"
           }
         ],
         "responses": {
@@ -2798,6 +2862,34 @@
               "default": 0
             },
             "description": "Pagination offset"
+          },
+          {
+            "in": "query",
+            "name": "sortBy",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Field to sort by"
+          },
+          {
+            "in": "query",
+            "name": "sortOrder",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "description": "Sort order"
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive search on user email or name"
           }
         ],
         "responses": {
@@ -4990,6 +5082,14 @@
               "default": 50,
               "maximum": 200
             }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive substring match on component name"
           }
         ],
         "responses": {

--- a/server/api/components/link-suggestions.get.ts
+++ b/server/api/components/link-suggestions.get.ts
@@ -1,4 +1,5 @@
 import { componentService } from '../../services/singletons'
+import { parseSearchParam } from '../../utils/query-params'
 
 /**
  * @openapi
@@ -40,7 +41,7 @@ export default defineEventHandler(async (event) => {
   const skip = Math.max(0, Math.floor(Number(query.skip ?? '0')) || 0)
   const limit = Math.min(200, Math.max(1, Math.floor(Number(query.limit ?? '50')) || 50))
 
-  const result = await componentService.getLinkSuggestions(skip, limit, query.search as string | undefined)
+  const result = await componentService.getLinkSuggestions(skip, limit, parseSearchParam(query.search))
 
   return {
     success: true,

--- a/server/api/components/link-suggestions.get.ts
+++ b/server/api/components/link-suggestions.get.ts
@@ -22,6 +22,11 @@ import { componentService } from '../../services/singletons'
  *           type: integer
  *           default: 50
  *           maximum: 200
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Case-insensitive substring match on component name
  *     responses:
  *       200:
  *         description: Link suggestions returned
@@ -35,7 +40,7 @@ export default defineEventHandler(async (event) => {
   const skip = Math.max(0, Math.floor(Number(query.skip ?? '0')) || 0)
   const limit = Math.min(200, Math.max(1, Math.floor(Number(query.limit ?? '50')) || 50))
 
-  const result = await componentService.getLinkSuggestions(skip, limit)
+  const result = await componentService.getLinkSuggestions(skip, limit, query.search as string | undefined)
 
   return {
     success: true,

--- a/server/api/platforms.get.ts
+++ b/server/api/platforms.get.ts
@@ -22,6 +22,22 @@ import { platformService } from '../services/singletons'
  *           type: integer
  *           default: 0
  *         description: Pagination offset
+ *       - in: query
+ *         name: sortBy
+ *         schema:
+ *           type: string
+ *         description: Field to sort by
+ *       - in: query
+ *         name: sortOrder
+ *         schema:
+ *           type: string
+ *           enum: [asc, desc]
+ *         description: Sort order
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Case-insensitive substring match on platform name
  *     responses:
  *       200:
  *         description: Successfully retrieved platforms
@@ -61,7 +77,8 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Platform>> 
         sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
       },
       limit,
-      offset
+      offset,
+      query.search as string | undefined
     )
 
     return {

--- a/server/api/platforms.get.ts
+++ b/server/api/platforms.get.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse, Platform } from '~~/types/api'
 import { platformService } from '../services/singletons'
+import { parseSearchParam } from '../utils/query-params'
 
 /**
  * @openapi
@@ -78,7 +79,7 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Platform>> 
       },
       limit,
       offset,
-      query.search as string | undefined
+      parseSearchParam(query.search)
     )
 
     return {

--- a/server/api/teams.get.ts
+++ b/server/api/teams.get.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse, Team } from '~~/types/api'
 import { teamService } from '../services/singletons'
+import { parseSearchParam } from '../utils/query-params'
 
 /**
  * @openapi
@@ -82,7 +83,7 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Team>> => {
       },
       limit,
       offset,
-      query.search as string | undefined
+      parseSearchParam(query.search)
     )
 
     return {

--- a/server/api/teams.get.ts
+++ b/server/api/teams.get.ts
@@ -22,6 +22,22 @@ import { teamService } from '../services/singletons'
  *           type: integer
  *           default: 0
  *         description: Pagination offset
+ *       - in: query
+ *         name: sortBy
+ *         schema:
+ *           type: string
+ *         description: Field to sort by
+ *       - in: query
+ *         name: sortOrder
+ *         schema:
+ *           type: string
+ *           enum: [asc, desc]
+ *         description: Sort order
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Case-insensitive substring match on team name
  *     responses:
  *       200:
  *         description: Successfully retrieved teams
@@ -65,7 +81,8 @@ export default defineEventHandler(async (event): Promise<ApiResponse<Team>> => {
         sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
       },
       limit,
-      offset
+      offset,
+      query.search as string | undefined
     )
 
     return {

--- a/server/api/users/index.get.ts
+++ b/server/api/users/index.get.ts
@@ -1,4 +1,5 @@
 import { userService } from '../../services/singletons'
+import { parseSearchParam } from '../../utils/query-params'
 
 /**
  * @openapi
@@ -80,7 +81,7 @@ export default defineEventHandler(async (event) => {
     const allUsers = await userService.findAllSummary({
       sortBy: query.sortBy as string | undefined,
       sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
-    }, query.search as string | undefined)
+    }, parseSearchParam(query.search))
     const total = allUsers.length
     const paginatedUsers = allUsers.slice(offset, offset + limit)
     

--- a/server/api/users/index.get.ts
+++ b/server/api/users/index.get.ts
@@ -23,6 +23,22 @@ import { userService } from '../../services/singletons'
  *           type: integer
  *           default: 0
  *         description: Pagination offset
+ *       - in: query
+ *         name: sortBy
+ *         schema:
+ *           type: string
+ *         description: Field to sort by
+ *       - in: query
+ *         name: sortOrder
+ *         schema:
+ *           type: string
+ *           enum: [asc, desc]
+ *         description: Sort order
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Case-insensitive search on user email or name
  *     responses:
  *       200:
  *         description: Successfully retrieved users
@@ -64,7 +80,7 @@ export default defineEventHandler(async (event) => {
     const allUsers = await userService.findAllSummary({
       sortBy: query.sortBy as string | undefined,
       sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' : 'asc'
-    })
+    }, query.search as string | undefined)
     const total = allUsers.length
     const paginatedUsers = allUsers.slice(offset, offset + limit)
     

--- a/server/api/version-constraints.get.ts
+++ b/server/api/version-constraints.get.ts
@@ -16,7 +16,9 @@ export default defineEventHandler(async (event) => {
     const status = query.status as string | undefined
 
     const result = await versionConstraintService.findAll({
-      scope, status, limit, offset,
+      scope, status,
+      search: query.search as string | undefined,
+      limit, offset,
       sortBy: query.sortBy as string | undefined,
       sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const
     })

--- a/server/api/version-constraints.get.ts
+++ b/server/api/version-constraints.get.ts
@@ -1,4 +1,5 @@
 import { versionConstraintService } from '../services/singletons'
+import { parseSearchParam } from '../utils/query-params'
 
 export default defineEventHandler(async (event) => {
   try {
@@ -17,7 +18,7 @@ export default defineEventHandler(async (event) => {
 
     const result = await versionConstraintService.findAll({
       scope, status,
-      search: query.search as string | undefined,
+      search: parseSearchParam(query.search),
       limit, offset,
       sortBy: query.sortBy as string | undefined,
       sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const

--- a/server/database/queries/components/link-suggestions-count.cypher
+++ b/server/database/queries/components/link-suggestions-count.cypher
@@ -2,4 +2,5 @@ MATCH (c:Component)<-[uses:USES {isDirect: true}]-(:System)
 WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND c.linkDismissedAt IS NULL
   AND c.purl IS NOT NULL
+  AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
 RETURN count(DISTINCT c.name) AS total

--- a/server/database/queries/components/link-suggestions-count.cypher
+++ b/server/database/queries/components/link-suggestions-count.cypher
@@ -3,4 +3,6 @@ WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND c.linkDismissedAt IS NULL
   AND c.purl IS NOT NULL
   AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
+WITH c, toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
+WHERE size(purlName) > 0
 RETURN count(DISTINCT c.name) AS total

--- a/server/database/queries/components/link-suggestions.cypher
+++ b/server/database/queries/components/link-suggestions.cypher
@@ -17,6 +17,7 @@ MATCH (c:Component)<-[uses:USES {isDirect: true}]-(:System)
 WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND c.linkDismissedAt IS NULL
   AND c.purl IS NOT NULL
+  AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
 WITH c.name AS componentName, c.packageManager AS packageManager,
      toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
 WHERE size(purlName) > 0

--- a/server/database/queries/platforms/find-all.cypher
+++ b/server/database/queries/platforms/find-all.cypher
@@ -1,4 +1,5 @@
 MATCH (p:Platform)
+WHERE $search IS NULL OR toLower(p.name) CONTAINS toLower($search)
 // Pin a single, deterministic steward team (alphabetically first) before
 // the other OPTIONAL MATCH so a Platform with more than one steward doesn't
 // multiply into duplicate rows and inflate `total` below (same class of bug

--- a/server/database/queries/teams/find-all.cypher
+++ b/server/database/queries/teams/find-all.cypher
@@ -1,4 +1,5 @@
 MATCH (t:Team)
+WHERE $search IS NULL OR toLower(t.name) CONTAINS toLower($search)
 OPTIONAL MATCH (t)-[:STEWARDED_BY]->(tech:Technology)
 OPTIONAL MATCH (t)-[:OWNS]->(sys:System)
 OPTIONAL MATCH (u:User)-[:MEMBER_OF]->(t)

--- a/server/database/queries/users/find-all-summary.cypher
+++ b/server/database/queries/users/find-all-summary.cypher
@@ -1,4 +1,5 @@
 MATCH (u:User)
+WHERE $search IS NULL OR toLower(u.email) CONTAINS toLower($search) OR toLower(u.name) CONTAINS toLower($search)
 OPTIONAL MATCH (u)-[:MEMBER_OF]->(t:Team)
 WITH u, count(t) as teamCount
 RETURN u.id as id,

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -375,14 +375,14 @@ export class ComponentRepository extends BaseRepository {
     }
   }
 
-  async getLinkSuggestions(skip: number, limit: number): Promise<{ data: LinkSuggestion[]; total: number }> {
+  async getLinkSuggestions(skip: number, limit: number, search?: string): Promise<{ data: LinkSuggestion[]; total: number }> {
     const countQuery = await loadQuery('components/link-suggestions-count.cypher')
     const dataQuery = await loadQuery('components/link-suggestions.cypher')
 
-    const { records: countRecords } = await this.executeQuery(countQuery, {})
+    const { records: countRecords } = await this.executeQuery(countQuery, { search: search || null })
     const total = countRecords.length > 0 ? countRecords[0]!.get('total').toNumber() : 0
 
-    const { records } = await this.executeQuery(dataQuery, { skip, limit })
+    const { records } = await this.executeQuery(dataQuery, { skip, limit, search: search || null })
     return {
       data: records.map(record => ({
         purl: record.get('purl') as string,

--- a/server/repositories/platform.repository.ts
+++ b/server/repositories/platform.repository.ts
@@ -57,11 +57,11 @@ export interface PlatformDetail extends Platform {
  * docs/architecture/decisions/0004-technology-requires-component.md.
  */
 export class PlatformRepository extends BaseRepository {
-  async findAll(sort?: SortParams, limit = 50, offset = 0): Promise<{ data: Platform[]; total: number }> {
+  async findAll(sort?: SortParams, limit = 50, offset = 0, search?: string): Promise<{ data: Platform[]; total: number }> {
     const query = await loadQuery('platforms/find-all.cypher')
     const orderBy = buildOrderByClause(sort || {}, platformSortConfig)
     const finalQuery = injectOrderBy(query, orderBy)
-    const { records } = await this.executeQuery(finalQuery, { limit, offset })
+    const { records } = await this.executeQuery(finalQuery, { limit, offset, search: search || null })
 
     const total = records.length > 0 ? records[0]!.get('total').toNumber() : 0
     return { data: records.map(record => this.mapToPlatform(record)), total }

--- a/server/repositories/team.repository.ts
+++ b/server/repositories/team.repository.ts
@@ -127,11 +127,11 @@ export class TeamRepository extends BaseRepository {
    * 
    * @returns Array of teams
    */
-  async findAll(sort?: SortParams, limit = 50, offset = 0): Promise<{ data: Team[]; total: number }> {
+  async findAll(sort?: SortParams, limit = 50, offset = 0, search?: string): Promise<{ data: Team[]; total: number }> {
     const query = await loadQuery('teams/find-all.cypher')
     const orderBy = buildOrderByClause(sort || {}, teamSortConfig)
     const finalQuery = injectOrderBy(query, orderBy)
-    const { records } = await this.executeQuery(finalQuery, { limit, offset })
+    const { records } = await this.executeQuery(finalQuery, { limit, offset, search: search || null })
 
     const total = records.length > 0 ? records[0]!.get('total').toNumber() : 0
     return { data: records.map(record => this.mapToTeam(record)), total }

--- a/server/repositories/user.repository.ts
+++ b/server/repositories/user.repository.ts
@@ -138,11 +138,11 @@ export class UserRepository extends BaseRepository {
    * 
    * @returns Array of user summaries
    */
-  async findAllSummary(sort?: SortParams): Promise<UserSummary[]> {
+  async findAllSummary(sort?: SortParams, search?: string): Promise<UserSummary[]> {
     let query = await loadQuery('users/find-all-summary.cypher')
     const orderBy = buildOrderByClause(sort || {}, userSortConfig)
     query = query.replace(/ORDER BY .+$/, `ORDER BY ${orderBy}`)
-    const { records } = await this.executeQuery(query)
+    const { records } = await this.executeQuery(query, { search: search || null })
     
     return records.map(record => this.mapToUserSummary(record))
   }

--- a/server/repositories/version-constraint.repository.ts
+++ b/server/repositories/version-constraint.repository.ts
@@ -21,6 +21,7 @@ export interface ViolationFilters {
 export interface VersionConstraintFilters {
   scope?: string
   status?: string
+  search?: string
   sortBy?: string
   sortOrder?: 'asc' | 'desc'
   limit?: number
@@ -115,6 +116,11 @@ export class VersionConstraintRepository extends BaseRepository {
 
     const conditions: string[] = []
     const params: Record<string, unknown> = { limit, offset }
+
+    if (filters.search) {
+      conditions.push('toLower(vc.name) CONTAINS toLower($search)')
+      params.search = filters.search
+    }
 
     if (filters.scope) {
       conditions.push('vc.scope = $scope')

--- a/server/services/component.service.ts
+++ b/server/services/component.service.ts
@@ -77,8 +77,8 @@ export class ComponentService {
     return await this.componentRepo.findDependencies(identity, filters)
   }
 
-  async getLinkSuggestions(skip: number, limit: number): Promise<{ data: LinkSuggestion[]; count: number; total: number }> {
-    const { data, total } = await this.componentRepo.getLinkSuggestions(skip, limit)
+  async getLinkSuggestions(skip: number, limit: number, search?: string): Promise<{ data: LinkSuggestion[]; count: number; total: number }> {
+    const { data, total } = await this.componentRepo.getLinkSuggestions(skip, limit, search)
     return { data, count: data.length, total }
   }
 

--- a/server/services/platform.service.ts
+++ b/server/services/platform.service.ts
@@ -66,8 +66,8 @@ export class PlatformService {
   /**
    * Get all platforms with their approvals
    */
-  async findAll(sort?: SortParams, limit = 50, offset = 0): Promise<{ data: Platform[]; count: number; total: number }> {
-    const { data, total } = await this.platformRepo.findAll(sort, limit, offset)
+  async findAll(sort?: SortParams, limit = 50, offset = 0, search?: string): Promise<{ data: Platform[]; count: number; total: number }> {
+    const { data, total } = await this.platformRepo.findAll(sort, limit, offset, search)
     return { data, count: data.length, total }
   }
 

--- a/server/services/team.service.ts
+++ b/server/services/team.service.ts
@@ -18,8 +18,8 @@ export class TeamService {
    * 
    * @returns Array of teams with count
    */
-  async findAll(sort?: SortParams, limit = 50, offset = 0): Promise<{ data: Team[]; count: number; total: number }> {
-    const { data, total } = await this.teamRepo.findAll(sort, limit, offset)
+  async findAll(sort?: SortParams, limit = 50, offset = 0, search?: string): Promise<{ data: Team[]; count: number; total: number }> {
+    const { data, total } = await this.teamRepo.findAll(sort, limit, offset, search)
     return { data, count: data.length, total }
   }
 

--- a/server/services/user.service.ts
+++ b/server/services/user.service.ts
@@ -73,8 +73,8 @@ export class UserService {
    * 
    * @returns Array of user summaries
    */
-  async findAllSummary(sort?: SortParams): Promise<UserSummary[]> {
-    return await this.userRepo.findAllSummary(sort)
+  async findAllSummary(sort?: SortParams, search?: string): Promise<UserSummary[]> {
+    return await this.userRepo.findAllSummary(sort, search)
   }
 
   /**

--- a/server/utils/query-params.ts
+++ b/server/utils/query-params.ts
@@ -1,0 +1,13 @@
+/**
+ * Normalize a `getQuery()` value into a single trimmed search string.
+ *
+ * h3 returns `string[]` for repeated query params (e.g. `?search=a&search=b`);
+ * passing that straight into a Cypher `toLower($search)` throws at the DB layer.
+ * Takes the first value when an array is given, and treats an empty/whitespace
+ * string as no search.
+ */
+export function parseSearchParam(value: unknown): string | undefined {
+  const raw = Array.isArray(value) ? value[0] : value
+  const trimmed = typeof raw === 'string' ? raw.trim() : ''
+  return trimmed.length > 0 ? trimmed : undefined
+}

--- a/test/app/pages/components/index.test.ts
+++ b/test/app/pages/components/index.test.ts
@@ -29,6 +29,10 @@ describe('components index page', () => {
     vi.stubGlobal('useSortableTable', () => ({
       getSortableHeader: () => 'sortable'
     }))
+    vi.stubGlobal('useTableSearch', () => ({
+      searchInput: ref(''),
+      debouncedSearch: ref('')
+    }))
     vi.stubGlobal('usePaginatedSorting', usePaginatedSorting)
     vi.stubGlobal('useApiData', useApiData)
     vi.stubGlobal('useApiCount', useApiCount)
@@ -52,7 +56,8 @@ describe('components index page', () => {
           USwitch: true,
           UTable: { props: ['data'], template: '<div><slot name="empty" /></div>' },
           UTooltip: { template: '<span><slot /><slot name="content" /></span>' },
-          PaginatedTable: { template: '<section><slot name="header" /><slot name="empty" /></section>' }
+          PaginatedTable: { template: '<section><slot name="header" /><slot name="empty" /></section>' },
+          TableSearchHeader: { template: '<div><slot /></div>' }
         }
       }
     })

--- a/test/server/api/component-link-suggestions.spec.ts
+++ b/test/server/api/component-link-suggestions.spec.ts
@@ -55,7 +55,7 @@ describe('GET /api/components/link-suggestions', () => {
 
     await linkSuggestionsHandler(mockEvent({ query: { skip: '50', limit: '25' } }))
 
-    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(50, 25)
+    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(50, 25, undefined)
   })
 
   it('should clamp limit to 200 maximum', async () => {
@@ -63,7 +63,7 @@ describe('GET /api/components/link-suggestions', () => {
 
     await linkSuggestionsHandler(mockEvent({ query: { limit: '999' } }))
 
-    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(0, 200)
+    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(0, 200, undefined)
   })
 
   it('should clamp skip to 0 minimum', async () => {
@@ -71,7 +71,7 @@ describe('GET /api/components/link-suggestions', () => {
 
     await linkSuggestionsHandler(mockEvent({ query: { skip: '-10' } }))
 
-    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(0, 50)
+    expect(componentService.getLinkSuggestions).toHaveBeenCalledWith(0, 50, undefined)
   })
 
   it('should enforce superuser access', async () => {

--- a/test/server/utils/query-params.spec.ts
+++ b/test/server/utils/query-params.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest'
+import { parseSearchParam } from '../../../server/utils/query-params'
+
+describe('parseSearchParam', () => {
+  it('returns undefined when absent', () => {
+    expect(parseSearchParam(undefined)).toBeUndefined()
+  })
+
+  it('returns the trimmed string for a normal value', () => {
+    expect(parseSearchParam('  react  ')).toBe('react')
+  })
+
+  it('returns undefined for an empty or whitespace-only string', () => {
+    expect(parseSearchParam('')).toBeUndefined()
+    expect(parseSearchParam('   ')).toBeUndefined()
+  })
+
+  it('takes the first value when given an array (repeated query params)', () => {
+    expect(parseSearchParam(['react', 'vue'])).toBe('react')
+  })
+
+  it('returns undefined for a non-string value', () => {
+    expect(parseSearchParam(42)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Description

Introduces a shared search box across entity list pages, replacing ad-hoc per-page debounce logic with a common composable/component.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Changes Made

- Added shared `TableSearchHeader` component and `useTableSearch` composable (debounced search input).
- Wired a `search` query param through the components, licenses, platforms, teams, technologies, users, and version-constraints pages, their APIs, services, repositories, and Cypher queries.
- Restyled the technologies view-mode toggle as a segmented control.
- Added `run_mdlint` and `generate_docs` tools to the local-model MCP server; documented them in `CLAUDE.md`.

## Checklist

- [x] Lint (`npm run lint`) passes
- [x] Full test suite (`npm run test`) passes — 951 passed
- [x] OpenAPI docs regenerated (`public/openapi.json`)