### PR TITLE
Fix team detail page showing empty Members/Technologies/Systems/Approvals tabs

### DIFF
--- a/server/database/queries/teams/find-by-name.cypher
+++ b/server/database/queries/teams/find-by-name.cypher
@@ -1,13 +1,30 @@
 MATCH (t:Team {name: $name})
 OPTIONAL MATCH (t)-[:STEWARDED_BY]->(tech:Technology)
+OPTIONAL MATCH (t)-[stewardApproval:APPROVES]->(tech)
 OPTIONAL MATCH (t)-[:OWNS]->(sys:System)
 OPTIONAL MATCH (t)-[:OWNS]->(sys2:System)-[:USES]->(:Component)-[:IS_VERSION_OF]->(usedTech:Technology)
 OPTIONAL MATCH (u:User)-[:MEMBER_OF]->(t)
+OPTIONAL MATCH (u)-[canManage:CAN_MANAGE]->(t)
 WITH t,
   count(DISTINCT tech) as technologyCount,
   count(DISTINCT sys) as systemCount,
   count(DISTINCT usedTech) as usedTechnologyCount,
-  count(DISTINCT u) as memberCount
+  count(DISTINCT u) as memberCount,
+  collect(DISTINCT {
+    name: tech.name,
+    type: tech.type,
+    timeCategory: stewardApproval.time
+  }) as stewardedTechnologies,
+  collect(DISTINCT {
+    name: sys.name,
+    businessCriticality: sys.businessCriticality,
+    environment: sys.environment
+  }) as systems,
+  collect(DISTINCT {
+    name: u.name,
+    email: u.email,
+    isManager: canManage IS NOT NULL
+  }) as members
 RETURN {
   name: t.name,
   email: t.email,
@@ -15,5 +32,8 @@ RETURN {
   technologyCount: toInteger(technologyCount),
   systemCount: toInteger(systemCount),
   usedTechnologyCount: toInteger(usedTechnologyCount),
-  memberCount: toInteger(memberCount)
+  memberCount: toInteger(memberCount),
+  stewardedTechnologies: stewardedTechnologies,
+  systems: systems,
+  members: members
 } as team

--- a/server/repositories/team.repository.ts
+++ b/server/repositories/team.repository.ts
@@ -20,6 +20,36 @@ export interface Team {
   systemCount: number
   usedTechnologyCount?: number
   memberCount?: number
+  members?: TeamMember[]
+  systems?: TeamSystemRef[]
+  technologies?: TeamTechnologyRef[]
+  approvals?: TeamApprovalRef[]
+}
+
+export interface TeamMember {
+  name: string
+  email: string
+  role: 'Manager' | 'Member'
+}
+
+export interface TeamSystemRef {
+  name: string
+  businessCriticality: string | null
+  environment: string | null
+}
+
+export interface TeamTechnologyRef {
+  name: string
+  type: string | null
+  timeCategory: string | null
+  relationship: 'Steward' | 'User'
+}
+
+export interface TeamApprovalRef {
+  technologyName: string
+  timeCategory: string | null
+  approvedAt: string | null
+  approvedBy: string | null
 }
 
 export interface TechnologyApproval {
@@ -164,7 +194,16 @@ export class TeamRepository extends BaseRepository {
       technologyCount: this.toNumber(team.technologyCount),
       systemCount: this.toNumber(team.systemCount),
       usedTechnologyCount: this.toNumber(team.usedTechnologyCount),
-      memberCount: this.toNumber(team.memberCount)
+      memberCount: this.toNumber(team.memberCount),
+      members: (team.members as Array<{ name: string | null; email: string | null; isManager: boolean }>)
+        .filter(m => m.name)
+        .map(m => ({ name: m.name!, email: m.email!, role: m.isManager ? 'Manager' as const : 'Member' as const })),
+      systems: (team.systems as Array<{ name: string | null; businessCriticality: string | null; environment: string | null }>)
+        .filter(s => s.name)
+        .map(s => ({ name: s.name!, businessCriticality: s.businessCriticality, environment: s.environment })),
+      technologies: (team.stewardedTechnologies as Array<{ name: string | null; type: string | null; timeCategory: string | null }>)
+        .filter(t => t.name)
+        .map(t => ({ name: t.name!, type: t.type, timeCategory: t.timeCategory, relationship: 'Steward' as const }))
     }
   }
   

--- a/server/services/team.service.ts
+++ b/server/services/team.service.ts
@@ -2,6 +2,7 @@ import { TeamRepository } from '../repositories/team.repository'
 import type { Team, TeamApprovalsResult, TeamConstraintsResult, TeamUsageResult, ApprovalStatus } from '../repositories/team.repository'
 import type { SortParams } from '../utils/sorting'
 import { buildAuditChanges, buildDeleteChanges } from '../utils/audit-diff'
+import { toDateString } from '../utils/neo4j'
 
 /**
  * Service for team-related business logic
@@ -66,13 +67,44 @@ export class TeamService {
   }
 
   /**
-   * Get a team by name
-   * 
+   * Get a team by name, enriched with the technologies it uses (in addition
+   * to the ones it stewards) and its technology approvals — merged in from
+   * findUsage()/findApprovals() so the team detail page doesn't need to call
+   * three separate endpoints.
+   *
    * @param name - Team name
    * @returns Team or null if not found
    */
   async findByName(name: string): Promise<Team | null> {
-    return await this.teamRepo.findByName(name)
+    const team = await this.teamRepo.findByName(name)
+    if (!team) {
+      return null
+    }
+
+    const [usage, approvals] = await Promise.all([
+      this.teamRepo.findUsage(name),
+      this.teamRepo.findApprovals(name)
+    ])
+
+    const stewardedNames = new Set((team.technologies ?? []).map(t => t.name))
+    const usedTechnologies = usage.usage
+      .filter(u => !stewardedNames.has(u.technology))
+      .map(u => ({
+        name: u.technology,
+        type: u.type,
+        timeCategory: u.approvalStatus,
+        relationship: 'User' as const
+      }))
+
+    team.technologies = [...(team.technologies ?? []), ...usedTechnologies]
+    team.approvals = approvals.technologyApprovals.map(a => ({
+      technologyName: a.technology,
+      timeCategory: a.time,
+      approvedAt: toDateString(a.approvedAt),
+      approvedBy: a.approvedBy
+    }))
+
+    return team
   }
 
   /**

--- a/test/server/repositories/team.repository.spec.ts
+++ b/test/server/repositories/team.repository.spec.ts
@@ -85,6 +85,64 @@ describe('TeamRepository', () => {
       expect(team).not.toBeNull()
       expect(team!.name).toBe(`${PREFIX}platform`)
     })
+
+    it('should return empty members/systems/technologies for a team with none', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `CREATE (:Team { name: $n })`, { n: `${PREFIX}bare` })
+
+      const team = await repo.findByName(`${PREFIX}bare`)
+
+      expect(team!.members).toEqual([])
+      expect(team!.systems).toEqual([])
+      expect(team!.technologies).toEqual([])
+    })
+
+    it('should list members with role derived from CAN_MANAGE', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Team { name: $team })
+        CREATE (u1:User { id: $u1, email: $e1, name: 'Regular Member', role: 'user', provider: 'github', createdAt: datetime() })
+        CREATE (u2:User { id: $u2, email: $e2, name: 'Team Lead', role: 'user', provider: 'github', createdAt: datetime() })
+        CREATE (u1)-[:MEMBER_OF]->(t)
+        CREATE (u2)-[:MEMBER_OF]->(t)
+        CREATE (u2)-[:CAN_MANAGE]->(t)
+      `, {
+        team: `${PREFIX}staffed`,
+        u1: `${PREFIX}u1`, e1: `${PREFIX}u1@test.com`,
+        u2: `${PREFIX}u2`, e2: `${PREFIX}u2@test.com`
+      })
+
+      const team = await repo.findByName(`${PREFIX}staffed`)
+
+      expect(team!.members).toEqual(expect.arrayContaining([
+        { name: 'Regular Member', email: `${PREFIX}u1@test.com`, role: 'Member' },
+        { name: 'Team Lead', email: `${PREFIX}u2@test.com`, role: 'Manager' }
+      ]))
+      expect(team!.members).toHaveLength(2)
+    })
+
+    it('should list owned systems and stewarded technologies', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Team { name: $team })
+        CREATE (s:System { name: $sys, businessCriticality: 'high', environment: 'prod' })
+        CREATE (tech:Technology { name: $tech, type: 'framework' })
+        CREATE (t)-[:OWNS]->(s)
+        CREATE (t)-[:STEWARDED_BY]->(tech)
+        CREATE (t)-[:APPROVES { time: 'invest' }]->(tech)
+      `, {
+        team: `${PREFIX}owner2`, sys: `${PREFIX}sys1`, tech: `${PREFIX}tech1`
+      })
+
+      const team = await repo.findByName(`${PREFIX}owner2`)
+
+      expect(team!.systems).toEqual([
+        { name: `${PREFIX}sys1`, businessCriticality: 'high', environment: 'prod' }
+      ])
+      expect(team!.technologies).toEqual([
+        { name: `${PREFIX}tech1`, type: 'framework', timeCategory: 'invest', relationship: 'Steward' }
+      ])
+    })
   })
 
   describe('exists()', () => {

--- a/test/server/services/team.service.spec.ts
+++ b/test/server/services/team.service.spec.ts
@@ -33,6 +33,15 @@ describe('TeamService', () => {
   })
 
   describe('findByName()', () => {
+    beforeEach(() => {
+      vi.mocked(TeamRepository.prototype.findUsage).mockResolvedValue({
+        team: 'Platform', usage: [], summary: { totalTechnologies: 0, compliant: 0, unapproved: 0, violations: 0, migrationNeeded: 0 }
+      })
+      vi.mocked(TeamRepository.prototype.findApprovals).mockResolvedValue({
+        team: 'Platform', technologyApprovals: [], versionApprovals: []
+      })
+    })
+
     it('should return team when found', async () => {
       vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(mockTeam)
 
@@ -46,6 +55,37 @@ describe('TeamService', () => {
       vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue(null)
 
       expect(await service.findByName('nonexistent')).toBeNull()
+      expect(TeamRepository.prototype.findUsage).not.toHaveBeenCalled()
+    })
+
+    it('should merge used technologies (not already stewarded) and approvals into the team', async () => {
+      vi.mocked(TeamRepository.prototype.findByName).mockResolvedValue({
+        ...mockTeam,
+        technologies: [{ name: 'React', type: 'framework', timeCategory: 'invest', relationship: 'Steward' }]
+      })
+      vi.mocked(TeamRepository.prototype.findUsage).mockResolvedValue({
+        team: 'Platform',
+        usage: [
+          { technology: 'React', type: 'framework', domain: null, vendor: null, systemCount: 2, firstUsed: null, lastVerified: null, approvalStatus: 'invest', complianceStatus: 'compliant' },
+          { technology: 'Node.js', type: 'runtime', domain: null, vendor: null, systemCount: 1, firstUsed: null, lastVerified: null, approvalStatus: null, complianceStatus: 'unapproved' }
+        ],
+        summary: { totalTechnologies: 2, compliant: 1, unapproved: 1, violations: 0, migrationNeeded: 0 }
+      })
+      vi.mocked(TeamRepository.prototype.findApprovals).mockResolvedValue({
+        team: 'Platform',
+        technologyApprovals: [{ technology: 'React', type: 'framework', vendor: null, time: 'invest', approvedAt: '2024-01-15', deprecatedAt: null, eolDate: null, migrationTarget: null, notes: null, approvedBy: 'jsf' }],
+        versionApprovals: []
+      })
+
+      const result = await service.findByName('Platform')
+
+      expect(result!.technologies).toEqual([
+        { name: 'React', type: 'framework', timeCategory: 'invest', relationship: 'Steward' },
+        { name: 'Node.js', type: 'runtime', timeCategory: null, relationship: 'User' }
+      ])
+      expect(result!.approvals).toEqual([
+        { technologyName: 'React', timeCategory: 'invest', approvedAt: '2024-01-15', approvedBy: 'jsf' }
+      ])
     })
   })
 

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -519,6 +519,12 @@ export interface Team {
   responsibilityArea: string | null
   technologyCount: number
   systemCount: number
+  usedTechnologyCount?: number
+  memberCount?: number
+  members?: Array<{ name: string; email: string; role: 'Manager' | 'Member' }>
+  systems?: Array<{ name: string; businessCriticality: string | null; environment: string | null }>
+  technologies?: Array<{ name: string; type: string | null; timeCategory: string | null; relationship: 'Steward' | 'User' }>
+  approvals?: Array<{ technologyName: string; timeCategory: string | null; approvedAt: string | null; approvedBy: string | null }>
 }
 
 export interface VersionConstraint {


### PR DESCRIPTION
## Description

The team detail page (`/teams/{name}`) always rendered its Members, Technologies, Systems, and Approvals tabs as empty, regardless of actual team membership or ownership. Root cause: `GET /api/teams/{name}` only ever returned aggregate counts (`memberCount`, `technologyCount`, etc.) — the frontend reads `data.members`/`.technologies`/`.systems`/`.approvals`, which were always `undefined`. Verified against the live dev DB that a user's `MEMBER_OF` relationship to a team existed correctly; the data was simply never surfaced by the API.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Reported directly by a user, not tracked as a GitHub issue.

## Changes Made

- `find-by-name.cypher` now collects the member list (role derived from `CAN_MANAGE`), owned systems, and stewarded technologies alongside the existing counts.
- `TeamRepository.findByName` maps and filters these new lists (Cypher's `collect(DISTINCT {...})` produces a null placeholder row when a relationship has zero matches).
- `TeamService.findByName` merges in technologies the team *uses* (via the existing `findUsage()`) and its approvals (via the existing `findApprovals()`), so the page gets one composed response instead of needing three separate fetches — matching the pattern already used by the technology detail page.
- Extended the shared `Team` type (`types/api.d.ts`) to match.
- Added repository tests (live Neo4j) covering members/role derivation/systems/technologies, and a service test covering the used-vs-stewarded merge logic.

## Screenshots

Verified live against the running dev server: `/teams/Security` now shows the previously-missing member ("Johannes Skov Frandsen" / `jsf@greenoak.dk` / Member) and its 20 owned systems in the respective tabs.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev` (verified via API response and browser snapshot)
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed (OpenAPI docs regenerated — no schema changes required)

## Additional Notes

Scope note: the working tree also had unrelated pre-existing changes (`.mcp.json`, `CLAUDE.md`, `app/pages/technologies/index.vue`, an untracked `tot.md`) that were intentionally left out of this branch/PR per the user's request, to keep this PR focused on the team-detail fix.