### PR TITLE
feat: automated service and team compliance scorecard with per-check drill-down

### DIFF
--- a/app/components/ComplianceScorecard.vue
+++ b/app/components/ComplianceScorecard.vue
@@ -1,0 +1,45 @@
+<template>
+  <UCard>
+    <template #header>
+      <div class="flex items-center justify-between gap-3">
+        <div class="flex items-center gap-2">
+          <UIcon name="i-lucide-shield-check" class="w-5 h-5 text-(--ui-text-muted)" />
+          <h2 class="text-lg font-semibold">Compliance Scorecard</h2>
+        </div>
+        <UBadge :color="scoreColor" variant="subtle">
+          {{ scorecard.score }} / {{ scorecard.maxScore }}
+        </UBadge>
+      </div>
+    </template>
+
+    <UProgress :model-value="scorecard.score" :max="scorecard.maxScore" :color="scoreColor" class="mb-4" />
+
+    <ul class="space-y-3">
+      <li v-for="check in scorecard.checks" :key="check.id" class="flex items-start gap-2">
+        <UIcon
+          :name="check.passed ? 'i-lucide-check-circle-2' : 'i-lucide-x-circle'"
+          :class="check.passed ? 'text-(--ui-success)' : 'text-(--ui-error)'"
+          class="w-5 h-5 mt-0.5 shrink-0"
+        />
+        <div>
+          <p class="font-medium text-sm">{{ check.label }}</p>
+          <p class="text-sm text-(--ui-text-muted)">{{ check.detail }}</p>
+        </div>
+      </li>
+    </ul>
+  </UCard>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { Scorecard } from '~~/types/api'
+
+const props = defineProps<{ scorecard: Scorecard }>()
+
+const scoreColor = computed<'success' | 'warning' | 'error'>(() => {
+  const ratio = props.scorecard.maxScore === 0 ? 1 : props.scorecard.score / props.scorecard.maxScore
+  if (ratio === 1) return 'success'
+  if (ratio >= 0.6) return 'warning'
+  return 'error'
+})
+</script>

--- a/app/pages/systems/[name]/index.vue
+++ b/app/pages/systems/[name]/index.vue
@@ -52,6 +52,8 @@
         </EntityDescriptionList>
       </UCard>
 
+      <ComplianceScorecard v-if="scorecardData?.data" :scorecard="scorecardData.data" />
+
       <SystemIssues v-if="issuesData?.data" :issues="issuesData.data" />
 
       <PaginatedTable
