### PR TITLE
Implement version sprawl detection and consolidation recommendations

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -304,6 +304,11 @@ const mainMenuItems = computed<NavigationMenuItem[][]>(() => {
       label: 'Version Constraints',
       icon: 'i-lucide-file-text',
       to: '/version-constraints'
+    },
+    {
+      label: 'Version Sprawl',
+      icon: 'i-lucide-layers',
+      to: '/version-sprawl'
     }
   ]
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -20,7 +20,7 @@
     </div>
 
     <!-- Statistics Grid -->
-    <div class="grid grid-cols-1 lg:grid-cols-4 gap-6">
+    <div class="grid grid-cols-1 lg:grid-cols-5 gap-6">
       <UCard>
         <template #header>
           <div class="flex justify-between items-center">
@@ -121,6 +121,29 @@
           <div>
             <p class="text-sm text-(--ui-text-muted)">Systems</p>
             <p class="text-xl font-bold">{{ lifecycleStats.systems }}</p>
+          </div>
+        </div>
+      </UCard>
+
+      <UCard>
+        <template #header>
+          <div class="flex justify-between items-center">
+            <h3 class="font-semibold">Version Sprawl</h3>
+            <NuxtLink to="/version-sprawl" class="text-sm text-(--ui-color-primary-500)">View all →</NuxtLink>
+          </div>
+        </template>
+        <div class="grid grid-cols-3 gap-2 text-center">
+          <div>
+            <p class="text-sm text-(--ui-text-muted)">High</p>
+            <p class="text-xl font-bold text-(--ui-color-error-500)">{{ sprawlStats.high }}</p>
+          </div>
+          <div>
+            <p class="text-sm text-(--ui-text-muted)">Medium</p>
+            <p class="text-xl font-bold text-(--ui-color-warning-500)">{{ sprawlStats.medium }}</p>
+          </div>
+          <div>
+            <p class="text-sm text-(--ui-text-muted)">Low</p>
+            <p class="text-xl font-bold">{{ sprawlStats.low }}</p>
           </div>
         </div>
       </UCard>
@@ -267,7 +290,7 @@
 </template>
 
 <script setup lang="ts">
