### PR TITLE
Fix GitHub import missing private repos for own account

### DIFF
--- a/server/services/github-org-import.service.ts
+++ b/server/services/github-org-import.service.ts
@@ -101,7 +101,7 @@ export class GitHubOrgImportService {
     try {
       const repositories = input.repositories && input.repositories.length > 0
         ? input.repositories
-        : (await listGitHubOwnerRepositories(input.organization, input.filters || {})).map(repo => ({
+        : (await listGitHubOwnerRepositories(input.organization, input.filters || {}, input.githubToken)).map(repo => ({
             repositoryFullName: repo.full_name,
             repositoryUrl: repo.html_url
           }))

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -247,10 +247,51 @@ async function listRepositoriesForOwner(
 }
 
 /**
+ * List the token's own repositories via GET /user/repos, which — unlike
+ * GET /users/{username}/repos — is scoped to the authenticated account and
+ * includes private repos. There is no owner path segment: GitHub infers the
+ * account from the bearer token.
+ */
+async function listAuthenticatedUserRepositories(
+  filters: GitHubOrgRepositoryFilters = {},
+  token: string
+): Promise<GitHubOrgRepository[]> {
+  const nameRegex = compileNamePattern(filters.namePattern)
+  const repos: GitHubOrgRepository[] = []
+  const perPage = 100
+
+  for (let page = 1; ; page++) {
+    const url = `https://api.github.com/user/repos?affiliation=owner&visibility=all&sort=full_name&per_page=${perPage}&page=${page}`
+    const response = await fetchGitHub(url, 'authenticated user repositories', token)
+    const data = await response.json() as GitHubOrgRepository[]
+
+    repos.push(...data.filter(repo => matchesOrgRepositoryFilters(repo, filters, nameRegex)))
+
+    if (data.length < perPage) break
+  }
+
+  return repos
+}
+
+/** Fetch the login of the account a token belongs to, or null if it can't be resolved. */
+async function getAuthenticatedLogin(token: string): Promise<string | null> {
+  try {
+    const response = await fetchGitHub('https://api.github.com/user', 'authenticated user', token)
+    const data = await response.json() as { login?: string }
+    return data.login || null
+  } catch {
+    return null
+  }
+}
+
+/**
  * List repositories for a GitHub organization or user, following pagination.
  * Organization listing is attempted first so authenticated tokens can include
- * private organization repositories. If no organization exists, falls back to
- * the public user repositories endpoint.
+ * private organization repositories. If no organization exists and the owner
+ * is the token's own account, the authenticated /user/repos endpoint is used
+ * so private repos are included; otherwise falls back to the public user
+ * repositories endpoint (GET /users/{username}/repos only ever returns public
+ * repos, regardless of the caller's token or scopes).
  */
 export async function listGitHubOwnerRepositories(
   ownerInput: string,
@@ -263,6 +304,13 @@ export async function listGitHubOwnerRepositories(
     return await listRepositoriesForOwner(owner, 'organization', filters, token)
   } catch (error: unknown) {
     if (!isNotFoundError(error)) throw error
+  }
+
+  if (token) {
+    const login = await getAuthenticatedLogin(token)
+    if (login && login.toLowerCase() === owner.toLowerCase()) {
+      return await listAuthenticatedUserRepositories(filters, token)
+    }
   }
 
   return await listRepositoriesForOwner(owner, 'user', filters, token)

--- a/server/utils/github.ts
+++ b/server/utils/github.ts
@@ -279,7 +279,8 @@ async function getAuthenticatedLogin(token: string): Promise<string | null> {
     const response = await fetchGitHub('https://api.github.com/user', 'authenticated user', token)
     const data = await response.json() as { login?: string }
     return data.login || null
-  } catch {
+  } catch (error: unknown) {
+    logger.warn({ err: error }, 'Failed to resolve authenticated GitHub login')
     return null
   }
 }

--- a/test/server/services/github-org-import.service.spec.ts
+++ b/test/server/services/github-org-import.service.spec.ts
@@ -117,10 +117,45 @@ describe('GitHubOrgImportService', () => {
     expect(repo.createItems).toHaveBeenCalledWith('job-1', [
       { repositoryFullName: 'acme/repo-a', repositoryUrl: 'https://github.com/acme/repo-a', ownerTeam: null, systemName: null }
     ])
+    expect(listGitHubOwnerRepositories).toHaveBeenCalledWith('acme', {}, undefined)
     expect(repo.markItemFinished).toHaveBeenCalledWith('job-1', 'acme/repo-a', 'skipped', {
       message: 'Dry run only'
     })
     expect(repo.markCompleted).toHaveBeenCalledWith('job-1')
+  })
+
+  it('forwards the requesting user\'s githubToken when resolving repositories to import', async () => {
+    const repo = createRepoMocks()
+    vi.mocked(listGitHubOwnerRepositories).mockResolvedValue([
+      {
+        name: 'repo-a',
+        full_name: 'acme/repo-a',
+        html_url: 'https://github.com/acme/repo-a',
+        description: null,
+        default_branch: 'main',
+        language: 'TypeScript',
+        private: true,
+        fork: false,
+        archived: false,
+        topics: []
+      }
+    ])
+
+    const service = new GitHubOrgImportService(
+      repo as never,
+      { import: vi.fn() } as never,
+      { create: vi.fn() } as never
+    )
+
+    await service.process('job-1', {
+      organization: 'acme',
+      ownerTeam: 'Platform',
+      dryRun: true,
+      userId: 'user-1',
+      githubToken: 'user-token-abc'
+    })
+
+    expect(listGitHubOwnerRepositories).toHaveBeenCalledWith('acme', {}, 'user-token-abc')
   })
 
   it('previews repositories for an owner without creating a job', async () => {

--- a/test/server/utils/github.spec.ts
+++ b/test/server/utils/github.spec.ts
@@ -106,6 +106,37 @@ describe('GitHub utilities', () => {
       expect(result).toHaveLength(1)
       expect(result[0].full_name).toBe('localgod/polaris')
     })
+
+    it('uses the authenticated /user/repos endpoint (including private repos) when the owner is the token\'s own account', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Not Found' }), { status: 404, statusText: 'Not Found' }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ login: 'localgod' }), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify([
+          repo('polaris', { full_name: 'localgod/polaris', html_url: 'https://github.com/localgod/polaris' }),
+          repo('secret-project', { full_name: 'localgod/secret-project', html_url: 'https://github.com/localgod/secret-project', private: true })
+        ]), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await listGitHubOwnerRepositories('localgod', {}, 'user-token-abc')
+
+      expect(fetchMock).toHaveBeenNthCalledWith(1, expect.stringContaining('/orgs/localgod/repos?type=all'), expect.any(Object))
+      expect(fetchMock).toHaveBeenNthCalledWith(2, 'https://api.github.com/user', expect.any(Object))
+      expect(fetchMock).toHaveBeenNthCalledWith(3, expect.stringContaining('/user/repos?affiliation=owner&visibility=all'), expect.any(Object))
+      expect(result.map(r => r.full_name)).toEqual(['localgod/polaris', 'localgod/secret-project'])
+    })
+
+    it('falls back to the public user endpoint when the token belongs to a different account', async () => {
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(new Response(JSON.stringify({ message: 'Not Found' }), { status: 404, statusText: 'Not Found' }))
+        .mockResolvedValueOnce(new Response(JSON.stringify({ login: 'someone-else' }), { status: 200 }))
+        .mockResolvedValueOnce(new Response(JSON.stringify([repo('polaris', { full_name: 'localgod/polaris', html_url: 'https://github.com/localgod/polaris' })]), { status: 200 }))
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await listGitHubOwnerRepositories('localgod', {}, 'user-token-abc')
+
+      expect(fetchMock).toHaveBeenNthCalledWith(3, expect.stringContaining('/users/localgod/repos?type=owner'), expect.any(Object))
+      expect(result[0].full_name).toBe('localgod/polaris')
+    })
   })
 
   describe('cloneRepository()', () => {


### PR DESCRIPTION
## Description

When importing a system from GitHub while logged in via GitHub OAuth, only public repositories showed up — private repos owned by the logged-in user were missing, even with the `repo` OAuth scope granted.

## Root Cause

`server/utils/github.ts` fell back to `GET /users/{username}/repos` when the requested owner wasn't a GitHub organization. That endpoint always returns only public repos, regardless of the caller's token or scopes — it's not scoped to the authenticated user. The endpoint that returns your own repos (including private ones) is `GET /user/repos`, which has no owner path segment — GitHub infers the account from the bearer token.

A second, related bug: the background import job (`GitHubOrgImportService.process()`) resolved repositories via `listGitHubOwnerRepositories()` without passing the user's `githubToken` at all when repos weren't pre-selected from the preview list — silently falling back to an anonymous/env token and dropping private repos even after the primary fix.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Changes Made

- `server/utils/github.ts`: when the org lookup 404s and a token is present, resolve the token's own login (`GET /user`) and, if it matches the requested owner, list repos via the authenticated `GET /user/repos?affiliation=owner&visibility=all` endpoint instead of the public `GET /users/{username}/repos`.
- `server/services/github-org-import.service.ts`: forward `input.githubToken` when resolving repositories by filter in `process()`.
- Added test coverage for both fixes.

## Checklist

- [x] Lint (`npm run lint`) passes
- [x] Full test suite (`npm run test`) passes — 959 passed
- [x] OpenAPI docs regenerated — no changes needed