@@ -93,6 +95,7 @@
 <script setup lang="ts">
 import { defineAsyncComponent, h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { Scorecard } from '~~/types/api'
 
 const route = useRoute()
 const { getSortableHeader } = useSortableTable()
@@ -179,6 +182,11 @@ interface IssuesResponse {
   data: SystemIssues
 }
 
+interface ScorecardResponse {
+  success: boolean
+  data: Scorecard
+}
+
 interface Repository {
   name: string
   url: string
@@ -198,6 +206,10 @@ const { data: graphData } = useFetch<GraphResponse>(
 
 const { data: issuesData } = useFetch<IssuesResponse>(
   () => `/api/systems/${encodeURIComponent(route.params.name as string)}/issues`
+)
+
+const { data: scorecardData } = useFetch<ScorecardResponse>(
+  () => `/api/systems/${encodeURIComponent(route.params.name as string)}/scorecard`
 )
 
 const { data: reposData } = useFetch<RepositoriesResponse>(

--- a/app/pages/teams/[name].vue
+++ b/app/pages/teams/[name].vue
@@ -27,6 +27,8 @@
 
       <EntityStatStrip :items="statItems" />
 
+      <ComplianceScorecard v-if="scorecardData?.data" :scorecard="scorecardData.data" />
+
       <UCard>
         <UTabs :items="tabItems">
           <template #members>
@@ -66,6 +68,7 @@
 <script setup lang="ts">
 import { h } from 'vue'
 import type { TableColumn } from '@nuxt/ui'
+import type { Scorecard } from '~~/types/api'
 
 const { getSortableHeader } = useSortableTable()
 const memberSorting = ref([])
@@ -117,6 +120,11 @@ interface TeamDetail {
 interface TeamResponse {
   success: boolean
   data: TeamDetail
+}
+
+interface ScorecardResponse {
+  success: boolean
+  data: Scorecard
 }
 
 const memberColumns: TableColumn<Member>[] = [
@@ -227,6 +235,10 @@ const approvalColumns: TableColumn<Approval>[] = [
 ]
 
 const { data, pending, error } = await useFetch<TeamResponse>(() => `/api/teams/${encodeURIComponent(route.params.name as string)}`)
+
+const { data: scorecardData } = useFetch<ScorecardResponse>(
+  () => `/api/teams/${encodeURIComponent(route.params.name as string)}/scorecard`
+)
 
 const statItems = computed(() => [
   { label: 'Technologies Owned', value: data.value?.data?.technologyCount || 0 },

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Polaris API",
-    "version": "0.6.49",
+    "version": "0.6.52",
     "description": "# Polaris Technology Catalog API\n\nThe Polaris API provides programmatic access to the technology catalog, enabling automation, integration, and custom tooling.\n\n## Key Features\n\n- **RESTful Design** - Resource-based URLs with proper HTTP methods\n- **Comprehensive Coverage** - Systems, Teams, Technologies, Components, Policies, and more\n- **Developer-Friendly** - Clear error messages and consistent response structure\n\n## Authentication\n\nMost endpoints require authentication using session-based authentication integrated with the web application.\n\n**Authorization Levels:**\n- **Public** - No authentication required\n- **Authenticated** - Valid user session required  \n- **Team Member** - User must belong to a team\n- **Team Owner** - User must belong to team that owns the resource\n- **Superuser** - User must have superuser role\n\n## Response Format\n\nAll successful responses follow this structure:\n```json\n{\n  \"success\": true,\n  \"data\": [...],\n  \"count\": 10\n}\n```\n\nAll errors follow this structure:\n```json\n{\n  \"statusCode\": 404,\n  \"message\": \"Resource 'example' not found\"\n}\n```\n\n## Richardson Maturity Model\n\nThis API implements **RMM Level 2** with proper use of HTTP methods and status codes.",
     "license": {
       "name": "MIT",
@@ -3783,6 +3783,37 @@
         }
       }
     },
+    "/api/teams/{name}/scorecard": {
+      "get": {
+        "tags": [
+          "Teams"
+        ],
+        "summary": "Get the compliance scorecard for a team",
+        "description": "Computes an on-demand governance scorecard from existing compliance data:\nSBOM freshness across owned systems, Eliminate-marked technologies in use,\ndisallowed-license usage, critical version constraint violations, and TIME\nclassification coverage of used technologies.\n",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Team name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Scorecard computed"
+          },
+          "400": {
+            "description": "Team name is required"
+          },
+          "404": {
+            "description": "Team not found"
+          }
+        }
+      }
+    },
     "/teams/{name}/approvals": {
       "get": {
         "tags": [
@@ -4129,6 +4160,37 @@
           },
           "403": {
             "description": "Forbidden - user's team does not own this system"
+          },
+          "404": {
+            "description": "System not found"
+          }
+        }
+      }
+    },
+    "/api/systems/{name}/scorecard": {
+      "get": {
+        "tags": [
+          "Systems"
+        ],
+        "summary": "Get the compliance scorecard for a system",
+        "description": "Computes an on-demand governance scorecard from existing compliance data:\nSBOM freshness, Eliminate-marked technologies in use, disallowed-license\nusage, critical version constraint violations, and TIME classification\ncoverage of used technologies.\n",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "System name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Scorecard computed"
+          },
+          "400": {
+            "description": "System name is required"
           },
           "404": {
             "description": "System not found"

--- a/server/api/systems/[name]/scorecard.get.ts
+++ b/server/api/systems/[name]/scorecard.get.ts
@@ -1,0 +1,44 @@
+import { scorecardService } from '../../../services/singletons'
+import { sendSuccess, sendNotFound } from '../../../utils/response'
+
+/**
+ * @openapi
+ * /api/systems/{name}/scorecard:
+ *   get:
+ *     tags:
+ *       - Systems
+ *     summary: Get the compliance scorecard for a system
+ *     description: |
+ *       Computes an on-demand governance scorecard from existing compliance data:
+ *       SBOM freshness, Eliminate-marked technologies in use, disallowed-license
+ *       usage, critical version constraint violations, and TIME classification
+ *       coverage of used technologies.
+ *     parameters:
+ *       - name: name
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: System name
+ *     responses:
+ *       200:
+ *         description: Scorecard computed
+ *       400:
+ *         description: System name is required
+ *       404:
+ *         description: System not found
+ */
+export default defineEventHandler(async (event) => {
+  const rawName = getRouterParam(event, 'name')
+
+  if (!rawName) {
+    throw createError({ statusCode: 400, message: 'System name is required' })
+  }
+
+  const name = decodeURIComponent(rawName)
+  const scorecard = await scorecardService.getSystemScorecard(name)
+
+  if (scorecard === null) sendNotFound('System', name)
+
+  return sendSuccess(event, scorecard!)
+})

--- a/server/api/teams/[name]/scorecard.get.ts
+++ b/server/api/teams/[name]/scorecard.get.ts
@@ -1,0 +1,44 @@
+import { scorecardService } from '../../../services/singletons'
+import { sendSuccess, sendNotFound } from '../../../utils/response'
+
+/**
+ * @openapi
+ * /api/teams/{name}/scorecard:
+ *   get:
+ *     tags:
+ *       - Teams
+ *     summary: Get the compliance scorecard for a team
+ *     description: |
+ *       Computes an on-demand governance scorecard from existing compliance data:
+ *       SBOM freshness across owned systems, Eliminate-marked technologies in use,
+ *       disallowed-license usage, critical version constraint violations, and TIME
+ *       classification coverage of used technologies.
+ *     parameters:
+ *       - name: name
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Team name
+ *     responses:
+ *       200:
+ *         description: Scorecard computed
+ *       400:
+ *         description: Team name is required
+ *       404:
+ *         description: Team not found
+ */
+export default defineEventHandler(async (event) => {
+  const rawName = getRouterParam(event, 'name')
+
+  if (!rawName) {
+    throw createError({ statusCode: 400, message: 'Team name is required' })
+  }
+
+  const name = decodeURIComponent(rawName)
+  const scorecard = await scorecardService.getTeamScorecard(name)
+
+  if (scorecard === null) sendNotFound('Team', name)
+
+  return sendSuccess(event, scorecard!)
+})

--- a/server/database/queries/systems/scorecard.cypher
+++ b/server/database/queries/systems/scorecard.cypher
@@ -25,9 +25,13 @@ CALL {
     WHERE tech IS NOT NULL AND blanketApproval.environment IS NULL
   WITH tech, coalesce(envApproval.time, blanketApproval.time) AS resolvedTime
   WHERE tech IS NOT NULL
-  RETURN count(tech) AS usedTechnologyCount,
-         count(CASE WHEN resolvedTime IS NULL THEN 1 END) AS unclassifiedCount,
-         count(CASE WHEN resolvedTime = 'eliminate' THEN 1 END) AS eliminateCount
+  // DISTINCT guards against row multiplication if a team ever ends up with more
+  // than one matching APPROVES relationship for the same (team, tech, environment) —
+  // nothing at the database level prevents that (Neo4j Community Edition has no
+  // relationship-cardinality constraints; see ADR-0004).
+  RETURN count(DISTINCT tech) AS usedTechnologyCount,
+         count(DISTINCT CASE WHEN resolvedTime IS NULL THEN tech END) AS unclassifiedCount,
+         count(DISTINCT CASE WHEN resolvedTime = 'eliminate' THEN tech END) AS eliminateCount
 }
 
 CALL {

--- a/server/database/queries/systems/scorecard.cypher
+++ b/server/database/queries/systems/scorecard.cypher
@@ -1,0 +1,45 @@
+// Raw signals for the system compliance scorecard: SBOM freshness, TIME
+// classification of used technologies (resolved via the owning team's
+// approval, environment-aware — same precedence as compliance/find-violations.cypher),
+// and disallowed-license usage. Critical version-constraint violations are
+// computed separately in the service layer (semver evaluation happens in JS).
+//
+// Staged CALL {} subqueries avoid cross-multiplying unrelated OPTIONAL MATCHes.
+MATCH (sys:System {name: $name})
+OPTIONAL MATCH (owner:Team)-[:OWNS]->(sys)
+
+CALL {
+  WITH sys
+  OPTIONAL MATCH (sys)-[:HAS_SOURCE_IN]->(r:Repository)
+  RETURN max(r.lastSbomScanAt) AS lastSbomScanAt
+}
+
+CALL {
+  WITH sys, owner
+  OPTIONAL MATCH (sys)-[:USES]->(:Component)-[:IS_VERSION_OF]->(tech:Technology)
+  WITH sys, owner, collect(DISTINCT tech) AS usedTechs
+  UNWIND (CASE WHEN size(usedTechs) = 0 THEN [null] ELSE usedTechs END) AS tech
+  OPTIONAL MATCH (owner)-[envApproval:APPROVES]->(tech)
+    WHERE tech IS NOT NULL AND sys.environment IS NOT NULL AND envApproval.environment = sys.environment
+  OPTIONAL MATCH (owner)-[blanketApproval:APPROVES]->(tech)
+    WHERE tech IS NOT NULL AND blanketApproval.environment IS NULL
+  WITH tech, coalesce(envApproval.time, blanketApproval.time) AS resolvedTime
+  WHERE tech IS NOT NULL
+  RETURN count(tech) AS usedTechnologyCount,
+         count(CASE WHEN resolvedTime IS NULL THEN 1 END) AS unclassifiedCount,
+         count(CASE WHEN resolvedTime = 'eliminate' THEN 1 END) AS eliminateCount
+}
+
+CALL {
+  WITH sys
+  OPTIONAL MATCH (sys)-[:USES]->(comp:Component)-[:HAS_LICENSE]->(lic:License)
+    WHERE lic.allowed = false
+  RETURN count(DISTINCT comp) AS licenseViolationCount
+}
+
+RETURN
+  lastSbomScanAt,
+  usedTechnologyCount,
+  unclassifiedCount,
+  eliminateCount,
+  licenseViolationCount

--- a/server/database/queries/teams/scorecard.cypher
+++ b/server/database/queries/teams/scorecard.cypher
@@ -1,0 +1,25 @@
+// Raw signals for the team compliance scorecard that aren't already covered
+// by TeamRepository.findUsage() (teams/find-usage.cypher supplies the TIME
+// classification coverage / Eliminate-violation counts): SBOM freshness across
+// owned systems, and disallowed-license usage across owned systems.
+//
+// Staged CALL {} subqueries avoid cross-multiplying unrelated OPTIONAL MATCHes.
+MATCH (t:Team {name: $name})
+
+CALL {
+  WITH t
+  OPTIONAL MATCH (t)-[:OWNS]->(sys:System)
+  OPTIONAL MATCH (sys)-[:HAS_SOURCE_IN]->(r:Repository)
+  WITH sys, max(r.lastSbomScanAt) AS lastSbomScanAt
+  WITH collect(CASE WHEN sys IS NOT NULL THEN {system: sys.name, lastSbomScanAt: lastSbomScanAt} END) AS raw
+  RETURN [x IN raw WHERE x IS NOT NULL] AS systemScans
+}
+
+CALL {
+  WITH t
+  OPTIONAL MATCH (t)-[:OWNS]->(sys2:System)-[:USES]->(comp:Component)-[:HAS_LICENSE]->(lic:License)
+    WHERE lic.allowed = false
+  RETURN count(DISTINCT comp) AS licenseViolationCount
+}
+
+RETURN systemScans, licenseViolationCount

--- a/server/repositories/system.repository.ts
+++ b/server/repositories/system.repository.ts
@@ -46,6 +46,14 @@ export interface GraphComponentRow {
   dependsOnPurls: string[]
 }
 
+export interface SystemScorecardRaw {
+  lastSbomScanAt: string | null
+  usedTechnologyCount: number
+  unclassifiedCount: number
+  eliminateCount: number
+  licenseViolationCount: number
+}
+
 export interface ComponentIssueRow {
   componentName: string
   componentVersion: string | null
@@ -289,6 +297,28 @@ export class SystemRepository extends BaseRepository {
       isDeprecated: (record.get('isDeprecated') as boolean) ?? false,
       maintenanceStatus: record.get('maintenanceStatus') as string | null,
     }))
+  }
+
+  /**
+   * Get raw signals for the compliance scorecard: SBOM freshness, TIME
+   * classification of used technologies, and disallowed-license usage.
+   *
+   * System-not-found must be checked by the caller before invoking this method.
+   *
+   * @param name - System name
+   * @returns Raw scorecard signals
+   */
+  async getScorecardRaw(name: string): Promise<SystemScorecardRaw> {
+    const query = await loadQuery('systems/scorecard.cypher')
+    const { records } = await this.executeQuery(query, { name })
+    const record = records[0]!
+    return {
+      lastSbomScanAt: record.get('lastSbomScanAt')?.toString() || null,
+      usedTechnologyCount: record.get('usedTechnologyCount')?.toNumber() || 0,
+      unclassifiedCount: record.get('unclassifiedCount')?.toNumber() || 0,
+      eliminateCount: record.get('eliminateCount')?.toNumber() || 0,
+      licenseViolationCount: record.get('licenseViolationCount')?.toNumber() || 0,
+    }
   }
 
   /**

--- a/server/repositories/team.repository.ts
+++ b/server/repositories/team.repository.ts
@@ -100,6 +100,11 @@ export interface TeamUsageResult {
   }
 }
 
+export interface TeamScorecardRaw {
+  systemScans: Array<{ system: string; lastSbomScanAt: string | null }>
+  licenseViolationCount: number
+}
+
 export interface ApprovalStatus {
   team: string
   technology: string
@@ -369,6 +374,30 @@ export class TeamRepository extends BaseRepository {
         violations: usage.filter(u => u.complianceStatus === 'violation').length,
         migrationNeeded: usage.filter(u => u.complianceStatus === 'migration-needed').length
       }
+    }
+  }
+
+  /**
+   * Get raw signals for the compliance scorecard that aren't already covered
+   * by findUsage(): SBOM freshness across owned systems, and disallowed-license
+   * usage across owned systems.
+   *
+   * Team-not-found must be checked by the caller before invoking this method.
+   *
+   * @param name - Team name
+   * @returns Raw scorecard signals
+   */
+  async getScorecardRaw(name: string): Promise<TeamScorecardRaw> {
+    const query = await loadQuery('teams/scorecard.cypher')
+    const { records } = await this.executeQuery(query, { name })
+    const record = records[0]!
+    const systemScans = (record.get('systemScans') as Array<{ system: string; lastSbomScanAt: unknown }>) ?? []
+    return {
+      systemScans: systemScans.map(scan => ({
+        system: scan.system,
+        lastSbomScanAt: scan.lastSbomScanAt == null ? null : String(scan.lastSbomScanAt)
+      })),
+      licenseViolationCount: record.get('licenseViolationCount')?.toNumber() || 0
     }
   }
 

--- a/server/repositories/version-constraint.repository.ts
+++ b/server/repositories/version-constraint.repository.ts
@@ -167,6 +167,11 @@ export class VersionConstraintRepository extends BaseRepository {
       params.technology = filters.technology
     }
 
+    if (filters.system) {
+      conditions.push('sys.name = $system')
+      params.system = filters.system
+    }
+
     const finalQuery = injectWhereConditions(query, conditions)
 
     const { records } = await this.executeQuery(finalQuery, params)

--- a/server/services/scorecard.service.ts
+++ b/server/services/scorecard.service.ts
@@ -1,0 +1,169 @@
+import { SystemRepository } from '../repositories/system.repository'
+import { TeamRepository } from '../repositories/team.repository'
+import { VersionConstraintService } from './version-constraint.service'
+import type { Scorecard, ScorecardCheck } from '~~/types/api'
+
+const SBOM_FRESHNESS_DAYS = 30
+
+/**
+ * Service computing on-demand governance scorecards for Systems and Teams
+ * from existing compliance data (no persistence — recomputed per request).
+ */
+export class ScorecardService {
+  private systemRepo: SystemRepository
+  private teamRepo: TeamRepository
+  private versionConstraintService: VersionConstraintService
+
+  constructor() {
+    this.systemRepo = new SystemRepository()
+    this.teamRepo = new TeamRepository()
+    this.versionConstraintService = new VersionConstraintService()
+  }
+
+  /**
+   * Compute the scorecard for a system.
+   *
+   * @param name - System name
+   * @returns Scorecard, or null if the system does not exist
+   */
+  async getSystemScorecard(name: string): Promise<Scorecard | null> {
+    const system = await this.systemRepo.findByName(name)
+    if (!system) return null
+
+    const [raw, criticalViolations] = await Promise.all([
+      this.systemRepo.getScorecardRaw(name),
+      this.versionConstraintService.getViolations({ system: name, severity: 'critical' })
+    ])
+
+    const checks: ScorecardCheck[] = [
+      this.sbomFreshnessCheck(raw.lastSbomScanAt),
+      this.eliminateViolationsCheck(raw.eliminateCount, raw.usedTechnologyCount),
+      this.licenseViolationsCheck(raw.licenseViolationCount),
+      this.criticalConstraintCheck(criticalViolations.summary.critical),
+      this.classificationCoverageCheck(raw.unclassifiedCount, raw.usedTechnologyCount)
+    ]
+
+    return this.buildScorecard(checks)
+  }
+
+  /**
+   * Compute the scorecard for a team.
+   *
+   * @param name - Team name
+   * @returns Scorecard, or null if the team does not exist
+   */
+  async getTeamScorecard(name: string): Promise<Scorecard | null> {
+    const team = await this.teamRepo.findByName(name)
+    if (!team) return null
+
+    const [raw, usage, criticalViolations] = await Promise.all([
+      this.teamRepo.getScorecardRaw(name),
+      this.teamRepo.findUsage(name),
+      this.versionConstraintService.getViolations({ team: name, severity: 'critical' })
+    ])
+
+    const checks: ScorecardCheck[] = [
+      this.teamSbomFreshnessCheck(raw.systemScans),
+      this.eliminateViolationsCheck(usage.summary.violations, usage.summary.totalTechnologies),
+      this.licenseViolationsCheck(raw.licenseViolationCount),
+      this.criticalConstraintCheck(criticalViolations.summary.critical),
+      this.classificationCoverageCheck(usage.summary.unapproved, usage.summary.totalTechnologies)
+    ]
+
+    return this.buildScorecard(checks)
+  }
+
+  private buildScorecard(checks: ScorecardCheck[]): Scorecard {
+    return {
+      score: checks.filter(check => check.passed).length,
+      maxScore: checks.length,
+      checks
+    }
+  }
+
+  private sbomFreshnessCheck(lastSbomScanAt: string | null): ScorecardCheck {
+    const passed = this.isFresh(lastSbomScanAt)
+    return {
+      id: 'sbom-freshness',
+      label: 'SBOM freshness',
+      passed,
+      detail: lastSbomScanAt
+        ? `Last SBOM scan was ${this.daysSince(lastSbomScanAt)} day(s) ago`
+        : 'No SBOM scan has been recorded'
+    }
+  }
+
+  private teamSbomFreshnessCheck(systemScans: Array<{ system: string; lastSbomScanAt: string | null }>): ScorecardCheck {
+    if (systemScans.length === 0) {
+      return {
+        id: 'sbom-freshness',
+        label: 'SBOM freshness',
+        passed: true,
+        detail: 'Team owns no systems'
+      }
+    }
+
+    const stale = systemScans.filter(scan => !this.isFresh(scan.lastSbomScanAt))
+    return {
+      id: 'sbom-freshness',
+      label: 'SBOM freshness',
+      passed: stale.length === 0,
+      detail: stale.length === 0
+        ? `All ${systemScans.length} owned system(s) have a fresh SBOM scan`
+        : `${stale.length} of ${systemScans.length} owned system(s) have a stale or missing SBOM scan`
+    }
+  }
+
+  private eliminateViolationsCheck(violationCount: number, usedTechnologyCount: number): ScorecardCheck {
+    return {
+      id: 'no-eliminate-violations',
+      label: 'Eliminate violations',
+      passed: violationCount === 0,
+      detail: violationCount === 0
+        ? 'No technologies marked for elimination are in use'
+        : `${violationCount} of ${usedTechnologyCount} used technologies are marked for elimination`
+    }
+  }
+
+  private licenseViolationsCheck(licenseViolationCount: number): ScorecardCheck {
+    return {
+      id: 'no-license-violations',
+      label: 'License violations',
+      passed: licenseViolationCount === 0,
+      detail: licenseViolationCount === 0
+        ? 'No components use a disallowed license'
+        : `${licenseViolationCount} component(s) use a disallowed license`
+    }
+  }
+
+  private criticalConstraintCheck(criticalViolationCount: number): ScorecardCheck {
+    return {
+      id: 'no-critical-version-violations',
+      label: 'Critical version constraint violations',
+      passed: criticalViolationCount === 0,
+      detail: criticalViolationCount === 0
+        ? 'No critical version constraint violations'
+        : `${criticalViolationCount} critical version constraint violation(s)`
+    }
+  }
+
+  private classificationCoverageCheck(unclassifiedCount: number, usedTechnologyCount: number): ScorecardCheck {
+    return {
+      id: 'time-classification-coverage',
+      label: 'TIME classification coverage',
+      passed: unclassifiedCount === 0,
+      detail: unclassifiedCount === 0
+        ? `All ${usedTechnologyCount} used technologies have a TIME classification`
+        : `${unclassifiedCount} of ${usedTechnologyCount} used technologies have no TIME classification`
+    }
+  }
+
+  private isFresh(lastSbomScanAt: string | null): boolean {
+    if (!lastSbomScanAt) return false
+    return this.daysSince(lastSbomScanAt) < SBOM_FRESHNESS_DAYS
+  }
+
+  private daysSince(iso: string): number {
+    return Math.floor((Date.now() - new Date(iso).getTime()) / (1000 * 60 * 60 * 24))
+  }
+}

--- a/server/services/scorecard.service.ts
+++ b/server/services/scorecard.service.ts
@@ -62,12 +62,20 @@ export class ScorecardService {
       this.versionConstraintService.getViolations({ team: name, severity: 'critical' })
     ])
 
+    // usage.summary.unapproved only counts technologies with no APPROVES relationship
+    // at all — it misses complianceStatus 'unknown' (an APPROVES relationship exists
+    // but its `time` isn't one of the recognized TIME values). Coverage means "has a
+    // recognized TIME classification", so both cases count as unclassified.
+    const unclassifiedCount = usage.usage.filter(
+      u => u.complianceStatus === 'unapproved' || u.complianceStatus === 'unknown'
+    ).length
+
     const checks: ScorecardCheck[] = [
       this.teamSbomFreshnessCheck(raw.systemScans),
       this.eliminateViolationsCheck(usage.summary.violations, usage.summary.totalTechnologies),
       this.licenseViolationsCheck(raw.licenseViolationCount),
       this.criticalConstraintCheck(criticalViolations.summary.critical),
-      this.classificationCoverageCheck(usage.summary.unapproved, usage.summary.totalTechnologies)
+      this.classificationCoverageCheck(unclassifiedCount, usage.summary.totalTechnologies)
     ]
 
     return this.buildScorecard(checks)

--- a/server/services/singletons.ts
+++ b/server/services/singletons.ts
@@ -31,6 +31,7 @@ import { PackageMetadataService } from './package-metadata.service'
 import { SecurityScoreService } from './security-score.service'
 import { VulnerabilityService } from './vulnerability.service'
 import { HealthRefreshService } from './health-refresh.service'
+import { ScorecardService } from './scorecard.service'
 
 export const technologyService = new TechnologyService()
 export const platformService = new PlatformService()
@@ -53,3 +54,4 @@ export const packageMetadataService = new PackageMetadataService()
 export const securityScoreService = new SecurityScoreService()
 export const vulnerabilityService = new VulnerabilityService()
 export const healthRefreshService = new HealthRefreshService()
+export const scorecardService = new ScorecardService()

--- a/test/server/api/systems-scorecard.spec.ts
+++ b/test/server/api/systems-scorecard.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import handler from '../../../server/api/systems/[name]/scorecard.get'
+import { scorecardService } from '../../../server/services/singletons'
+import type { Scorecard } from '../../../types/api'
+
+vi.mock('../../../server/services/singletons', () => ({
+  scorecardService: { getSystemScorecard: vi.fn() }
+}))
+
+const mockScorecard: Scorecard = {
+  score: 5,
+  maxScore: 5,
+  checks: [
+    { id: 'sbom-freshness', label: 'SBOM freshness', passed: true, detail: 'ok' }
+  ]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/systems/{name}/scorecard', () => {
+  it('returns the scorecard for an existing system', async () => {
+    vi.mocked(scorecardService.getSystemScorecard).mockResolvedValue(mockScorecard)
+
+    const result = await handler(mockEvent({ params: { name: 'checkout-api' } }))
+
+    expect(scorecardService.getSystemScorecard).toHaveBeenCalledWith('checkout-api')
+    expect(result).toMatchObject({ success: true, data: mockScorecard })
+  })
+
+  it('decodes URL-encoded system names', async () => {
+    vi.mocked(scorecardService.getSystemScorecard).mockResolvedValue(mockScorecard)
+
+    await handler(mockEvent({ params: { name: 'checkout%20api' } }))
+
+    expect(scorecardService.getSystemScorecard).toHaveBeenCalledWith('checkout api')
+  })
+
+  it('returns 404 when the system does not exist', async () => {
+    vi.mocked(scorecardService.getSystemScorecard).mockResolvedValue(null)
+
+    await expect(handler(mockEvent({ params: { name: 'missing-system' } }))).rejects.toMatchObject({
+      statusCode: 404
+    })
+  })
+
+  it('returns 400 when the name param is missing', async () => {
+    await expect(handler(mockEvent({ params: {} }))).rejects.toMatchObject({
+      statusCode: 400
+    })
+  })
+})

--- a/test/server/api/teams-scorecard.spec.ts
+++ b/test/server/api/teams-scorecard.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import handler from '../../../server/api/teams/[name]/scorecard.get'
+import { scorecardService } from '../../../server/services/singletons'
+import type { Scorecard } from '../../../types/api'
+
+vi.mock('../../../server/services/singletons', () => ({
+  scorecardService: { getTeamScorecard: vi.fn() }
+}))
+
+const mockScorecard: Scorecard = {
+  score: 3,
+  maxScore: 5,
+  checks: [
+    { id: 'sbom-freshness', label: 'SBOM freshness', passed: true, detail: 'ok' }
+  ]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('GET /api/teams/{name}/scorecard', () => {
+  it('returns the scorecard for an existing team', async () => {
+    vi.mocked(scorecardService.getTeamScorecard).mockResolvedValue(mockScorecard)
+
+    const result = await handler(mockEvent({ params: { name: 'payments-team' } }))
+
+    expect(scorecardService.getTeamScorecard).toHaveBeenCalledWith('payments-team')
+    expect(result).toMatchObject({ success: true, data: mockScorecard })
+  })
+
+  it('returns 404 when the team does not exist', async () => {
+    vi.mocked(scorecardService.getTeamScorecard).mockResolvedValue(null)
+
+    await expect(handler(mockEvent({ params: { name: 'missing-team' } }))).rejects.toMatchObject({
+      statusCode: 404
+    })
+  })
+
+  it('returns 400 when the name param is missing', async () => {
+    await expect(handler(mockEvent({ params: {} }))).rejects.toMatchObject({
+      statusCode: 400
+    })
+  })
+})

--- a/test/server/services/scorecard.service.spec.ts
+++ b/test/server/services/scorecard.service.spec.ts
@@ -4,7 +4,7 @@ import { SystemRepository } from '../../../server/repositories/system.repository
 import { TeamRepository } from '../../../server/repositories/team.repository'
 import { VersionConstraintRepository } from '../../../server/repositories/version-constraint.repository'
 import type { System } from '../../../server/repositories/system.repository'
-import type { Team, TeamUsageResult } from '../../../server/repositories/team.repository'
+import type { Team, TeamUsageResult, TechnologyUsage } from '../../../server/repositories/team.repository'
 import type { Violation } from '../../../server/repositories/version-constraint.repository'
 import '../../fixtures/service-test-helper'
 
@@ -54,6 +54,20 @@ function freshDate(): string {
 
 function staleDate(): string {
   return new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString()
+}
+
+function usageRow(complianceStatus: string, technology = 'tech'): TechnologyUsage {
+  return {
+    technology,
+    type: null,
+    domain: null,
+    vendor: null,
+    systemCount: 1,
+    firstUsed: null,
+    lastVerified: null,
+    approvalStatus: null,
+    complianceStatus
+  }
 }
 
 describe('ScorecardService', () => {
@@ -182,7 +196,12 @@ describe('ScorecardService', () => {
       })
       vi.mocked(TeamRepository.prototype.findUsage).mockResolvedValue({
         team: 'payments-team',
-        usage: [],
+        usage: [
+          usageRow('compliant', 'tech-1'),
+          usageRow('unapproved', 'tech-2'),
+          usageRow('unapproved', 'tech-3'),
+          usageRow('violation', 'tech-4')
+        ],
         summary: { totalTechnologies: 4, compliant: 1, unapproved: 2, violations: 1, migrationNeeded: 0 }
       })
       vi.mocked(VersionConstraintRepository.prototype.findViolations).mockResolvedValue([criticalViolation])
@@ -196,6 +215,29 @@ describe('ScorecardService', () => {
       expect(byId['no-license-violations']!.passed).toBe(false)
       expect(byId['no-critical-version-violations']!.passed).toBe(false)
       expect(byId['sbom-freshness']!.passed).toBe(false)
+    })
+
+    it('treats an "unknown" compliance status as unclassified for TIME coverage', async () => {
+      // An APPROVES relationship with a time value outside the recognized TIME enum
+      // maps to complianceStatus 'unknown' (teams/find-usage.cypher) — it is not
+      // counted in summary.unapproved, so coverage must be derived from usage.usage
+      // rather than relying on summary.unapproved alone.
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(mockTeam)
+      vi.mocked(TeamRepository.prototype.getScorecardRaw).mockResolvedValue({
+        systemScans: [{ system: 'checkout-api', lastSbomScanAt: freshDate() }],
+        licenseViolationCount: 0,
+      })
+      vi.mocked(TeamRepository.prototype.findUsage).mockResolvedValue({
+        team: 'payments-team',
+        usage: [usageRow('unknown', 'tech-1')],
+        summary: { totalTechnologies: 1, compliant: 0, unapproved: 0, violations: 0, migrationNeeded: 0 }
+      })
+      vi.mocked(VersionConstraintRepository.prototype.findViolations).mockResolvedValue([])
+
+      const result = await service.getTeamScorecard('payments-team')
+
+      const coverageCheck = result!.checks.find(check => check.id === 'time-classification-coverage')
+      expect(coverageCheck!.passed).toBe(false)
     })
   })
 })

--- a/test/server/services/scorecard.service.spec.ts
+++ b/test/server/services/scorecard.service.spec.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ScorecardService } from '../../../server/services/scorecard.service'
+import { SystemRepository } from '../../../server/repositories/system.repository'
+import { TeamRepository } from '../../../server/repositories/team.repository'
+import { VersionConstraintRepository } from '../../../server/repositories/version-constraint.repository'
+import type { System } from '../../../server/repositories/system.repository'
+import type { Team, TeamUsageResult } from '../../../server/repositories/team.repository'
+import type { Violation } from '../../../server/repositories/version-constraint.repository'
+import '../../fixtures/service-test-helper'
+
+vi.mock('../../../server/repositories/system.repository')
+vi.mock('../../../server/repositories/team.repository')
+vi.mock('../../../server/repositories/version-constraint.repository')
+
+const mockSystem: System = {
+  name: 'checkout-api',
+  domain: 'commerce',
+  ownerTeam: 'payments-team',
+  businessCriticality: 'high',
+  environment: 'prod',
+  componentCount: 10,
+  repositoryCount: 1,
+}
+
+const mockTeam: Team = {
+  name: 'payments-team',
+  email: null,
+  responsibilityArea: null,
+  technologyCount: 5,
+  systemCount: 2,
+}
+
+const cleanUsage: TeamUsageResult = {
+  team: 'payments-team',
+  usage: [],
+  summary: { totalTechnologies: 4, compliant: 4, unapproved: 0, violations: 0, migrationNeeded: 0 }
+}
+
+const criticalViolation: Violation = {
+  team: 'payments-team',
+  system: 'checkout-api',
+  systemBusinessCriticality: 'high',
+  systemEnvironment: 'prod',
+  component: 'left-pad',
+  componentVersion: '1.0.0',
+  technology: 'Node.js',
+  technologyType: 'runtime',
+  constraint: { name: 'no-legacy-node', description: null, severity: 'critical', versionRange: '>=18.0.0' }
+}
+
+function freshDate(): string {
+  return new Date().toISOString()
+}
+
+function staleDate(): string {
+  return new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString()
+}
+
+describe('ScorecardService', () => {
+  let service: ScorecardService
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    service = new ScorecardService()
+  })
+
+  describe('getSystemScorecard()', () => {
+    it('returns null when the system does not exist', async () => {
+      vi.mocked(SystemRepository.prototype.findByName).mockResolvedValue(null)
+
+      const result = await service.getSystemScorecard('missing-system')
+
+      expect(result).toBeNull()
+    })
+
+    it('passes every check when signals are all clean', async () => {
+      vi.mocked(SystemRepository.prototype.findByName).mockResolvedValue(mockSystem)
+      vi.mocked(SystemRepository.prototype.getScorecardRaw).mockResolvedValue({
+        lastSbomScanAt: freshDate(),
+        usedTechnologyCount: 4,
+        unclassifiedCount: 0,
+        eliminateCount: 0,
+        licenseViolationCount: 0,
+      })
+      vi.mocked(VersionConstraintRepository.prototype.findViolations).mockResolvedValue([])
+
+      const result = await service.getSystemScorecard('checkout-api')
+
+      expect(result).not.toBeNull()
+      expect(result!.score).toBe(5)
+      expect(result!.maxScore).toBe(5)
+      expect(result!.checks.every(check => check.passed)).toBe(true)
+    })
+
+    it('fails checks when signals indicate violations', async () => {
+      vi.mocked(SystemRepository.prototype.findByName).mockResolvedValue(mockSystem)
+      vi.mocked(SystemRepository.prototype.getScorecardRaw).mockResolvedValue({
+        lastSbomScanAt: staleDate(),
+        usedTechnologyCount: 4,
+        unclassifiedCount: 2,
+        eliminateCount: 1,
+        licenseViolationCount: 3,
+      })
+      vi.mocked(VersionConstraintRepository.prototype.findViolations).mockResolvedValue([criticalViolation])
+
+      const result = await service.getSystemScorecard('checkout-api')
+
+      expect(result!.score).toBe(0)
+      expect(result!.maxScore).toBe(5)
+
+      const byId = Object.fromEntries(result!.checks.map(check => [check.id, check]))
+      expect(byId['sbom-freshness']!.passed).toBe(false)
+      expect(byId['no-eliminate-violations']!.passed).toBe(false)
+      expect(byId['no-license-violations']!.passed).toBe(false)
+      expect(byId['no-critical-version-violations']!.passed).toBe(false)
+      expect(byId['time-classification-coverage']!.passed).toBe(false)
+    })
+
+    it('treats a missing SBOM scan as stale', async () => {
+      vi.mocked(SystemRepository.prototype.findByName).mockResolvedValue(mockSystem)
+      vi.mocked(SystemRepository.prototype.getScorecardRaw).mockResolvedValue({
+        lastSbomScanAt: null,
+        usedTechnologyCount: 0,
+        unclassifiedCount: 0,
+        eliminateCount: 0,
+        licenseViolationCount: 0,
+      })
+      vi.mocked(VersionConstraintRepository.prototype.findViolations).mockResolvedValue([])
+
+      const result = await service.getSystemScorecard('checkout-api')
+
+      const sbomCheck = result!.checks.find(check => check.id === 'sbom-freshness')
+      expect(sbomCheck!.passed).toBe(false)
+    })
+  })
+
+  describe('getTeamScorecard()', () => {
+    it('returns null when the team does not exist', async () => {
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(null)
+
+      const result = await service.getTeamScorecard('missing-team')
+
+      expect(result).toBeNull()
+    })
+
+    it('passes every check when signals are all clean', async () => {
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(mockTeam)
+      vi.mocked(TeamRepository.prototype.getScorecardRaw).mockResolvedValue({
+        systemScans: [{ system: 'checkout-api', lastSbomScanAt: freshDate() }],
+        licenseViolationCount: 0,
+      })
+      vi.mocked(TeamRepository.prototype.findUsage).mockResolvedValue(cleanUsage)
+      vi.mocked(VersionConstraintRepository.prototype.findViolations).mockResolvedValue([])
+
+      const result = await service.getTeamScorecard('payments-team')
+
+      expect(result!.score).toBe(5)
+      expect(result!.maxScore).toBe(5)
+    })
+
+    it('treats owning no systems as a vacuous pass for SBOM freshness', async () => {
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(mockTeam)
+      vi.mocked(TeamRepository.prototype.getScorecardRaw).mockResolvedValue({
+        systemScans: [],
+        licenseViolationCount: 0,
+      })
+      vi.mocked(TeamRepository.prototype.findUsage).mockResolvedValue(cleanUsage)
+      vi.mocked(VersionConstraintRepository.prototype.findViolations).mockResolvedValue([])
+
+      const result = await service.getTeamScorecard('payments-team')
+
+      const sbomCheck = result!.checks.find(check => check.id === 'sbom-freshness')
+      expect(sbomCheck!.passed).toBe(true)
+      expect(sbomCheck!.detail).toMatch(/owns no systems/)
+    })
+
+    it('fails checks when usage summary reports violations and unapproved technologies', async () => {
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(mockTeam)
+      vi.mocked(TeamRepository.prototype.getScorecardRaw).mockResolvedValue({
+        systemScans: [{ system: 'checkout-api', lastSbomScanAt: staleDate() }],
+        licenseViolationCount: 2,
+      })
+      vi.mocked(TeamRepository.prototype.findUsage).mockResolvedValue({
+        team: 'payments-team',
+        usage: [],
+        summary: { totalTechnologies: 4, compliant: 1, unapproved: 2, violations: 1, migrationNeeded: 0 }
+      })
+      vi.mocked(VersionConstraintRepository.prototype.findViolations).mockResolvedValue([criticalViolation])
+
+      const result = await service.getTeamScorecard('payments-team')
+
+      expect(result!.score).toBe(0)
+      const byId = Object.fromEntries(result!.checks.map(check => [check.id, check]))
+      expect(byId['no-eliminate-violations']!.passed).toBe(false)
+      expect(byId['time-classification-coverage']!.passed).toBe(false)
+      expect(byId['no-license-violations']!.passed).toBe(false)
+      expect(byId['no-critical-version-violations']!.passed).toBe(false)
+      expect(byId['sbom-freshness']!.passed).toBe(false)
+    })
+  })
+})

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -559,6 +559,26 @@ export interface LicenseViolation {
   licenseCategory: string | null
 }
 