-import type { HealthDashboardSummary } from '~~/types/api'
+import type { HealthDashboardSummary, VersionSprawlSummary } from '~~/types/api'
 
 interface DashboardSummaryResponse {
   success: boolean
@@ -316,6 +339,14 @@ interface HealthSummaryApiResponse {
 
 const { data: healthSummaryData } = await useFetch<HealthSummaryApiResponse>('/api/health/summary')
 
+interface SprawlSummaryApiResponse {
+  success: boolean
+  data: VersionSprawlSummary
+  count: number
+}
+
+const { data: sprawlSummaryData } = await useFetch<SprawlSummaryApiResponse>('/api/version-sprawl/summary')
+
 const summary = computed(() => dashboardData.value?.data)
 
 const counts = computed(() => ({
@@ -361,6 +392,12 @@ const lifecycleStats = computed(() => ({
   unsupported: summary.value?.lifecycle.unsupported || 0,
   approaching: summary.value?.lifecycle.approaching || 0,
   systems: summary.value?.lifecycle.systems || 0
+}))
+
+const sprawlStats = computed(() => ({
+  high: sprawlSummaryData.value?.data.high || 0,
+  medium: sprawlSummaryData.value?.data.medium || 0,
+  low: sprawlSummaryData.value?.data.low || 0
 }))
 
 const emptyHealthSummary: HealthDashboardSummary = {

--- a/app/pages/version-sprawl/index.vue
+++ b/app/pages/version-sprawl/index.vue
@@ -1,0 +1,153 @@
+<template>
+  <div class="space-y-6">
+    <UPageHeader
+      title="Version Sprawl"
+      description="Technologies with multiple versions declared as direct dependencies across systems, ranked by consolidation priority"
+    />
+
+    <UAlert
+      v-if="error"
+      color="error"
+      variant="subtle"
+      icon="i-lucide-alert-circle"
+      title="Error"
+      :description="error.message"
+    />
+
+    <template v-else>
+      <EntityStatStrip v-if="summary" :items="summaryStats" />
+
+      <PaginatedTable
+        :data="detections"
+        :columns="columns"
+        :loading="pending"
+      >
+        <template #header>
+          <div class="flex flex-wrap items-center gap-2">
+            <USelect
+              v-model="severityFilter"
+              :items="severityItems"
+              placeholder="All severities"
+              class="w-40"
+            />
+            <UButton
+              v-if="severityFilter"
+              label="Clear"
+              variant="ghost"
+              color="neutral"
+              icon="i-lucide-x"
+              @click="severityFilter = undefined"
+            />
+          </div>
+        </template>
+        <template #empty>
+          <div class="text-center py-8">
+            <UIcon name="i-lucide-check-circle" class="text-5xl text-(--ui-color-success-500)" />
+            <h3 class="mt-4">No Version Sprawl Detected!</h3>
+            <p class="text-(--ui-text-muted) mt-2">No technology has more than one version declared as a direct dependency.</p>
+          </div>
+        </template>
+      </PaginatedTable>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse, VersionSprawlDetection } from '~~/types/api'
+
+const { getSortableHeader } = useSortableTable()
+
+const UBadge = resolveComponent('UBadge')
+const NuxtLink = resolveComponent('NuxtLink')
+
+const severityItems = ['high', 'medium', 'low']
+const severityFilter = ref<string | undefined>(undefined)
+
+const queryParams = computed(() => {
+  const params: Record<string, string> = {}
+  if (severityFilter.value) params.severity = severityFilter.value
+  return params
+})
+
+const { data, pending, error } = await useFetch<ApiResponse<VersionSprawlDetection>>('/api/version-sprawl', {
+  query: queryParams
+})
+
+interface SummaryResponse {
+  success: boolean
+  data: { high: number; medium: number; low: number; total: number }
+}
+
+const { data: summaryData } = await useFetch<SummaryResponse>('/api/version-sprawl/summary')
+
+const detections = useApiData(data)
+const summary = computed(() => summaryData.value?.data)
+const summaryStats = computed(() => summary.value
+  ? [
+      { label: 'Total', value: summary.value.total },
+      { label: 'High', value: summary.value.high },
+      { label: 'Medium', value: summary.value.medium },
+      { label: 'Low', value: summary.value.low }
+    ]
+  : [])
+
+const columns: TableColumn<VersionSprawlDetection>[] = [
+  {
+    id: 'technologyName',
+    accessorFn: row => row.technologyName,
+    header: ({ column }) => getSortableHeader(column, 'Technology'),
+    cell: ({ row }) => h(NuxtLink, {
+      to: `/technologies/${encodeURIComponent(row.original.technologyName)}`,
+      class: 'hover:underline font-medium'
+    }, () => row.original.technologyName)
+  },
+  {
+    id: 'severity',
+    accessorFn: row => row.severity,
+    header: ({ column }) => getSortableHeader(column, 'Severity'),
+    cell: ({ row }) => h(UBadge, {
+      color: getSprawlSeverityColor(row.original.severity),
+      variant: 'subtle'
+    }, () => row.original.severity)
+  },
+  {
+    id: 'sprawlScore',
+    accessorFn: row => row.sprawlScore,
+    header: ({ column }) => getSortableHeader(column, 'Score'),
+    cell: ({ row }) => row.original.sprawlScore
+  },
+  {
+    id: 'versionCount',
+    accessorFn: row => row.versionCount,
+    header: ({ column }) => getSortableHeader(column, 'Versions'),
+    cell: ({ row }) => h('div', {}, [
+      h('span', {}, `${row.original.versionCount} versions`),
+      h('p', { class: 'text-sm text-(--ui-text-muted)' }, `${row.original.versionRange.oldest} → ${row.original.versionRange.newest}`)
+    ])
+  },
+  {
+    id: 'affectedSystemCount',
+    accessorFn: row => row.affectedSystemCount,
+    header: ({ column }) => getSortableHeader(column, 'Systems'),
+    cell: ({ row }) => row.original.affectedSystemCount
+  },
+  {
+    id: 'recommendedVersion',
+    accessorFn: row => row.recommendedVersion,
+    header: 'Recommended',
+    cell: ({ row }) => h('code', { class: 'text-sm' }, row.original.recommendedVersion)
+  },
+  {
+    id: 'hasEolVersion',
+    accessorFn: row => row.hasEolVersion,
+    header: 'EOL',
+    cell: ({ row }) => row.original.hasEolVersion
+      ? h(UBadge, { color: 'error', variant: 'subtle' }, () => 'EOL version in use')
+      : h('span', { class: 'text-(--ui-text-muted)' }, '—')
+  }
+]
+
+useHead({ title: 'Version Sprawl - Polaris' })
+</script>

--- a/app/utils/badge-colors.ts
+++ b/app/utils/badge-colors.ts
@@ -56,3 +56,13 @@ const TIME_CATEGORY_COLORS: Record<string, BadgeColor> = {
 export function getTimeCategoryColor(value: string | null | undefined): BadgeColor {
   return TIME_CATEGORY_COLORS[value?.toLowerCase() ?? ''] ?? 'neutral'
 }
+
+const SPRAWL_SEVERITY_COLORS: Record<string, BadgeColor> = {
+  high: 'error',
+  medium: 'warning',
+  low: 'neutral'
+}
+
+export function getSprawlSeverityColor(value: string | null | undefined): BadgeColor {
+  return SPRAWL_SEVERITY_COLORS[value?.toLowerCase() ?? ''] ?? 'neutral'
+}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Polaris API",
-    "version": "0.6.52",
+    "version": "0.6.57",
     "description": "# Polaris Technology Catalog API\n\nThe Polaris API provides programmatic access to the technology catalog, enabling automation, integration, and custom tooling.\n\n## Key Features\n\n- **RESTful Design** - Resource-based URLs with proper HTTP methods\n- **Comprehensive Coverage** - Systems, Teams, Technologies, Components, Policies, and more\n- **Developer-Friendly** - Clear error messages and consistent response structure\n\n## Authentication\n\nMost endpoints require authentication using session-based authentication integrated with the web application.\n\n**Authorization Levels:**\n- **Public** - No authentication required\n- **Authenticated** - Valid user session required  \n- **Team Member** - User must belong to a team\n- **Team Owner** - User must belong to team that owns the resource\n- **Superuser** - User must have superuser role\n\n## Response Format\n\nAll successful responses follow this structure:\n```json\n{\n  \"success\": true,\n  \"data\": [...],\n  \"count\": 10\n}\n```\n\nAll errors follow this structure:\n```json\n{\n  \"statusCode\": 404,\n  \"message\": \"Resource 'example' not found\"\n}\n```\n\n## Richardson Maturity Model\n\nThis API implements **RMM Level 2** with proper use of HTTP methods and status codes.",
     "license": {
       "name": "MIT",
@@ -819,6 +819,96 @@
           "description": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "VersionSprawlVersionBreakdown": {
+        "type": "object",
+        "required": [
+          "version",
+          "systemCount",
+          "systems"
+        ],
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "systemCount": {
+            "type": "integer"
+          },
+          "systems": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "VersionSprawlDetection": {
+        "type": "object",
+        "required": [
+          "technologyName",
+          "versions",
+          "versionCount",
+          "versionRange",
+          "affectedSystemCount",
+          "versionBreakdown",
+          "sprawlScore",
+          "severity",
+          "recommendedVersion",
+          "hasEolVersion"
+        ],
+        "properties": {
+          "technologyName": {
+            "type": "string"
+          },
+          "versions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "versionCount": {
+            "type": "integer"
+          },
+          "versionRange": {
+            "type": "object",
+            "properties": {
+              "oldest": {
+                "type": "string"
+              },
+              "newest": {
+                "type": "string"
+              }
+            }
+          },
+          "affectedSystemCount": {
+            "type": "integer"
+          },
+          "versionBreakdown": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/VersionSprawlVersionBreakdown"
+            }
+          },
+          "sprawlScore": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
+          },
+          "recommendedVersion": {
+            "type": "string"
+          },
+          "hasEolVersion": {
+            "type": "boolean"
           }
         }
       },
@@ -2828,6 +2918,81 @@
           },
           "404": {
             "description": "Team or technology not found"
+          }
+        }
+      }
+    },
+    "/version-sprawl/summary": {
+      "get": {
+        "tags": [
+          "Components"
+        ],
+        "summary": "Get version sprawl counts by severity",
+        "description": "Returns counts of detected version sprawl groups by severity tier, for dashboard summary widgets.",
+        "responses": {
+          "200": {
+            "description": "Version sprawl summary retrieved successfully"
+          }
+        }
+      }
+    },
+    "/version-sprawl": {
+      "get": {
+        "tags": [
+          "Components"
+        ],
+        "summary": "List detected version sprawl",
+        "description": "Detects technologies with 2+ distinct versions in use as direct dependencies across systems, scored and ranked by sprawl severity (version count, affected system count, major-version spread, and EOL exposure). Transitive-only versions are excluded since a team cannot act on a version it doesn't declare itself.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "severity",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "high",
+                "medium",
+                "low"
+              ]
+            },
+            "description": "Filter to a single severity tier"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successfully retrieved version sprawl detections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiSuccessResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/VersionSprawlDetection"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to detect version sprawl",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiErrorResponse"
+                }
+              }
+            }
           }
         }
       }

--- a/server/api/version-sprawl/index.get.ts
+++ b/server/api/version-sprawl/index.get.ts
@@ -1,0 +1,64 @@
+import type { ApiResponse, VersionSprawlDetection } from '~~/types/api'
+import { versionSprawlService } from '../../services/singletons'
+import { cachedFetch } from '../../utils/cache'
+
+/**
+ * @openapi
+ * /version-sprawl:
+ *   get:
+ *     tags:
+ *       - Components
+ *     summary: List detected version sprawl
+ *     description: Detects technologies with 2+ distinct versions in use as direct dependencies across systems, scored and ranked by sprawl severity (version count, affected system count, major-version spread, and EOL exposure). Transitive-only versions are excluded since a team cannot act on a version it doesn't declare itself.
+ *     parameters:
+ *       - in: query
+ *         name: severity
+ *         schema:
+ *           type: string
+ *           enum: [high, medium, low]
+ *         description: Filter to a single severity tier
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved version sprawl detections
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiSuccessResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/VersionSprawlDetection'
+ *       500:
+ *         description: Failed to detect version sprawl
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiErrorResponse'
+ */
+export default defineEventHandler(async (event): Promise<ApiResponse<VersionSprawlDetection>> => {
+  try {
+    const query = getQuery(event)
+    const severity = ['high', 'medium', 'low'].includes(query.severity as string)
+      ? query.severity as string
+      : undefined
+
+    const detections = await cachedFetch(
+      'version-sprawl:v1:detections',
+      () => versionSprawlService.detect(),
+      300
+    )
+
+    const data = severity
+      ? detections.filter(detection => detection.severity === severity)
+      : detections
+
+    return { success: true, data, count: data.length }
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : 'Failed to detect version sprawl'
+    setResponseStatus(event, 500)
+    return { success: false, error: errorMessage, data: [] }
+  }
+})

--- a/server/api/version-sprawl/summary.get.ts
+++ b/server/api/version-sprawl/summary.get.ts
@@ -1,0 +1,25 @@
+import type { VersionSprawlSummary } from '~~/types/api'
+import { versionSprawlService } from '../../services/singletons'
+import { cachedFetch } from '../../utils/cache'
+
+/**
+ * @openapi
+ * /version-sprawl/summary:
+ *   get:
+ *     tags:
+ *       - Components
+ *     summary: Get version sprawl counts by severity
+ *     description: Returns counts of detected version sprawl groups by severity tier, for dashboard summary widgets.
+ *     responses:
+ *       200:
+ *         description: Version sprawl summary retrieved successfully
+ */
+export default defineEventHandler(async () => {
+  const data = await cachedFetch<VersionSprawlSummary>(
+    'version-sprawl:v1:summary',
+    () => versionSprawlService.getSummary(),
+    300
+  )
+
+  return { success: true, data, count: 1 }
+})