+export type ScorecardCheckId =
+  | 'sbom-freshness'
+  | 'no-eliminate-violations'
+  | 'no-license-violations'
+  | 'no-critical-version-violations'
+  | 'time-classification-coverage'
+
+export interface ScorecardCheck {
+  id: ScorecardCheckId
+  label: string
+  passed: boolean
+  detail: string
+}
+
+export interface Scorecard {
+  score: number
+  maxScore: number
+  checks: ScorecardCheck[]
+}
+
 export interface ApiSuccessResponse<T> {
   success: true
   data: T[]


### PR DESCRIPTION
## Description

Implements #554: an on-demand governance scorecard for Systems and Teams, computed at request time from existing compliance data (no persistence, per the issue's v1 scope). Each check reports pass/fail plus a drill-down detail message.

Closes #554

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Changes Made

- `GET /api/systems/{name}/scorecard` and `GET /api/teams/{name}/scorecard`, backed by a new `ScorecardService` computing 5 checks per entity: SBOM freshness (< 30 days), no Eliminate-classified technologies in use, no disallowed-license usage, no critical version-constraint violations, and TIME classification coverage of used technologies.
- New Cypher (`systems/scorecard.cypher`, `teams/scorecard.cypher`) and `getScorecardRaw()` repository methods for the raw signals; reuses `TeamRepository.findUsage()` and `VersionConstraintService.getViolations()` where equivalent logic already existed, so semver evaluation for critical constraints stays in one place.
- Bug fix found along the way: `VersionConstraintRepository.findViolations()` declared a `system` filter in `ViolationFilters` that was never wired into the query — added the missing `sys.name = $system` condition (the system scorecard's critical-constraint check depends on it).
- New `ComplianceScorecard.vue` component (progress bar + per-check list), wired into both the System and Team detail pages.
- New `Scorecard`/`ScorecardCheck`/`ScorecardCheckId` types in `types/api.d.ts`.
- Unit tests for the service (not-found, all-clean, all-failing, and edge cases like a team owning zero systems) and both new API handlers.
- Regenerated `public/openapi.json`.

## Screenshots

N/A (see verification notes below)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

Verified against the live dev Neo4j database and the running dev server: hit both endpoints directly (including the 404 path) and confirmed the scorecard renders server-side on the System and Team detail pages with real data (e.g. `/systems/AzureMap`, `/teams/Platform%20Team`).