--- a/server/database/queries/components/detect-version-sprawl.cypher
+++ b/server/database/queries/components/detect-version-sprawl.cypher
@@ -1,0 +1,34 @@
+// Detect technologies with multiple distinct versions in use as *direct*
+// dependencies across systems. Grouping is by claimed Technology (via
+// IS_VERSION_OF) rather than raw component name, since Technology is the
+// canonical, deduplicated identity in the graph model.
+//
+// Restricted to USES {isDirect: true}: a team can only change the version it
+// declares in its own manifest, not one pulled in transitively by another
+// dependency, so transitive-only versions would just be unactionable noise
+// in a consolidation report.
+// Staged CALL {} subqueries avoid cross-multiplying the per-version and
+// tech-wide system MATCHes against each other.
+MATCH (:System)-[:USES {isDirect: true}]->(c:Component)-[:IS_VERSION_OF]->(tech:Technology)
+WITH tech, collect(DISTINCT c.version) AS versions
+WHERE size(versions) >= toInteger($minVersions)
+
+CALL {
+  WITH tech
+  MATCH (sys:System)-[:USES {isDirect: true}]->(comp:Component)-[:IS_VERSION_OF]->(tech)
+  WITH comp.version AS version, collect(DISTINCT sys.name) AS systemNames
+  RETURN collect({version: version, systemCount: size(systemNames), systems: systemNames}) AS versionBreakdown
+}
+
+CALL {
+  WITH tech
+  MATCH (sys2:System)-[:USES {isDirect: true}]->(comp2:Component)-[:IS_VERSION_OF]->(tech)
+  RETURN count(DISTINCT sys2) AS affectedSystemCount
+}
+
+RETURN tech.name AS technologyName,
+       versions,
+       size(versions) AS versionCount,
+       versionBreakdown,
+       affectedSystemCount
+ORDER BY versionCount DESC, affectedSystemCount DESC

--- a/server/openapi.ts
+++ b/server/openapi.ts
@@ -575,6 +575,40 @@ This API implements **RMM Level 2** with proper use of HTTP methods and status c
             description: { type: 'string', nullable: true }
           }
         },
+        VersionSprawlVersionBreakdown: {
+          type: 'object',
+          required: ['version', 'systemCount', 'systems'],
+          properties: {
+            version: { type: 'string' },
+            systemCount: { type: 'integer' },
+            systems: { type: 'array', items: { type: 'string' } }
+          }
+        },
+        VersionSprawlDetection: {
+          type: 'object',
+          required: ['technologyName', 'versions', 'versionCount', 'versionRange', 'affectedSystemCount', 'versionBreakdown', 'sprawlScore', 'severity', 'recommendedVersion', 'hasEolVersion'],
+          properties: {
+            technologyName: { type: 'string' },
+            versions: { type: 'array', items: { type: 'string' } },
+            versionCount: { type: 'integer' },
+            versionRange: {
+              type: 'object',
+              properties: {
+                oldest: { type: 'string' },
+                newest: { type: 'string' }
+              }
+            },
+            affectedSystemCount: { type: 'integer' },
+            versionBreakdown: {
+              type: 'array',
+              items: { $ref: '#/components/schemas/VersionSprawlVersionBreakdown' }
+            },
+            sprawlScore: { type: 'integer', minimum: 0, maximum: 100 },
+            severity: { type: 'string', enum: ['high', 'medium', 'low'] },
+            recommendedVersion: { type: 'string' },
+            hasEolVersion: { type: 'boolean' }
+          }
+        },
         Technology: {
           type: 'object',
           properties: {

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -62,6 +62,20 @@ export interface ComponentEOLCandidate {
   systems: Array<{ name: string }>
 }
 
+export interface VersionSprawlVersionBreakdownRaw {
+  version: string
+  systemCount: number
+  systems: string[]
+}
+
+export interface VersionSprawlRaw {
+  technologyName: string
+  versions: string[]
+  versionCount: number
+  versionBreakdown: VersionSprawlVersionBreakdownRaw[]
+  affectedSystemCount: number
+}
+
 interface DependencyPathNode {
   elementId: string
   name: string
@@ -414,6 +428,26 @@ export class ComponentRepository extends BaseRepository {
       systems: ((record.get('systems') ?? []) as string[])
         .filter(Boolean)
         .map(name => ({ name }))
+    }))
+  }
+
+  async findVersionSprawl(minVersions = 2): Promise<VersionSprawlRaw[]> {
+    const query = await loadQuery('components/detect-version-sprawl.cypher')
+    const { records } = await this.executeQuery(query, { minVersions })
+    return records.map(record => ({
+      technologyName: record.get('technologyName'),
+      versions: record.get('versions') as string[],
+      versionCount: record.get('versionCount').toNumber(),
+      versionBreakdown: (record.get('versionBreakdown') as Array<{
+        version: string
+        systemCount: { toNumber(): number }
+        systems: string[]
+      }>).map(vb => ({
+        version: vb.version,
+        systemCount: vb.systemCount.toNumber(),
+        systems: vb.systems
+      })),
+      affectedSystemCount: record.get('affectedSystemCount').toNumber()
     }))
   }
 

--- a/server/services/singletons.ts
+++ b/server/services/singletons.ts
@@ -32,6 +32,7 @@ import { SecurityScoreService } from './security-score.service'
 import { VulnerabilityService } from './vulnerability.service'
 import { HealthRefreshService } from './health-refresh.service'
 import { ScorecardService } from './scorecard.service'
+import { VersionSprawlService } from './version-sprawl.service'
 
 export const technologyService = new TechnologyService()
 export const platformService = new PlatformService()
@@ -55,3 +56,4 @@ export const securityScoreService = new SecurityScoreService()
 export const vulnerabilityService = new VulnerabilityService()
 export const healthRefreshService = new HealthRefreshService()
 export const scorecardService = new ScorecardService()
+export const versionSprawlService = new VersionSprawlService()

--- a/server/services/version-sprawl.service.ts
+++ b/server/services/version-sprawl.service.ts
@@ -1,0 +1,91 @@
+import semver from 'semver'
+import type { VersionSprawlDetection, VersionSprawlSeverity, VersionSprawlSummary } from '~~/types/api'
+import { ComponentRepository, type VersionSprawlRaw } from '../repositories/component.repository'
+import { EOLService } from './eol.service'
+
+const MIN_VERSIONS = 2
+const HIGH_VERSION_THRESHOLD = 5
+const MEDIUM_VERSION_THRESHOLD = 3
+
+export class VersionSprawlService {
+  constructor(
+    private readonly componentRepo = new ComponentRepository(),
+    private readonly eolService = new EOLService()
+  ) {}
+
+  async detect(): Promise<VersionSprawlDetection[]> {
+    const raw = await this.componentRepo.findVersionSprawl(MIN_VERSIONS)
+    const detections = await Promise.all(raw.map(group => this.toDetection(group)))
+    return detections.sort((a, b) => b.sprawlScore - a.sprawlScore)
+  }
+
+  async getSummary(): Promise<VersionSprawlSummary> {
+    const detections = await this.detect()
+    return detections.reduce<VersionSprawlSummary>((summary, detection) => {
+      summary[detection.severity] += 1
+      summary.total += 1
+      return summary
+    }, { high: 0, medium: 0, low: 0, total: 0 })
+  }
+
+  private async toDetection(group: VersionSprawlRaw): Promise<VersionSprawlDetection> {
+    const versions = sortVersionsAscending(group.versions)
+    const hasEolVersion = await this.anyVersionEol(group.technologyName, versions)
+
+    return {
+      technologyName: group.technologyName,
+      versions,
+      versionCount: group.versionCount,
+      versionRange: { oldest: versions[0], newest: versions[versions.length - 1] },
+      affectedSystemCount: group.affectedSystemCount,
+      versionBreakdown: group.versionBreakdown,
+      sprawlScore: calculateSprawlScore(group, hasEolVersion),
+      severity: severityFor(group.versionCount),
+      recommendedVersion: versions[versions.length - 1],
+      hasEolVersion
+    }
+  }
+
+  private async anyVersionEol(technologyName: string, versions: string[]): Promise<boolean> {
+    const statuses = await Promise.all(versions.map(version =>
+      this.eolService.getEOLStatus({ name: technologyName, version, technologyName })
+    ))
+    return statuses.some(status => status.status === 'unsupported')
+  }
+}
+
+function severityFor(versionCount: number): VersionSprawlSeverity {
+  if (versionCount >= HIGH_VERSION_THRESHOLD) return 'high'
+  if (versionCount >= MEDIUM_VERSION_THRESHOLD) return 'medium'
+  return 'low'
+}
+
+function calculateSprawlScore(group: VersionSprawlRaw, hasEolVersion: boolean): number {
+  const versionCountScore = Math.min(group.versionCount * 10, 40)
+  const systemCountScore = Math.min(group.affectedSystemCount * 2, 30)
+  const majorSpreadScore = Math.min(countDistinctMajors(group.versions) * 10, 30)
+  const eolScore = hasEolVersion ? 20 : 0
+
+  return Math.min(versionCountScore + systemCountScore + majorSpreadScore + eolScore, 100)
+}
+
+function countDistinctMajors(versions: string[]): number {
+  const majors = new Set<number>()
+  for (const version of versions) {
+    const coerced = semver.coerce(version)
+    if (coerced) majors.add(coerced.major)
+  }
+  return majors.size
+}
+
+// Semver-aware sort with a lexicographic fallback for non-semver schemes
+// (e.g. Maven, Go pseudo-versions) so sprawl detection degrades gracefully
+// instead of throwing on unparsable versions.
+function sortVersionsAscending(versions: string[]): string[] {
+  return [...versions].sort((a, b) => {
+    const coercedA = semver.coerce(a)
+    const coercedB = semver.coerce(b)
+    if (coercedA && coercedB) return semver.compare(coercedA, coercedB)
+    return a.localeCompare(b)
+  })
+}

--- a/test/server/api/version-sprawl.spec.ts
+++ b/test/server/api/version-sprawl.spec.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import listHandler from '../../../server/api/version-sprawl/index.get'
+import summaryHandler from '../../../server/api/version-sprawl/summary.get'
+import { versionSprawlService } from '../../../server/services/singletons'
+import type { VersionSprawlDetection } from '../../../types/api'
+
+vi.mock('../../../server/services/singletons', () => ({
+  versionSprawlService: {
+    detect: vi.fn(),
+    getSummary: vi.fn()
+  }
+}))
+
+const highDetection: VersionSprawlDetection = {
+  technologyName: 'react',
+  versions: ['16.8.0', '17.0.2', '18.3.1', '18.0.0', '19.0.0'],
+  versionCount: 5,
+  versionRange: { oldest: '16.8.0', newest: '19.0.0' },
+  affectedSystemCount: 23,
+  versionBreakdown: [],
+  sprawlScore: 90,
+  severity: 'high',
+  recommendedVersion: '19.0.0',
+  hasEolVersion: true
+}
+
+const lowDetection: VersionSprawlDetection = {
+  ...highDetection,
+  technologyName: 'lodash',
+  versions: ['4.17.20', '4.17.21'],
+  versionCount: 2,
+  severity: 'low',
+  sprawlScore: 20,
+  hasEolVersion: false
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  const store = new Map<string, unknown>()
+  vi.stubGlobal('useStorage', () => ({
+    getItem: vi.fn(async (key: string) => store.get(key) ?? null),
+    setItem: vi.fn(async (key: string, value: unknown) => { store.set(key, value) })
+  }))
+})
+
+describe('GET /api/version-sprawl', () => {
+  it('returns all detections', async () => {
+    vi.mocked(versionSprawlService.detect).mockResolvedValue([highDetection, lowDetection])
+
+    const result = await listHandler(mockEvent())
+
+    expect(result).toMatchObject({ success: true, count: 2 })
+    expect(result.data).toHaveLength(2)
+  })
+
+  it('filters by severity', async () => {
+    vi.mocked(versionSprawlService.detect).mockResolvedValue([highDetection, lowDetection])
+
+    const result = await listHandler(mockEvent({ query: { severity: 'high' } }))
+
+    expect(result.data).toEqual([highDetection])
+  })
+
+  it('ignores an invalid severity filter', async () => {
+    vi.mocked(versionSprawlService.detect).mockResolvedValue([highDetection, lowDetection])
+
+    const result = await listHandler(mockEvent({ query: { severity: 'bogus' } }))
+
+    expect(result.data).toHaveLength(2)
+  })
+
+  it('returns 500 when detection fails', async () => {
+    vi.mocked(versionSprawlService.detect).mockRejectedValue(new Error('boom'))
+
+    const result = await listHandler(mockEvent())
+
+    expect(result).toMatchObject({ success: false, error: 'boom', data: [] })
+  })
+})
+
+describe('GET /api/version-sprawl/summary', () => {
+  it('returns severity counts', async () => {
+    vi.mocked(versionSprawlService.getSummary).mockResolvedValue({ high: 1, medium: 0, low: 1, total: 2 })
+
+    const result = await summaryHandler()
+
+    expect(result).toEqual({ success: true, data: { high: 1, medium: 0, low: 1, total: 2 }, count: 1 })
+  })
+})

--- a/test/server/repositories/component.repository.spec.ts
+++ b/test/server/repositories/component.repository.spec.ts
@@ -895,4 +895,89 @@ describe('ComponentRepository', () => {
     })
   })
 
+  describe('findVersionSprawl()', () => {
+    it('groups by technology and reports per-version distinct direct-usage system counts', async () => {
+      if (!ctx.neo4jAvailable) return
+      const techName = `${PREFIX}sprawl-react`
+      await seed(ctx.driver, `
+        CREATE (tech:Technology { name: $techName })
+        CREATE (v1:Component { name: $techName, version: '16.8.0', packageManager: 'npm', purl: $p1 })
+        CREATE (v2:Component { name: $techName, version: '17.0.2', packageManager: 'npm', purl: $p2 })
+        CREATE (v3:Component { name: $techName, version: '18.3.1', packageManager: 'npm', purl: $p3 })
+        CREATE (v1)-[:IS_VERSION_OF]->(tech)
+        CREATE (v2)-[:IS_VERSION_OF]->(tech)
+        CREATE (v3)-[:IS_VERSION_OF]->(tech)
+        CREATE (sysA:System { name: $sysA })
+        CREATE (sysB:System { name: $sysB })
+        CREATE (sysC:System { name: $sysC })
+        CREATE (sysA)-[:USES { isDirect: true }]->(v1)
+        CREATE (sysB)-[:USES { isDirect: true }]->(v1)
+        CREATE (sysB)-[:USES { isDirect: true }]->(v2)
+        CREATE (sysC)-[:USES { isDirect: false }]->(v3)
+      `, {
+        techName,
+        p1: `pkg:npm/${techName}@16.8.0`,
+        p2: `pkg:npm/${techName}@17.0.2`,
+        p3: `pkg:npm/${techName}@18.3.1`,
+        sysA: `${PREFIX}sprawl-sys-a`,
+        sysB: `${PREFIX}sprawl-sys-b`,
+        sysC: `${PREFIX}sprawl-sys-c`
+      })
+
+      const results = await repo.findVersionSprawl(2)
+      const group = results.find(r => r.technologyName === techName)
+
+      expect(group).toBeDefined()
+      expect(group!.versionCount).toBe(2)
+      expect(new Set(group!.versions)).toEqual(new Set(['16.8.0', '17.0.2']))
+      expect(group!.affectedSystemCount).toBe(2)
+
+      const breakdownByVersion = Object.fromEntries(group!.versionBreakdown.map(vb => [vb.version, vb]))
+      expect(breakdownByVersion['16.8.0'].systemCount).toBe(2)
+      expect(breakdownByVersion['17.0.2'].systemCount).toBe(1)
+      expect(breakdownByVersion['18.3.1']).toBeUndefined()
+    })
+
+    it('excludes a technology whose multiple versions are only reachable transitively', async () => {
+      if (!ctx.neo4jAvailable) return
+      const techName = `${PREFIX}sprawl-transitive-only`
+      await seed(ctx.driver, `
+        CREATE (tech:Technology { name: $techName })
+        CREATE (v1:Component { name: $techName, version: '1.0.0', packageManager: 'npm', purl: $p1 })
+        CREATE (v2:Component { name: $techName, version: '2.0.0', packageManager: 'npm', purl: $p2 })
+        CREATE (v1)-[:IS_VERSION_OF]->(tech)
+        CREATE (v2)-[:IS_VERSION_OF]->(tech)
+        CREATE (sys:System { name: $sysName })
+        CREATE (sys)-[:USES { isDirect: false }]->(v1)
+        CREATE (sys)-[:USES { isDirect: false }]->(v2)
+      `, {
+        techName,
+        p1: `pkg:npm/${techName}@1.0.0`,
+        p2: `pkg:npm/${techName}@2.0.0`,
+        sysName: `${PREFIX}sprawl-transitive-sys`
+      })
+
+      const results = await repo.findVersionSprawl(2)
+
+      expect(results.find(r => r.technologyName === techName)).toBeUndefined()
+    })
+
+    it('excludes technologies below the minimum version threshold', async () => {
+      if (!ctx.neo4jAvailable) return
+      const techName = `${PREFIX}sprawl-single-version`
+      await seed(ctx.driver, `
+        CREATE (tech:Technology { name: $techName })
+        CREATE (v1:Component { name: $techName, version: '1.0.0', packageManager: 'npm', purl: $p1 })
+        CREATE (v1)-[:IS_VERSION_OF]->(tech)
+      `, {
+        techName,
+        p1: `pkg:npm/${techName}@1.0.0`
+      })
+
+      const results = await repo.findVersionSprawl(2)
+
+      expect(results.find(r => r.technologyName === techName)).toBeUndefined()
+    })
+  })
+
 })

--- a/test/server/services/version-sprawl.service.spec.ts
+++ b/test/server/services/version-sprawl.service.spec.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest'
+import { VersionSprawlService } from '../../../server/services/version-sprawl.service'
+import type { EOLStatus } from '../../../types/api'
+import type { VersionSprawlRaw } from '../../../server/repositories/component.repository'
+
+const activeStatus: EOLStatus = {
+  status: 'active',
+  productName: 'react',
+  productLabel: 'React',
+  matchedCycle: '18',
+  eolDate: null,
+  supportEndDate: null,
+  daysUntilEOL: null,
+  daysSinceEOL: null,
+  lts: true,
+  latestVersion: '18.3.1',
+  latestReleaseDate: null,
+  source: { name: 'endoflife.date', url: 'https://endoflife.date/react' }
+}
+
+const unsupportedStatus: EOLStatus = { ...activeStatus, status: 'unsupported' }
+
+function makeGroup(overrides: Partial<VersionSprawlRaw> = {}): VersionSprawlRaw {
+  return {
+    technologyName: 'react',
+    versions: ['16.8.0', '17.0.2', '18.3.1'],
+    versionCount: 3,
+    versionBreakdown: [
+      { version: '16.8.0', systemCount: 2, systems: ['sys-a', 'sys-b'] },
+      { version: '17.0.2', systemCount: 3, systems: ['sys-c', 'sys-d', 'sys-e'] },
+      { version: '18.3.1', systemCount: 1, systems: ['sys-f'] }
+    ],
+    affectedSystemCount: 6,
+    ...overrides
+  }
+}
+
+describe('VersionSprawlService', () => {
+  describe('detect()', () => {
+    it('sorts versions ascending and recommends the newest one', async () => {
+      const service = new VersionSprawlService(
+        { findVersionSprawl: vi.fn(async () => [makeGroup({ versions: ['18.3.1', '16.8.0', '17.0.2'] })]) } as never,
+        { getEOLStatus: vi.fn(async () => activeStatus) } as never
+      )
+
+      const [detection] = await service.detect()
+
+      expect(detection.versions).toEqual(['16.8.0', '17.0.2', '18.3.1'])
+      expect(detection.versionRange).toEqual({ oldest: '16.8.0', newest: '18.3.1' })
+      expect(detection.recommendedVersion).toBe('18.3.1')
+    })
+
+    it('classifies severity by version count', async () => {
+      const findVersionSprawl = vi.fn(async () => [
+        makeGroup({ technologyName: 'low-tech', versions: ['1.0.0', '2.0.0'], versionCount: 2 }),
+        makeGroup({ technologyName: 'medium-tech', versions: ['1.0.0', '2.0.0', '3.0.0'], versionCount: 3 }),
+        makeGroup({ technologyName: 'high-tech', versions: ['1.0.0', '2.0.0', '3.0.0', '4.0.0', '5.0.0'], versionCount: 5 })
+      ])
+      const service = new VersionSprawlService(
+        { findVersionSprawl } as never,
+        { getEOLStatus: vi.fn(async () => activeStatus) } as never
+      )
+
+      const detections = await service.detect()
+      const byTech = Object.fromEntries(detections.map(d => [d.technologyName, d.severity]))
+
+      expect(byTech['low-tech']).toBe('low')
+      expect(byTech['medium-tech']).toBe('medium')
+      expect(byTech['high-tech']).toBe('high')
+    })
+
+    it('flags hasEolVersion and boosts the sprawl score when any version is unsupported', async () => {
+      const service = new VersionSprawlService(
+        { findVersionSprawl: vi.fn(async () => [makeGroup()]) } as never,
+        {
+          getEOLStatus: vi.fn(async ({ version }: { version: string }) =>
+            version === '16.8.0' ? unsupportedStatus : activeStatus)
+        } as never
+      )
+
+      const [withEol] = await service.detect()
+
+      const serviceWithoutEol = new VersionSprawlService(
+        { findVersionSprawl: vi.fn(async () => [makeGroup()]) } as never,
+        { getEOLStatus: vi.fn(async () => activeStatus) } as never
+      )
+      const [withoutEol] = await serviceWithoutEol.detect()
+
+      expect(withEol.hasEolVersion).toBe(true)
+      expect(withoutEol.hasEolVersion).toBe(false)
+      expect(withEol.sprawlScore).toBeGreaterThan(withoutEol.sprawlScore)
+    })
+
+    it('sorts detections by sprawl score descending', async () => {
+      const findVersionSprawl = vi.fn(async () => [
+        makeGroup({ technologyName: 'small', versions: ['1.0.0', '2.0.0'], versionCount: 2, affectedSystemCount: 1 }),
+        makeGroup({ technologyName: 'big', versions: ['1.0.0', '2.0.0', '3.0.0', '4.0.0', '5.0.0'], versionCount: 5, affectedSystemCount: 20 })
+      ])
+      const service = new VersionSprawlService(
+        { findVersionSprawl } as never,
+        { getEOLStatus: vi.fn(async () => activeStatus) } as never
+      )
+
+      const detections = await service.detect()
+
+      expect(detections[0].technologyName).toBe('big')
+      expect(detections[0].sprawlScore).toBeGreaterThanOrEqual(detections[1].sprawlScore)
+    })
+  })
+
+  describe('getSummary()', () => {
+    it('counts detections per severity tier', async () => {
+      const findVersionSprawl = vi.fn(async () => [
+        makeGroup({ technologyName: 'low-tech', versions: ['1.0.0', '2.0.0'], versionCount: 2 }),
+        makeGroup({ technologyName: 'high-tech', versions: ['1.0.0', '2.0.0', '3.0.0', '4.0.0', '5.0.0'], versionCount: 5 })
+      ])
+      const service = new VersionSprawlService(
+        { findVersionSprawl } as never,
+        { getEOLStatus: vi.fn(async () => activeStatus) } as never
+      )
+
+      const summary = await service.getSummary()
+
+      expect(summary).toEqual({ high: 1, medium: 0, low: 1, total: 2 })
+    })
+  })
+})

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -255,6 +255,34 @@ export interface HealthDashboardSummary {
   }
 }
 
+export type VersionSprawlSeverity = 'high' | 'medium' | 'low'
+
+export interface VersionSprawlVersionBreakdown {
+  version: string
+  systemCount: number
+  systems: string[]
+}
+
+export interface VersionSprawlDetection {
+  technologyName: string
+  versions: string[]
+  versionCount: number
+  versionRange: { oldest: string; newest: string }
+  affectedSystemCount: number
+  versionBreakdown: VersionSprawlVersionBreakdown[]
+  sprawlScore: number
+  severity: VersionSprawlSeverity
+  recommendedVersion: string
+  hasEolVersion: boolean
+}
+
+export interface VersionSprawlSummary {
+  high: number
+  medium: number
+  low: number
+  total: number
+}
+
 export type MaintenanceHealthStatus = 'healthy' | 'stable' | 'aging' | 'stale' | 'unknown'
 
 export type MaintenanceHealthConfidence = 'high' | 'medium' | 'low'


### PR DESCRIPTION
## Description

Implements GitHub issue #625 by adding automated version sprawl detection and consolidation recommendations. Detects technologies with multiple distinct versions declared as **direct** dependencies across systems, scores/ranks them by severity, and surfaces the findings via a new `/version-sprawl` page and a dashboard summary card.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Related Issues

Fixes #625

## Changes Made

- `server/database/queries/components/detect-version-sprawl.cypher` — groups by claimed `Technology`, restricted to `USES {isDirect: true}` so results are actionable (a team can't change a version it doesn't declare itself).
- `ComponentRepository.findVersionSprawl()` (repository layer, tested against live Neo4j).
- `VersionSprawlService` — sprawl score (version count + system count + major-version spread + EOL exposure via the existing `EOLService`), severity tiers (high ≥5 versions, medium 3-4, low 2), semver-aware sort with lexicographic fallback for non-semver schemes.
- `GET /api/version-sprawl` (list, `?severity=` filter) and `GET /api/version-sprawl/summary`, both cached 5 min via the existing `cachedFetch` utility. OpenAPI schemas/docs regenerated.
- New `/version-sprawl` page (severity filter, sortable table, stat strip) plus a "Version Sprawl" card on the home dashboard and a nav link.
- Repository, service, and API handler tests for the new behavior.

## Scope notes

- No email/Slack/webhook alerting and no scheduled detection job/admin trigger endpoint — detection is computed on-demand and cached briefly, consistent with the original issue's own "compute on-demand, don't persist" decision.
- Detection is restricted to **direct** dependencies only, not transitive ones — a version pulled in transitively by another library isn't something a team can fix by bumping their own manifest, so counting it would just be noise. On real data this cut the detected set from 4 technologies down to 2, most of the original "sprawl" was transitive.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev` (verified via browser: dashboard card, full page, severity filter, live data)
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed (OpenAPI docs regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)