### PR TITLE
feat(audit): audit failed CRUD attempts and sensitive-data reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* No changes
+- No changes
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.48...v0.6.49
 
@@ -55,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* fix(sbom): correctly mark isDirect for Composer and other SPDX SBOMs (#722) @localgod (#725)
+- fix(sbom): correctly mark isDirect for Composer and other SPDX SBOMs (#722) @localgod (#725)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.46...v0.6.47
 
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore(deps)(deps): bump the production-dependencies group across 1 directory with 2 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#688)
+- chore(deps)(deps): bump the production-dependencies group across 1 directory with 2 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#688)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.28...v0.6.29
 
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* Improve component detail dependency layout @localgod (#664)
+- Improve component detail dependency layout @localgod (#664)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.13...v0.6.14
 
@@ -83,7 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore(deps)(deps-dev): bump @cucumber/gherkin from 39.1.0 to 40.0.0 @[dependabot[bot]](https://github.com/apps/dependabot) (#644)
+- chore(deps)(deps-dev): bump @cucumber/gherkin from 39.1.0 to 40.0.0 @[dependabot[bot]](https://github.com/apps/dependabot) (#644)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.6...v0.6.7
 
@@ -91,7 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* Add deps.dev package metadata overlay @localgod (#613)
+- Add deps.dev package metadata overlay @localgod (#613)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.48...v0.5.49
 
@@ -101,7 +101,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore(deps)(deps-dev): bump the development-dependencies group with 4 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#606)
+- chore(deps)(deps-dev): bump the development-dependencies group with 4 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#606)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.45...v0.5.46
 
@@ -111,7 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore(deps)(deps-dev): bump the development-dependencies group with 6 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#593)
+- chore(deps)(deps-dev): bump the development-dependencies group with 6 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#593)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.41...v0.5.42
 
@@ -119,7 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* fix: move dependency scope from Component node to USES/DIRECT\_DEP edges @localgod (#582)
+- fix: move dependency scope from Component node to USES/DIRECT\_DEP edges @localgod (#582)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.36...v0.5.37
 
@@ -127,11 +127,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* fix: make ownerTeam required in GitHub import dialog @localgod (#565)
+- fix: make ownerTeam required in GitHub import dialog @localgod (#565)
 
 ## 🔧 Maintenance
 
-* chore: release v0.5.28 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#564)
+- chore: release v0.5.28 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#564)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.28...v0.5.29
 
@@ -139,7 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* feat: use Simple Icons for package manager types @localgod (#563)
+- feat: use Simple Icons for package manager types @localgod (#563)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.27...v0.5.28
 
@@ -149,7 +149,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore(deps)(deps): bump devalue from 5.8.0 to 5.8.1 @[dependabot[bot]](https://github.com/apps/dependabot) (#506)
+- chore(deps)(deps): bump devalue from 5.8.0 to 5.8.1 @[dependabot[bot]](https://github.com/apps/dependabot) (#506)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.8...v0.5.9
 
@@ -159,7 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🚀 Features
 
-* fix: neo4j plugin fails fast on connection failure at startup @localgod (#492)
+- fix: neo4j plugin fails fast on connection failure at startup @localgod (#492)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.4.2...v0.5.0
 
@@ -167,7 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* feat: dependency graph, SBOM pipeline fixes, and component filtering @localgod (#476)
+- feat: dependency graph, SBOM pipeline fixes, and component filtering @localgod (#476)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.85...v0.1.86
 
@@ -177,7 +177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore(actions): bump dorny/paths-filter from 3 to 4 @[dependabot[bot]](https://github.com/apps/dependabot) (#463)
+- chore(actions): bump dorny/paths-filter from 3 to 4 @[dependabot[bot]](https://github.com/apps/dependabot) (#463)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.81...v0.1.82
 
@@ -187,7 +187,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore: release v0.1.77 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#459)
+- chore: release v0.1.77 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#459)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.77...v0.1.78
 
@@ -195,7 +195,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* feat: environment-scoped technology approvals @localgod (#458)
+- feat: environment-scoped technology approvals @localgod (#458)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.76...v0.1.77
 
@@ -203,7 +203,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* fix: regenerate lockfile and fix CHANGELOG markdown lint errors @localgod (#330)
+- fix: regenerate lockfile and fix CHANGELOG markdown lint errors @localgod (#330)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.27...v0.1.28
 
@@ -211,11 +211,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* chore(deps): ignore next-auth >=4.23.0 in dependabot @localgod (#320)
+- chore(deps): ignore next-auth >=4.23.0 in dependabot @localgod (#320)
 
 ## 🔧 Maintenance
 
-* chore: release v0.1.22 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#319)
+- chore: release v0.1.22 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#319)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.22...v0.1.23
 
@@ -223,11 +223,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* fix: replace scp-action with inline SSH heredoc for compose file @localgod (#318)
+- fix: replace scp-action with inline SSH heredoc for compose file @localgod (#318)
 
 ## 🔧 Maintenance
 
-* chore: release v0.1.21 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#317)
+- chore: release v0.1.21 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#317)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.21...v0.1.22
 
@@ -237,7 +237,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore: release v0.1.19 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#313)
+- chore: release v0.1.19 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#313)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.20...v0.1.21
 
@@ -247,7 +247,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore(actions): bump actions/checkout from 4 to 6 @[dependabot[bot]](https://github.com/apps/dependabot) (#310)
+- chore(actions): bump actions/checkout from 4 to 6 @[dependabot[bot]](https://github.com/apps/dependabot) (#310)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.18...v0.1.19
 
@@ -257,7 +257,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-* chore: release v0.1.10 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#294)
+- chore: release v0.1.10 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#294)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.12...v0.1.13
 
@@ -265,11 +265,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* fix: add mobile top bar with sidebar trigger @localgod (#293)
+- fix: add mobile top bar with sidebar trigger @localgod (#293)
 
 ## 🔧 Maintenance
 
-* chore: release v0.1.9 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#292)
+- chore: release v0.1.9 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#292)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.9...v0.1.10
 
@@ -277,6 +277,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-* No changes
+- No changes
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.8...v0.1.9

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Polaris API",
-    "version": "0.6.57",
+    "version": "0.6.63",
     "description": "# Polaris Technology Catalog API\n\nThe Polaris API provides programmatic access to the technology catalog, enabling automation, integration, and custom tooling.\n\n## Key Features\n\n- **RESTful Design** - Resource-based URLs with proper HTTP methods\n- **Comprehensive Coverage** - Systems, Teams, Technologies, Components, Policies, and more\n- **Developer-Friendly** - Clear error messages and consistent response structure\n\n## Authentication\n\nMost endpoints require authentication using session-based authentication integrated with the web application.\n\n**Authorization Levels:**\n- **Public** - No authentication required\n- **Authenticated** - Valid user session required  \n- **Team Member** - User must belong to a team\n- **Team Owner** - User must belong to team that owns the resource\n- **Superuser** - User must have superuser role\n\n## Response Format\n\nAll successful responses follow this structure:\n```json\n{\n  \"success\": true,\n  \"data\": [...],\n  \"count\": 10\n}\n```\n\nAll errors follow this structure:\n```json\n{\n  \"statusCode\": 404,\n  \"message\": \"Resource 'example' not found\"\n}\n```\n\n## Richardson Maturity Model\n\nThis API implements **RMM Level 2** with proper use of HTTP methods and status codes.",
     "license": {
       "name": "MIT",

--- a/server/api/admin/impersonate.delete.ts
+++ b/server/api/admin/impersonate.delete.ts
@@ -1,5 +1,6 @@
 import { getRealUser } from '../../utils/auth'
 import { AuditLogRepository } from '../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * Stop impersonating. Clears the impersonation cookie.
@@ -22,14 +23,25 @@ export default defineEventHandler(async (event) => {
   })
 
   if (impersonatedUserId) {
-    const auditRepo = new AuditLogRepository()
-    await auditRepo.create({
-      operation: 'IMPERSONATION_STOPPED',
-      entityType: 'User',
-      entityId: impersonatedUserId,
-      entityLabel: impersonatedUserId,
-      userId: realUser.id,
-    })
+    try {
+      const auditRepo = new AuditLogRepository()
+      await auditRepo.create({
+        operation: 'IMPERSONATION_STOPPED',
+        entityType: 'User',
+        entityId: impersonatedUserId,
+        entityLabel: impersonatedUserId,
+        userId: realUser.id,
+      })
+    } catch (error) {
+      await auditFailedOperation(event, {
+        operation: 'IMPERSONATION_STOPPED',
+        entityType: 'User',
+        entityId: impersonatedUserId,
+        reason: error instanceof Error ? error.message : 'Failed to record impersonation stop',
+        userId: realUser.id
+      })
+      throw error
+    }
   }
 
   return { success: true }

--- a/server/api/admin/impersonate.post.ts
+++ b/server/api/admin/impersonate.post.ts
@@ -1,6 +1,7 @@
 import { getRealUser } from '../../utils/auth'
 import { userService } from '../../services/singletons'
 import { AuditLogRepository } from '../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * Start impersonating a user. Superuser only.
@@ -19,42 +20,53 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'userId is required' })
   }
 
-  // Prevent impersonating yourself
-  if (body.userId === realUser.id) {
-    throw createError({ statusCode: 422, message: 'Cannot impersonate yourself' })
-  }
-
-  // Verify target user exists
-  const target = await userService.findById(body.userId)
-
-  if (!target) {
-    throw createError({ statusCode: 404, message: 'User not found' })
-  }
-
-  setCookie(event, 'polaris-impersonate', body.userId, {
-    httpOnly: true,
-    sameSite: 'lax',
-    path: '/',
-    secure: process.env.COOKIE_SECURE !== 'false',
-    maxAge: 60 * 60 // 1 hour
-  })
-
-  const auditRepo = new AuditLogRepository()
-  await auditRepo.create({
-    operation: 'IMPERSONATION_STARTED',
-    entityType: 'User',
-    entityId: body.userId,
-    entityLabel: target.email,
-    userId: realUser.id,
-  })
-
-  return {
-    success: true,
-    impersonating: {
-      id: target.id,
-      email: target.email,
-      name: target.name,
-      role: target.role
+  try {
+    // Prevent impersonating yourself
+    if (body.userId === realUser.id) {
+      throw createError({ statusCode: 422, message: 'Cannot impersonate yourself' })
     }
+
+    // Verify target user exists
+    const target = await userService.findById(body.userId)
+
+    if (!target) {
+      throw createError({ statusCode: 404, message: 'User not found' })
+    }
+
+    setCookie(event, 'polaris-impersonate', body.userId, {
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+      secure: process.env.COOKIE_SECURE !== 'false',
+      maxAge: 60 * 60 // 1 hour
+    })
+
+    const auditRepo = new AuditLogRepository()
+    await auditRepo.create({
+      operation: 'IMPERSONATION_STARTED',
+      entityType: 'User',
+      entityId: body.userId,
+      entityLabel: target.email,
+      userId: realUser.id,
+    })
+
+    return {
+      success: true,
+      impersonating: {
+        id: target.id,
+        email: target.email,
+        name: target.name,
+        role: target.role
+      }
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'IMPERSONATION_STARTED',
+      entityType: 'User',
+      entityId: body.userId,
+      reason: error instanceof Error ? error.message : 'Failed to start impersonation',
+      userId: realUser.id
+    })
+    throw error
   }
 })

--- a/server/api/admin/import/github-org.post.ts
+++ b/server/api/admin/import/github-org.post.ts
@@ -1,4 +1,5 @@
 import { gitHubOrgImportService } from '../../../services/singletons'
+import { auditFailedOperation } from '../../../utils/audit'
 import { getServerSession } from '#auth'
 
 /**
@@ -127,11 +128,20 @@ export default defineEventHandler(async (event) => {
       data: job
     }
   } catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'GitHub owner import failed'
+    await auditFailedOperation(event, {
+      operation: 'IMPORT',
+      entityType: 'ImportJob',
+      entityId: owner,
+      reason: message,
+      userId: user.id,
+      realUserId
+    })
+
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }
 
-    const message = error instanceof Error ? error.message : 'GitHub owner import failed'
     throw createError({ statusCode: 422, statusMessage: message, message })
   }
 })

--- a/server/api/admin/import/github.post.ts
+++ b/server/api/admin/import/github.post.ts
@@ -1,5 +1,6 @@
 import { gitHubImportService } from '../../../services/singletons'
 import { AuditLogRepository } from '../../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../../utils/audit'
 import { getServerSession } from '#auth'
 
 /**
@@ -109,12 +110,22 @@ export default defineEventHandler(async (event) => {
       data: result
     }
   } catch (error: unknown) {
+    const failureMessage = error instanceof Error ? error.message : 'Import failed'
+    await auditFailedOperation(event, {
+      operation: 'IMPORT',
+      entityType: 'System',
+      entityId: systemName || repositoryUrl,
+      reason: failureMessage,
+      userId: user.id,
+      realUserId
+    })
+
     // Re-throw HTTP errors (4xx/5xx already created via createError)
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }
 
-    const message = error instanceof Error ? error.message : 'Import failed'
+    const message = failureMessage
     const stack = error instanceof Error ? error.stack : undefined
 
     // Log the full error so it appears in production server logs

--- a/server/api/admin/licenses/whitelist.put.ts
+++ b/server/api/admin/licenses/whitelist.put.ts
@@ -1,4 +1,5 @@
 import { licenseService } from '../../../services/singletons'
+import { auditFailedOperation } from '../../../utils/audit'
 
 interface AllowedUpdateRequest {
   licenseId?: string
@@ -130,6 +131,14 @@ export default defineEventHandler(async (event): Promise<AllowedUpdateResponse> 
         } else {
           setResponseStatus(event, 500)
         }
+        await auditFailedOperation(event, {
+          operation: 'UPDATE',
+          entityType: 'License',
+          entityId: body.licenseId,
+          reason: errorMessage,
+          userId: user.id,
+          realUserId
+        })
         return {
           success: false,
           message: errorMessage
@@ -140,7 +149,7 @@ export default defineEventHandler(async (event): Promise<AllowedUpdateResponse> 
     // Handle bulk license update
     if (body.licenseIds) {
       const result = await licenseService.bulkUpdateAllowedStatus(body.licenseIds, body.allowed, user.id, realUserId)
-      
+
       if (result.success) {
         setResponseStatus(event, 200)
         return {
@@ -152,6 +161,14 @@ export default defineEventHandler(async (event): Promise<AllowedUpdateResponse> 
         // Check if any errors mention "not found"
         const hasNotFoundError = result.errors?.some(err => err.includes('not found'))
         setResponseStatus(event, hasNotFoundError ? 404 : 400)
+        await auditFailedOperation(event, {
+          operation: 'UPDATE',
+          entityType: 'License',
+          entityId: body.licenseIds.join(','),
+          reason: result.errors?.join('; ') || 'Failed to update some licenses',
+          userId: user.id,
+          realUserId
+        })
         return {
           success: false,
           message: 'Failed to update some licenses',
@@ -168,6 +185,14 @@ export default defineEventHandler(async (event): Promise<AllowedUpdateResponse> 
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Failed to update license allowed status'
     setResponseStatus(event, 500)
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'License',
+      entityId: 'unknown',
+      reason: errorMessage,
+      userId: user.id,
+      realUserId
+    })
     return {
       success: false,
       message: errorMessage

--- a/server/api/admin/systems/[name]/rescan.post.ts
+++ b/server/api/admin/systems/[name]/rescan.post.ts
@@ -1,5 +1,6 @@
 import { gitHubImportService, systemService } from '../../../../services/singletons'
 import { getServerSession } from '#auth'
+import { auditFailedOperation } from '../../../../utils/audit'
 
 export default defineEventHandler(async (event) => {
   const user = await requireSuperuser(event)
@@ -14,47 +15,58 @@ export default defineEventHandler(async (event) => {
 
   const name = decodeURIComponent(rawName)
 
-  const system = await systemService.findByName(name)
+  try {
+    const system = await systemService.findByName(name)
 
-  if (!system) {
-    throw createError({ statusCode: 404, message: `System '${name}' not found` })
-  }
+    if (!system) {
+      throw createError({ statusCode: 404, message: `System '${name}' not found` })
+    }
 
-  if (!system.ownerTeam) {
-    throw createError({ statusCode: 422, message: `System '${name}' has no owner team — cannot rescan` })
-  }
+    if (!system.ownerTeam) {
+      throw createError({ statusCode: 422, message: `System '${name}' has no owner team — cannot rescan` })
+    }
 
-  const { data: repositories } = await systemService.getRepositories(name)
+    const { data: repositories } = await systemService.getRepositories(name)
 
-  if (repositories.length === 0) {
-    throw createError({ statusCode: 422, message: `System '${name}' has no linked repositories — cannot rescan` })
-  }
+    if (repositories.length === 0) {
+      throw createError({ statusCode: 422, message: `System '${name}' has no linked repositories — cannot rescan` })
+    }
 
-  const results = await Promise.allSettled(
-    repositories.map(repo =>
-      gitHubImportService.import({
-        repositoryUrl: repo.url,
-        systemName: name,
-        ownerTeam: system.ownerTeam!,
-        userId: user.id,
-        githubToken
-      })
+    const results = await Promise.allSettled(
+      repositories.map(repo =>
+        gitHubImportService.import({
+          repositoryUrl: repo.url,
+          systemName: name,
+          ownerTeam: system.ownerTeam!,
+          userId: user.id,
+          githubToken
+        })
+      )
     )
-  )
 
-  const succeeded = results.filter(r => r.status === 'fulfilled').length
-  const failed = results.filter(r => r.status === 'rejected').length
+    const succeeded = results.filter(r => r.status === 'fulfilled').length
+    const failed = results.filter(r => r.status === 'rejected').length
 
-  const failures = results
-    .map((r, i) => r.status === 'rejected' ? { repository: repositories[i]!.url, error: r.reason instanceof Error ? r.reason.message : String(r.reason) } : null)
-    .filter(Boolean)
+    const failures = results
+      .map((r, i) => r.status === 'rejected' ? { repository: repositories[i]!.url, error: r.reason instanceof Error ? r.reason.message : String(r.reason) } : null)
+      .filter(Boolean)
 
-  if (failures.length > 0) {
-    event.context.logger?.warn({ failures }, 'Some repositories failed to rescan')
-  }
+    if (failures.length > 0) {
+      event.context.logger?.warn({ failures }, 'Some repositories failed to rescan')
+    }
 
-  return {
-    success: true,
-    data: { total: repositories.length, succeeded, failed, failures }
+    return {
+      success: true,
+      data: { total: repositories.length, succeeded, failed, failures }
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'RESCAN',
+      entityType: 'System',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to rescan system',
+      userId: user.id
+    })
+    throw error
   }
 })

--- a/server/api/admin/users/[userId]/index.delete.ts
+++ b/server/api/admin/users/[userId]/index.delete.ts
@@ -1,5 +1,6 @@
 import { UserRepository } from '../../../../repositories/user.repository'
 import { AuditLogRepository } from '../../../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../../../utils/audit'
 
 /**
  * @openapi
@@ -24,37 +25,48 @@ import { AuditLogRepository } from '../../../../repositories/audit-log.repositor
  *         description: User not found
  */
 export default defineEventHandler(async (event) => {
-  await requireSuperuser(event)
+  const currentUser = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   const userId = getRouterParam(event, 'userId')
   if (!userId) {
     throw createError({ statusCode: 400, message: 'userId is required' })
   }
 
-  const userRepo = new UserRepository()
-  const user = await userRepo.findById(userId)
+  try {
+    const userRepo = new UserRepository()
+    const user = await userRepo.findById(userId)
 
-  if (!user) {
-    throw createError({ statusCode: 404, message: 'User not found' })
+    if (!user) {
+      throw createError({ statusCode: 404, message: 'User not found' })
+    }
+
+    if (user.provider !== 'technical') {
+      throw createError({ statusCode: 400, message: 'Only technical users can be deleted' })
+    }
+
+    await userRepo.deleteUser(userId)
+
+    const auditRepo = new AuditLogRepository()
+    await auditRepo.create({
+      operation: 'DELETE',
+      entityType: 'User',
+      entityId: userId,
+      entityLabel: user.name || user.email,
+      userId: currentUser.id,
+      realUserId
+    })
+
+    return { success: true, message: 'Technical user deleted' }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE',
+      entityType: 'User',
+      entityId: userId,
+      reason: error instanceof Error ? error.message : 'Failed to delete user',
+      userId: currentUser.id,
+      realUserId
+    })
+    throw error
   }
-
-  if (user.provider !== 'technical') {
-    throw createError({ statusCode: 400, message: 'Only technical users can be deleted' })
-  }
-
-  await userRepo.deleteUser(userId)
-
-  const currentUser = await getCurrentUser(event)
-  const realUserId = await getImpersonatorId(event)
-  const auditRepo = new AuditLogRepository()
-  await auditRepo.create({
-    operation: 'DELETE',
-    entityType: 'User',
-    entityId: userId,
-    entityLabel: user.name || user.email,
-    userId: currentUser.id,
-    realUserId
-  })
-
-  return { success: true, message: 'Technical user deleted' }
 })

--- a/server/api/admin/users/[userId]/role.put.ts
+++ b/server/api/admin/users/[userId]/role.put.ts
@@ -1,4 +1,5 @@
 import { userService } from '../../../../services/singletons'
+import { auditFailedOperation } from '../../../../utils/audit'
 
 /**
  * @openapi
@@ -65,22 +66,34 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Bad Request', message: 'Role must be "user" or "superuser"' })
   }
 
-  // Prevent a superuser from demoting themselves
-  const actingAs = realUserId ?? currentUser.id
-  if (role === 'user' && actingAs === userId) {
-    throw createError({ statusCode: 403, statusMessage: 'Forbidden', message: 'You cannot remove your own superuser access' })
+  try {
+    // Prevent a superuser from demoting themselves
+    const actingAs = realUserId ?? currentUser.id
+    if (role === 'user' && actingAs === userId) {
+      throw createError({ statusCode: 403, statusMessage: 'Forbidden', message: 'You cannot remove your own superuser access' })
+    }
+
+    const user = await userService.updateRole({
+      userId,
+      role,
+      performedBy: currentUser.id,
+      realUserId
+    })
+
+    if (!user) {
+      throw createError({ statusCode: 404, statusMessage: 'Not Found', message: 'User not found' })
+    }
+
+    return { success: true, data: user }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'CHANGE_ROLE',
+      entityType: 'User',
+      entityId: userId,
+      reason: error instanceof Error ? error.message : 'Failed to update role',
+      userId: currentUser.id,
+      realUserId
+    })
+    throw error
   }
-
-  const user = await userService.updateRole({
-    userId,
-    role,
-    performedBy: currentUser.id,
-    realUserId
-  })
-
-  if (!user) {
-    throw createError({ statusCode: 404, statusMessage: 'Not Found', message: 'User not found' })
-  }
-
-  return { success: true, data: user }
 })

--- a/server/api/admin/users/[userId]/teams.post.ts
+++ b/server/api/admin/users/[userId]/teams.post.ts
@@ -1,4 +1,5 @@
 import { userService } from '../../../../services/singletons'
+import { auditFailedOperation } from '../../../../utils/audit'
 
 /**
  * @openapi
@@ -128,6 +129,14 @@ export default defineEventHandler(async (event) => {
       data: user
     }
   } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'ASSIGN_TEAMS',
+      entityType: 'User',
+      entityId: userId,
+      reason: error instanceof Error ? error.message : 'User not found',
+      userId: currentUser.id,
+      realUserId
+    })
     throw createError({
       statusCode: 404,
       statusMessage: 'Not Found',

--- a/server/api/admin/users/[userId]/tokens.get.ts
+++ b/server/api/admin/users/[userId]/tokens.get.ts
@@ -1,4 +1,5 @@
 import { tokenService } from '../../../../services/singletons'
+import { auditSensitiveRead } from '../../../../utils/audit'
 
 /**
  * @openapi
@@ -19,7 +20,8 @@ import { tokenService } from '../../../../services/singletons'
  *         description: Tokens listed
  */
 export default defineEventHandler(async (event) => {
-  await requireSuperuser(event)
+  const currentUser = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   const userId = getRouterParam(event, 'userId')
   if (!userId) {
@@ -27,6 +29,14 @@ export default defineEventHandler(async (event) => {
   }
 
   const tokens = await tokenService.listTokens(userId)
+
+  await auditSensitiveRead(event, {
+    entityType: 'ApiToken',
+    entityId: userId,
+    reason: `Listed API tokens for user ${userId}`,
+    userId: currentUser.id,
+    realUserId
+  })
 
   return {
     success: true,

--- a/server/api/admin/users/[userId]/tokens.post.ts
+++ b/server/api/admin/users/[userId]/tokens.post.ts
@@ -1,6 +1,7 @@
 import { UserRepository } from '../../../../repositories/user.repository'
 import { tokenService } from '../../../../services/singletons'
 import { AuditLogRepository } from '../../../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../../../utils/audit'
 
 /**
  * @openapi
@@ -38,47 +39,58 @@ import { AuditLogRepository } from '../../../../repositories/audit-log.repositor
  *         description: User not found
  */
 export default defineEventHandler(async (event) => {
-  await requireSuperuser(event)
+  const currentUser = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   const userId = getRouterParam(event, 'userId')
   if (!userId) {
     throw createError({ statusCode: 400, message: 'userId is required' })
   }
 
-  const userRepo = new UserRepository()
-  const user = await userRepo.findById(userId)
+  try {
+    const userRepo = new UserRepository()
+    const user = await userRepo.findById(userId)
 
-  if (!user) {
-    throw createError({ statusCode: 404, message: 'User not found' })
-  }
+    if (!user) {
+      throw createError({ statusCode: 404, message: 'User not found' })
+    }
 
-  if (user.provider !== 'technical') {
-    throw createError({ statusCode: 400, message: 'Tokens can only be generated for technical users' })
-  }
+    if (user.provider !== 'technical') {
+      throw createError({ statusCode: 400, message: 'Tokens can only be generated for technical users' })
+    }
 
-  const body = await readBody(event) || {}
+    const body = await readBody(event) || {}
 
-  const result = await tokenService.createToken(userId, {
-    description: body.description || null,
-    expiresInDays: body.expiresInDays || undefined
-  })
+    const result = await tokenService.createToken(userId, {
+      description: body.description || null,
+      expiresInDays: body.expiresInDays || undefined
+    })
 
-  const currentUser = await getCurrentUser(event)
-  const realUserId = await getImpersonatorId(event)
-  const auditRepo = new AuditLogRepository()
-  await auditRepo.create({
-    operation: 'CREATE',
-    entityType: 'ApiToken',
-    entityId: result.id,
-    entityLabel: `Token for ${user.name || user.email}`,
-    changedFields: ['description', 'expiresAt'],
-    userId: currentUser.id,
-    realUserId
-  })
+    const auditRepo = new AuditLogRepository()
+    await auditRepo.create({
+      operation: 'CREATE',
+      entityType: 'ApiToken',
+      entityId: result.id,
+      entityLabel: `Token for ${user.name || user.email}`,
+      changedFields: ['description', 'expiresAt'],
+      userId: currentUser.id,
+      realUserId
+    })
 
-  setResponseStatus(event, 201)
-  return {
-    success: true,
-    data: result
+    setResponseStatus(event, 201)
+    return {
+      success: true,
+      data: result
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'CREATE',
+      entityType: 'ApiToken',
+      entityId: userId,
+      reason: error instanceof Error ? error.message : 'Failed to create token',
+      userId: currentUser.id,
+      realUserId
+    })
+    throw error
   }
 })

--- a/server/api/admin/users/[userId]/tokens/[tokenId].delete.ts
+++ b/server/api/admin/users/[userId]/tokens/[tokenId].delete.ts
@@ -1,5 +1,6 @@
 import { tokenService } from '../../../../../services/singletons'
 import { AuditLogRepository } from '../../../../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../../../../utils/audit'
 
 /**
  * @openapi
@@ -27,7 +28,8 @@ import { AuditLogRepository } from '../../../../../repositories/audit-log.reposi
  *         description: Token not found
  */
 export default defineEventHandler(async (event) => {
-  await requireSuperuser(event)
+  const currentUser = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   const tokenId = getRouterParam(event, 'tokenId')
   if (!tokenId) {
@@ -39,22 +41,32 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'userId is required' })
   }
 
-  const revoked = await tokenService.revokeToken(tokenId, userId)
+  try {
+    const revoked = await tokenService.revokeToken(tokenId, userId)
 
-  if (!revoked) {
-    throw createError({ statusCode: 404, message: 'Token not found' })
+    if (!revoked) {
+      throw createError({ statusCode: 404, message: 'Token not found' })
+    }
+    const auditRepo = new AuditLogRepository()
+    await auditRepo.create({
+      operation: 'DELETE',
+      entityType: 'ApiToken',
+      entityId: tokenId,
+      entityLabel: `Token ${tokenId} for user ${userId}`,
+      userId: currentUser.id,
+      realUserId
+    })
+
+    return { success: true, message: 'Token revoked' }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE',
+      entityType: 'ApiToken',
+      entityId: tokenId,
+      reason: error instanceof Error ? error.message : 'Failed to revoke token',
+      userId: currentUser.id,
+      realUserId
+    })
+    throw error
   }
-  const currentUser = await getCurrentUser(event)
-  const realUserId = await getImpersonatorId(event)
-  const auditRepo = new AuditLogRepository()
-  await auditRepo.create({
-    operation: 'DELETE',
-    entityType: 'ApiToken',
-    entityId: tokenId,
-    entityLabel: `Token ${tokenId} for user ${userId}`,
-    userId: currentUser.id,
-    realUserId
-  })
-
-  return { success: true, message: 'Token revoked' }
 })

--- a/server/api/admin/users/index.get.ts
+++ b/server/api/admin/users/index.get.ts
@@ -1,4 +1,5 @@
 import { userService } from '../../../services/singletons'
+import { auditSensitiveRead } from '../../../utils/audit'
 
 /**
  * @openapi
@@ -63,9 +64,18 @@ import { userService } from '../../../services/singletons'
  */
 export default defineEventHandler(async (event) => {
   // Require superuser access
-  await requireSuperuser(event)
+  const currentUser = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   const result = await userService.findAll()
+
+  await auditSensitiveRead(event, {
+    entityType: 'User',
+    entityId: 'all',
+    reason: 'Listed all users with team memberships',
+    userId: currentUser.id,
+    realUserId
+  })
 
   return {
     success: true,

--- a/server/api/admin/users/index.post.ts
+++ b/server/api/admin/users/index.post.ts
@@ -1,5 +1,6 @@
 import { UserRepository } from '../../../repositories/user.repository'
 import { AuditLogRepository } from '../../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../../utils/audit'
 import { randomBytes } from 'crypto'
 
 /**
@@ -31,7 +32,8 @@ import { randomBytes } from 'crypto'
  *         description: Not authorized
  */
 export default defineEventHandler(async (event) => {
-  await requireSuperuser(event)
+  const currentUser = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   const body = await readBody(event)
 
@@ -39,42 +41,52 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'name and email are required' })
   }
 
-  const userRepo = new UserRepository()
+  try {
+    const userRepo = new UserRepository()
 
-  // Check if email already exists
-  const existing = await userRepo.findAllSummary()
-  if (existing.some(u => u.email === body.email)) {
-    throw createError({ statusCode: 409, message: 'A user with this email already exists' })
-  }
+    // Check if email already exists
+    const existing = await userRepo.findAllSummary()
+    if (existing.some(u => u.email === body.email)) {
+      throw createError({ statusCode: 409, message: 'A user with this email already exists' })
+    }
 
-  const id = `technical_${randomBytes(12).toString('hex')}`
+    const id = `technical_${randomBytes(12).toString('hex')}`
 
-  await userRepo.createOrUpdateUser({
-    id,
-    email: body.email,
-    name: body.name,
-    provider: 'technical',
-    avatarUrl: null,
-    isSuperuser: false,
-    role: 'user'
-  })
+    await userRepo.createOrUpdateUser({
+      id,
+      email: body.email,
+      name: body.name,
+      provider: 'technical',
+      avatarUrl: null,
+      isSuperuser: false,
+      role: 'user'
+    })
 
-  const currentUser = await getCurrentUser(event)
-  const realUserId = await getImpersonatorId(event)
-  const auditRepo = new AuditLogRepository()
-  await auditRepo.create({
-    operation: 'CREATE',
-    entityType: 'User',
-    entityId: id,
-    entityLabel: body.name || body.email,
-    changedFields: ['name', 'email', 'provider'],
-    userId: currentUser.id,
-    realUserId
-  })
+    const auditRepo = new AuditLogRepository()
+    await auditRepo.create({
+      operation: 'CREATE',
+      entityType: 'User',
+      entityId: id,
+      entityLabel: body.name || body.email,
+      changedFields: ['name', 'email', 'provider'],
+      userId: currentUser.id,
+      realUserId
+    })
 
-  setResponseStatus(event, 201)
-  return {
-    success: true,
-    data: { id, name: body.name, email: body.email, provider: 'technical' }
+    setResponseStatus(event, 201)
+    return {
+      success: true,
+      data: { id, name: body.name, email: body.email, provider: 'technical' }
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'CREATE',
+      entityType: 'User',
+      entityId: body.email,
+      reason: error instanceof Error ? error.message : 'Failed to create technical user',
+      userId: currentUser.id,
+      realUserId
+    })
+    throw error
   }
 })

--- a/server/api/admin/users/invite.post.ts
+++ b/server/api/admin/users/invite.post.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'crypto'
 import { userService } from '../../../services/singletons'
+import { auditFailedOperation } from '../../../utils/audit'
 
 /**
  * @openapi
@@ -69,62 +70,74 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Bad Request', message: 'githubUsername is required' })
   }
 
-  // Check for an existing pending invite
-  const existing = await userService.findPendingByUsername(githubUsername)
-  if (existing) {
-    throw createError({
-      statusCode: 409,
-      statusMessage: 'Conflict',
-      message: `A pending invite already exists for @${githubUsername}`
-    })
-  }
-
-  // Fetch public profile from GitHub so we can show name/avatar immediately
-  let name: string | null = null
-  let avatarUrl: string | null = null
-  let email = ''
   try {
-    const ghRes = await $fetch<{ name?: string | null; avatar_url?: string; email?: string | null }>(
-      `https://api.github.com/users/${encodeURIComponent(githubUsername)}`,
-      { headers: { 'User-Agent': 'Polaris', Accept: 'application/vnd.github.v3+json' } }
-    )
-    name = ghRes.name ?? null
-    avatarUrl = ghRes.avatar_url ?? null
-    email = ghRes.email ?? ''
-  } catch {
-    // GitHub profile fetch is best-effort; proceed without it
-  }
+    // Check for an existing pending invite
+    const existing = await userService.findPendingByUsername(githubUsername)
+    if (existing) {
+      throw createError({
+        statusCode: 409,
+        statusMessage: 'Conflict',
+        message: `A pending invite already exists for @${githubUsername}`
+      })
+    }
 
-  const rawExpiry = body.expiryDays
-  const expiryDays: number | null =
-    rawExpiry == null ? 7 : Number.isFinite(Number(rawExpiry)) && Number(rawExpiry) > 0
-      ? Number(rawExpiry)
+    // Fetch public profile from GitHub so we can show name/avatar immediately
+    let name: string | null = null
+    let avatarUrl: string | null = null
+    let email = ''
+    try {
+      const ghRes = await $fetch<{ name?: string | null; avatar_url?: string; email?: string | null }>(
+        `https://api.github.com/users/${encodeURIComponent(githubUsername)}`,
+        { headers: { 'User-Agent': 'Polaris', Accept: 'application/vnd.github.v3+json' } }
+      )
+      name = ghRes.name ?? null
+      avatarUrl = ghRes.avatar_url ?? null
+      email = ghRes.email ?? ''
+    } catch {
+      // GitHub profile fetch is best-effort; proceed without it
+    }
+
+    const rawExpiry = body.expiryDays
+    const expiryDays: number | null =
+      rawExpiry == null ? 7 : Number.isFinite(Number(rawExpiry)) && Number(rawExpiry) > 0
+        ? Number(rawExpiry)
+        : null
+
+    const inviteToken = randomUUID()
+    const pendingId = `invite-${randomUUID()}`
+
+    await userService.createPendingUser({
+      id: pendingId,
+      email,
+      name,
+      avatarUrl,
+      githubUsername,
+      inviteToken,
+      expiryDays,
+      createdBy: currentUser.id,
+      realUserId
+    })
+
+    const baseUrl = process.env.NUXT_PUBLIC_BASE_URL || `https://${getRequestHost(event)}`
+    const inviteUrl = `${baseUrl}/invite/${inviteToken}`
+    const expiresAt = expiryDays
+      ? new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000).toISOString()
       : null
 
-  const inviteToken = randomUUID()
-  const pendingId = `invite-${randomUUID()}`
-
-  await userService.createPendingUser({
-    id: pendingId,
-    email,
-    name,
-    avatarUrl,
-    githubUsername,
-    inviteToken,
-    expiryDays,
-    createdBy: currentUser.id,
-    realUserId
-  })
-
-  const baseUrl = process.env.NUXT_PUBLIC_BASE_URL || `https://${getRequestHost(event)}`
-  const inviteUrl = `${baseUrl}/invite/${inviteToken}`
-  const expiresAt = expiryDays
-    ? new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000).toISOString()
-    : null
-
-  setResponseStatus(event, 201)
-  return {
-    success: true,
-    data: { inviteUrl, githubUsername, expiresAt }
+    setResponseStatus(event, 201)
+    return {
+      success: true,
+      data: { inviteUrl, githubUsername, expiresAt }
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'CREATE_INVITE',
+      entityType: 'User',
+      entityId: githubUsername,
+      reason: error instanceof Error ? error.message : 'Failed to create invite',
+      userId: currentUser.id,
+      realUserId
+    })
+    throw error
   }
 })

--- a/server/api/audit-logs.get.ts
+++ b/server/api/audit-logs.get.ts
@@ -1,4 +1,5 @@
 import { auditLogService } from '../services/singletons'
+import { auditSensitiveRead } from '../utils/audit'
 
 /**
  * @openapi
@@ -77,6 +78,7 @@ import { auditLogService } from '../services/singletons'
 
 export default defineEventHandler(async (event) => {
   const user = await requireAuth(event)
+  const realUserId = await getImpersonatorId(event)
 
   const query = getQuery(event)
 
@@ -96,7 +98,20 @@ export default defineEventHandler(async (event) => {
 
   try {
     const result = await auditLogService.getAuditLogs(filters)
-    
+
+    // Only flag reads of someone else's (or the whole org's) audit trail —
+    // a user checking their own history is routine self-service, not a
+    // security-relevant "who's watching whom" event.
+    if (!filters.userId || filters.userId !== user.id) {
+      await auditSensitiveRead(event, {
+        entityType: 'AuditLog',
+        entityId: filters.userId || 'all',
+        reason: filters.userId ? `Viewed audit history for user ${filters.userId}` : 'Viewed organization-wide audit log',
+        userId: user.id,
+        realUserId
+      })
+    }
+
     return {
       success: true,
       data: result.data,

--- a/server/api/components/dismiss-link.post.ts
+++ b/server/api/components/dismiss-link.post.ts
@@ -1,4 +1,5 @@
 import { componentService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * @openapi
@@ -31,14 +32,27 @@ import { componentService } from '../../services/singletons'
  *         description: Superuser access required
  */
 export default defineEventHandler(async (event) => {
-  await requireSuperuser(event)
+  const user = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   const body = await readBody(event)
   if (!body?.componentName) {
     throw createError({ statusCode: 400, message: 'componentName is required' })
   }
 
-  await componentService.dismissLink(body.componentName)
-  setResponseStatus(event, 204)
-  return null
+  try {
+    await componentService.dismissLink(body.componentName)
+    setResponseStatus(event, 204)
+    return null
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DISMISS_LINK',
+      entityType: 'Component',
+      entityId: body.componentName,
+      reason: error instanceof Error ? error.message : 'Failed to dismiss component link',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
 })

--- a/server/api/me/tokens.post.ts
+++ b/server/api/me/tokens.post.ts
@@ -1,6 +1,7 @@
 import { getRealUser } from '../../utils/auth'
 import { tokenService } from '../../services/singletons'
 import { AuditLogRepository } from '../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../utils/audit'
 
 const MAX_ACTIVE_TOKENS = 10
 
@@ -52,33 +53,45 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'description is required' })
   }
 
-  const activeCount = await tokenService.countActiveTokens(user.id)
-  if (activeCount >= MAX_ACTIVE_TOKENS) {
-    throw createError({
-      statusCode: 400,
-      message: `Maximum of ${MAX_ACTIVE_TOKENS} active tokens allowed. Revoke an existing token before creating a new one.`
+  try {
+    const activeCount = await tokenService.countActiveTokens(user.id)
+    if (activeCount >= MAX_ACTIVE_TOKENS) {
+      throw createError({
+        statusCode: 400,
+        message: `Maximum of ${MAX_ACTIVE_TOKENS} active tokens allowed. Revoke an existing token before creating a new one.`
+      })
+    }
+
+    const result = await tokenService.createToken(user.id, {
+      description,
+      expiresInDays: body.expiresInDays || undefined
     })
-  }
 
-  const result = await tokenService.createToken(user.id, {
-    description,
-    expiresInDays: body.expiresInDays || undefined
-  })
+    const auditRepo = new AuditLogRepository()
+    await auditRepo.create({
+      operation: 'CREATE',
+      entityType: 'ApiToken',
+      entityId: result.id,
+      entityLabel: `Token for ${user.email}`,
+      changedFields: ['description', 'expiresAt'],
+      userId: user.id,
+      realUserId: null
+    })
 
-  const auditRepo = new AuditLogRepository()
-  await auditRepo.create({
-    operation: 'CREATE',
-    entityType: 'ApiToken',
-    entityId: result.id,
-    entityLabel: `Token for ${user.email}`,
-    changedFields: ['description', 'expiresAt'],
-    userId: user.id,
-    realUserId: null
-  })
-
-  setResponseStatus(event, 201)
-  return {
-    success: true,
-    data: result
+    setResponseStatus(event, 201)
+    return {
+      success: true,
+      data: result
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'CREATE',
+      entityType: 'ApiToken',
+      entityId: user.id,
+      reason: error instanceof Error ? error.message : 'Failed to create token',
+      userId: user.id,
+      realUserId: null
+    })
+    throw error
   }
 })

--- a/server/api/me/tokens/[tokenId].delete.ts
+++ b/server/api/me/tokens/[tokenId].delete.ts
@@ -1,6 +1,7 @@
 import { getRealUser } from '../../../utils/auth'
 import { tokenService } from '../../../services/singletons'
 import { AuditLogRepository } from '../../../repositories/audit-log.repository'
+import { auditFailedOperation } from '../../../utils/audit'
 
 /**
  * @openapi
@@ -40,22 +41,34 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'tokenId is required' })
   }
 
-  // revokeToken enforces ownership via the userId match in the Cypher query.
-  const revoked = await tokenService.revokeToken(tokenId, user.id)
+  try {
+    // revokeToken enforces ownership via the userId match in the Cypher query.
+    const revoked = await tokenService.revokeToken(tokenId, user.id)
 
-  if (!revoked) {
-    throw createError({ statusCode: 404, message: 'Token not found' })
+    if (!revoked) {
+      throw createError({ statusCode: 404, message: 'Token not found' })
+    }
+
+    const auditRepo = new AuditLogRepository()
+    await auditRepo.create({
+      operation: 'DELETE',
+      entityType: 'ApiToken',
+      entityId: tokenId,
+      entityLabel: `Token ${tokenId} for user ${user.id}`,
+      userId: user.id,
+      realUserId: null
+    })
+
+    return { success: true, message: 'Token revoked' }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE',
+      entityType: 'ApiToken',
+      entityId: tokenId,
+      reason: error instanceof Error ? error.message : 'Failed to revoke token',
+      userId: user.id,
+      realUserId: null
+    })
+    throw error
   }
-
-  const auditRepo = new AuditLogRepository()
-  await auditRepo.create({
-    operation: 'DELETE',
-    entityType: 'ApiToken',
-    entityId: tokenId,
-    entityLabel: `Token ${tokenId} for user ${user.id}`,
-    userId: user.id,
-    realUserId: null
-  })
-
-  return { success: true, message: 'Token revoked' }
 })

--- a/server/api/platforms.post.ts
+++ b/server/api/platforms.post.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse } from '~~/types/api'
 import { platformService } from '../services/singletons'
+import { auditFailedOperation } from '../utils/audit'
 
 /**
  * @openapi
@@ -77,6 +78,15 @@ export default defineEventHandler(async (event): Promise<ApiResponse<CreatePlatf
       count: 1
     }
   } catch (error: unknown) {
+    await auditFailedOperation(event, {
+      operation: 'CREATE',
+      entityType: 'Platform',
+      entityId: body.name,
+      reason: error instanceof Error ? error.message : 'Failed to create platform',
+      userId: user.id,
+      realUserId
+    })
+
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }

--- a/server/api/platforms/[name].delete.ts
+++ b/server/api/platforms/[name].delete.ts
@@ -1,4 +1,5 @@
 import { platformService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * @openapi
@@ -44,28 +45,40 @@ export default defineEventHandler(async (event) => {
 
   const name = decodeURIComponent(rawName)
 
-  const platform = await platformService.findStewardTeam(name)
-  if (!platform) {
-    throw createError({
-      statusCode: 404,
-      message: `Platform '${name}' not found`
-    })
-  }
-
-  // Superusers can delete any platform
-  if (user.role !== 'superuser') {
-    // Regular users must belong to the steward team
-    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
-    if (!platform.stewardTeam || !userTeamNames.includes(platform.stewardTeam)) {
+  try {
+    const platform = await platformService.findStewardTeam(name)
+    if (!platform) {
       throw createError({
-        statusCode: 403,
-        message: 'Access denied. You must be a superuser or a member of the platform\'s steward team to delete it.'
+        statusCode: 404,
+        message: `Platform '${name}' not found`
       })
     }
+
+    // Superusers can delete any platform
+    if (user.role !== 'superuser') {
+      // Regular users must belong to the steward team
+      const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+      if (!platform.stewardTeam || !userTeamNames.includes(platform.stewardTeam)) {
+        throw createError({
+          statusCode: 403,
+          message: 'Access denied. You must be a superuser or a member of the platform\'s steward team to delete it.'
+        })
+      }
+    }
+
+    await platformService.delete(name, user.id, realUserId)
+
+    setResponseStatus(event, 204)
+    return null
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE',
+      entityType: 'Platform',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to delete platform',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
-
-  await platformService.delete(name, user.id, realUserId)
-
-  setResponseStatus(event, 204)
-  return null
 })

--- a/server/api/platforms/[name].put.ts
+++ b/server/api/platforms/[name].put.ts
@@ -1,4 +1,5 @@
 import { platformService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * @openapi
@@ -65,36 +66,48 @@ export default defineEventHandler(async (event) => {
 
   const name = decodeURIComponent(rawName)
 
-  const platform = await platformService.findStewardTeam(name)
-  if (!platform) {
-    throw createError({
-      statusCode: 404,
-      message: `Platform '${name}' not found`
-    })
-  }
-
-  // Superusers can update any platform
-  if (user.role !== 'superuser') {
-    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
-    if (!platform.stewardTeam || !userTeamNames.includes(platform.stewardTeam)) {
+  try {
+    const platform = await platformService.findStewardTeam(name)
+    if (!platform) {
       throw createError({
-        statusCode: 403,
-        message: 'Access denied. You must be a superuser or a member of the platform\'s steward team to update it.'
+        statusCode: 404,
+        message: `Platform '${name}' not found`
       })
     }
+
+    // Superusers can update any platform
+    if (user.role !== 'superuser') {
+      const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+      if (!platform.stewardTeam || !userTeamNames.includes(platform.stewardTeam)) {
+        throw createError({
+          statusCode: 403,
+          message: 'Access denied. You must be a superuser or a member of the platform\'s steward team to update it.'
+        })
+      }
+    }
+
+    const body = await readBody(event)
+
+    const result = await platformService.update({
+      name,
+      type: body.type,
+      domain: body.domain,
+      vendor: body.vendor,
+      stewardTeam: body.stewardTeam,
+      userId: user.id,
+      realUserId
+    })
+
+    return { name: result }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'Platform',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to update platform',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
-
-  const body = await readBody(event)
-
-  const result = await platformService.update({
-    name,
-    type: body.type,
-    domain: body.domain,
-    vendor: body.vendor,
-    stewardTeam: body.stewardTeam,
-    userId: user.id,
-    realUserId
-  })
-
-  return { name: result }
 })

--- a/server/api/platforms/[name]/approvals.post.ts
+++ b/server/api/platforms/[name]/approvals.post.ts
@@ -1,4 +1,5 @@
 import { platformService } from '../../../services/singletons'
+import { auditFailedOperation } from '../../../utils/audit'
 
 /**
  * @openapi
@@ -68,29 +69,41 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'teamName and time are required' })
   }
 
-  // Verify user is a member of the team or a superuser
-  if (user.role !== 'superuser') {
-    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
-    if (!userTeamNames.includes(body.teamName)) {
-      throw createError({
-        statusCode: 403,
-        message: `You must be a member of '${body.teamName}' to set its TIME approval`
-      })
+  try {
+    // Verify user is a member of the team or a superuser
+    if (user.role !== 'superuser') {
+      const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+      if (!userTeamNames.includes(body.teamName)) {
+        throw createError({
+          statusCode: 403,
+          message: `You must be a member of '${body.teamName}' to set its TIME approval`
+        })
+      }
     }
-  }
 
-  const result = await platformService.setApproval({
-    platformName,
-    teamName: body.teamName,
-    time: body.time,
-    environment: body.environment ?? null,
-    notes: body.notes,
-    userId: user.id,
-    realUserId
-  })
+    const result = await platformService.setApproval({
+      platformName,
+      teamName: body.teamName,
+      time: body.time,
+      environment: body.environment ?? null,
+      notes: body.notes,
+      userId: user.id,
+      realUserId
+    })
 
-  return {
-    success: true,
-    data: result
+    return {
+      success: true,
+      data: result
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'APPROVE',
+      entityType: 'Platform',
+      entityId: platformName,
+      reason: error instanceof Error ? error.message : 'Failed to set platform approval',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
 })

--- a/server/api/sboms.post.ts
+++ b/server/api/sboms.post.ts
@@ -1,6 +1,7 @@
 import { getSbomValidator } from '../utils/sbom-validator'
 import { validateSbomRequest, type SbomRequest as ValidatorSbomRequest } from '../utils/sbom-request-validator'
 import { sbomService } from '../services/singletons'
+import { auditFailedOperation } from '../utils/audit'
 
 /**
  * @openapi
@@ -275,14 +276,23 @@ export default defineEventHandler(async (event): Promise<SbomResponse> => {
   } catch (error) {
     // Handle specific errors
     if (error && typeof error === 'object' && 'statusCode' in error) {
-      const httpError = error as { 
+      const httpError = error as {
         statusCode: number
         message: string
         hint?: string
       }
-      
+
       setResponseStatus(event, httpError.statusCode)
-      
+
+      await auditFailedOperation(event, {
+        operation: 'IMPORT_SBOM',
+        entityType: 'System',
+        entityId: validatedBody.repositoryUrl,
+        reason: httpError.message,
+        userId: user.id,
+        realUserId
+      })
+
       // Repository not registered (404)
       if (httpError.statusCode === 404) {
         return {
@@ -292,7 +302,7 @@ export default defineEventHandler(async (event): Promise<SbomResponse> => {
           hint: httpError.hint || 'Register the repository first using POST /api/systems/{systemName}/repositories'
         }
       }
-      
+
       // Repository not linked to system (409)
       if (httpError.statusCode === 409) {
         return {
@@ -301,7 +311,7 @@ export default defineEventHandler(async (event): Promise<SbomResponse> => {
           message: httpError.message
         }
       }
-      
+
       // Other errors
       return {
         success: false,
@@ -313,6 +323,14 @@ export default defineEventHandler(async (event): Promise<SbomResponse> => {
     // Internal error during processing
     event.context.logger.error({ err: error }, 'SBOM processing error')
     setResponseStatus(event, 500)
+    await auditFailedOperation(event, {
+      operation: 'IMPORT_SBOM',
+      entityType: 'System',
+      entityId: validatedBody.repositoryUrl,
+      reason: error instanceof Error ? error.message : 'Internal server error',
+      userId: user.id,
+      realUserId
+    })
     return {
       success: false,
       error: 'internal_error',

--- a/server/api/systems.post.ts
+++ b/server/api/systems.post.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse } from '~~/types/api'
 import { systemService } from '../services/singletons'
+import { auditFailedOperation } from '../utils/audit'
 
 /**
  * @openapi
@@ -129,11 +130,20 @@ export default defineEventHandler(async (event): Promise<ApiResponse<CreateSyste
       count: 1
     }
   } catch (error: unknown) {
+    await auditFailedOperation(event, {
+      operation: 'CREATE',
+      entityType: 'System',
+      entityId: body.name,
+      reason: error instanceof Error ? error.message : 'Failed to create system',
+      userId: user.id,
+      realUserId
+    })
+
     // Re-throw createError exceptions to preserve HTTP status codes
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }
-    
+
     // Handle unexpected errors
     throw createError({
       statusCode: 500,

--- a/server/api/systems/[name].delete.ts
+++ b/server/api/systems/[name].delete.ts
@@ -1,4 +1,5 @@
 import { systemService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * @openapi
@@ -44,12 +45,24 @@ export default defineEventHandler(async (event) => {
   }
   
   const name = decodeURIComponent(rawName)
-  
-  // Validate that user's team owns this system
-  await validateTeamOwnership(event, 'System', name)
-  
-  await systemService.delete(name, user.id, realUserId)
-  
-  setResponseStatus(event, 204)
-  return null
+
+  try {
+    // Validate that user's team owns this system
+    await validateTeamOwnership(event, 'System', name)
+
+    await systemService.delete(name, user.id, realUserId)
+
+    setResponseStatus(event, 204)
+    return null
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE',
+      entityType: 'System',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to delete system',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
 })

--- a/server/api/systems/[name].patch.ts
+++ b/server/api/systems/[name].patch.ts
@@ -58,6 +58,7 @@
 import { buildAuditChanges } from '../../utils/audit-diff'
 import { VALID_CRITICALITIES, VALID_ENVIRONMENTS } from '../../services/system.service'
 import { loadQuery, injectPlaceholder } from '../../utils/query-loader'
+import { auditFailedOperation } from '../../utils/audit'
 import type { BusinessCriticality, SystemEnvironment } from '~~/types/api'
 
 export default defineEventHandler(async (event) => {
@@ -78,100 +79,112 @@ export default defineEventHandler(async (event) => {
   await validateTeamOwnership(event, 'System', name)
   
   const body = await readBody(event)
-  
-  // Validate that at least one field is provided
-  if (!body.description && !body.businessCriticality && !body.environment && !body.domain) {
-    throw createError({
-      statusCode: 422,
-      message: 'At least one field to update is required'
-    })
-  }
-  
-  // Validate businessCriticality if provided
-  if (body.businessCriticality) {
-    if (!VALID_CRITICALITIES.includes(body.businessCriticality as BusinessCriticality)) {
+
+  try {
+    // Validate that at least one field is provided
+    if (!body.description && !body.businessCriticality && !body.environment && !body.domain) {
       throw createError({
         statusCode: 422,
-        message: 'Invalid business criticality value. Must be one of: critical, high, medium, low'
+        message: 'At least one field to update is required'
       })
     }
-  }
-  
-  // Validate environment if provided
-  if (body.environment) {
-    if (!VALID_ENVIRONMENTS.includes(body.environment as SystemEnvironment)) {
+
+    // Validate businessCriticality if provided
+    if (body.businessCriticality) {
+      if (!VALID_CRITICALITIES.includes(body.businessCriticality as BusinessCriticality)) {
+        throw createError({
+          statusCode: 422,
+          message: 'Invalid business criticality value. Must be one of: critical, high, medium, low'
+        })
+      }
+    }
+
+    // Validate environment if provided
+    if (body.environment) {
+      if (!VALID_ENVIRONMENTS.includes(body.environment as SystemEnvironment)) {
+        throw createError({
+          statusCode: 422,
+          message: 'Invalid environment value. Must be one of: dev, test, staging, prod'
+        })
+      }
+    }
+
+    const driver = useDriver()
+
+    // Fetch current state before writing so we can diff it
+    const getCurrentStateQuery = await loadQuery('systems/get-current-state.cypher')
+    const { records: currentRecords } = await driver.executeQuery(getCurrentStateQuery, { name })
+
+    if (currentRecords.length === 0) {
       throw createError({
-        statusCode: 422,
-        message: 'Invalid environment value. Must be one of: dev, test, staging, prod'
+        statusCode: 404,
+        message: `System '${name}' not found`
       })
     }
-  }
 
-  const driver = useDriver()
+    const currentProps = currentRecords[0]!.get('props') as Record<string, unknown>
 
-  // Fetch current state before writing so we can diff it
-  const getCurrentStateQuery = await loadQuery('systems/get-current-state.cypher')
-  const { records: currentRecords } = await driver.executeQuery(getCurrentStateQuery, { name })
+    // Build dynamic SET clause based on provided fields
+    const updates: string[] = []
+    const params: Record<string, unknown> = { name }
 
-  if (currentRecords.length === 0) {
-    throw createError({
-      statusCode: 404,
-      message: `System '${name}' not found`
+    if (body.description !== undefined) {
+      updates.push('s.description = $description')
+      params.description = body.description
+    }
+    if (body.domain !== undefined) {
+      updates.push('s.domain = $domain')
+      params.domain = body.domain
+    }
+    if (body.businessCriticality !== undefined) {
+      updates.push('s.businessCriticality = $businessCriticality')
+      params.businessCriticality = body.businessCriticality
+    }
+    if (body.environment !== undefined) {
+      updates.push('s.environment = $environment')
+      params.environment = body.environment
+    }
+
+    const changedFields = updates.map(u => u.split(' = ')[0]!.replace('s.', ''))
+
+    // Build the incoming state from only the fields being updated
+    const incomingState: Record<string, unknown> = {}
+    for (const field of changedFields) {
+      incomingState[field] = params[field]
+    }
+    const changes = buildAuditChanges(currentProps, incomingState, changedFields)
+
+    params.userId = user.id
+    params.realUserId = realUserId
+    params.changes = JSON.stringify(changes)
+    params.changedFields = changedFields
+
+    const updateQuery = injectPlaceholder(
+      await loadQuery('systems/update-patch.cypher'),
+      'SET_CLAUSES', updates.join(', ')
+    )
+    const { records } = await driver.executeQuery(updateQuery, params)
+
+    if (records.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: `System '${name}' not found`
+      })
+    }
+
+    return {
+      success: true,
+      data: records[0]!.get('system')
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'System',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to update system',
+      userId: user.id,
+      realUserId
     })
-  }
-
-  const currentProps = currentRecords[0]!.get('props') as Record<string, unknown>
-  
-  // Build dynamic SET clause based on provided fields
-  const updates: string[] = []
-  const params: Record<string, unknown> = { name }
-
-  if (body.description !== undefined) {
-    updates.push('s.description = $description')
-    params.description = body.description
-  }
-  if (body.domain !== undefined) {
-    updates.push('s.domain = $domain')
-    params.domain = body.domain
-  }
-  if (body.businessCriticality !== undefined) {
-    updates.push('s.businessCriticality = $businessCriticality')
-    params.businessCriticality = body.businessCriticality
-  }
-  if (body.environment !== undefined) {
-    updates.push('s.environment = $environment')
-    params.environment = body.environment
-  }
-
-  const changedFields = updates.map(u => u.split(' = ')[0]!.replace('s.', ''))
-
-  // Build the incoming state from only the fields being updated
-  const incomingState: Record<string, unknown> = {}
-  for (const field of changedFields) {
-    incomingState[field] = params[field]
-  }
-  const changes = buildAuditChanges(currentProps, incomingState, changedFields)
-
-  params.userId = user.id
-  params.realUserId = realUserId
-  params.changes = JSON.stringify(changes)
-  params.changedFields = changedFields
-
-  const updateQuery = injectPlaceholder(
-    await loadQuery('systems/update-patch.cypher'),
-    'SET_CLAUSES', updates.join(', ')
-  )
-  const { records } = await driver.executeQuery(updateQuery, params)
-
-  if (records.length === 0) {
-    throw createError({
-      statusCode: 404,
-      message: `System '${name}' not found`
-    })
-  }
-
-  return {
-    success: true,
-    data: records[0]!.get('system')
+    throw error
   }
 })

--- a/server/api/systems/[name].put.ts
+++ b/server/api/systems/[name].put.ts
@@ -69,6 +69,7 @@
 import { buildAuditChanges } from '../../utils/audit-diff'
 import { VALID_CRITICALITIES, VALID_ENVIRONMENTS } from '../../services/system.service'
 import { loadQuery } from '../../utils/query-loader'
+import { auditFailedOperation } from '../../utils/audit'
 import type { BusinessCriticality, SystemEnvironment } from '~~/types/api'
 
 export default defineEventHandler(async (event) => {
@@ -87,91 +88,103 @@ export default defineEventHandler(async (event) => {
   const name = decodeURIComponent(rawName)
   
   await validateTeamOwnership(event, 'System', name)
-  
+
   const body = await readBody(event)
-  
-  // Validate ALL required fields for PUT (full replacement)
-  if (!body.domain || !body.ownerTeam || !body.businessCriticality || !body.environment) {
-    throw createError({
-      statusCode: 422,
-      message: 'All required fields must be provided for full update: domain, ownerTeam, businessCriticality, environment'
-    })
-  }
-  
-  // Validate businessCriticality
-  if (!VALID_CRITICALITIES.includes(body.businessCriticality as BusinessCriticality)) {
-    throw createError({
-      statusCode: 422,
-      message: 'Invalid business criticality value. Must be one of: critical, high, medium, low'
-    })
-  }
-  
-  // Validate environment
-  if (!VALID_ENVIRONMENTS.includes(body.environment as SystemEnvironment)) {
-    throw createError({
-      statusCode: 422,
-      message: 'Invalid environment value. Must be one of: dev, test, staging, prod'
-    })
-  }
 
-  const driver = useDriver()
-  
-  // Check if new owner team exists
-  const checkTeamQuery = await loadQuery('systems/check-team-exists.cypher')
-  const { records: teamRecords } = await driver.executeQuery(checkTeamQuery, { ownerTeam: body.ownerTeam })
-  
-  if (teamRecords.length === 0) {
-    throw createError({
-      statusCode: 422,
-      message: `Team '${body.ownerTeam}' not found`
-    })
-  }
-  
-  // Fetch current state before writing so we can diff it
-  const getCurrentStateQuery = await loadQuery('systems/get-current-state-full.cypher')
-  const { records: currentRecords } = await driver.executeQuery(getCurrentStateQuery, { name })
+  try {
+    // Validate ALL required fields for PUT (full replacement)
+    if (!body.domain || !body.ownerTeam || !body.businessCriticality || !body.environment) {
+      throw createError({
+        statusCode: 422,
+        message: 'All required fields must be provided for full update: domain, ownerTeam, businessCriticality, environment'
+      })
+    }
 
-  if (currentRecords.length === 0) {
-    throw createError({
-      statusCode: 404,
-      message: `System '${name}' not found`
-    })
-  }
+    // Validate businessCriticality
+    if (!VALID_CRITICALITIES.includes(body.businessCriticality as BusinessCriticality)) {
+      throw createError({
+        statusCode: 422,
+        message: 'Invalid business criticality value. Must be one of: critical, high, medium, low'
+      })
+    }
 
-  const currentProps = currentRecords[0]!.get('props') as Record<string, unknown>
-  const incomingProps: Record<string, unknown> = {
-    domain: body.domain,
-    ownerTeam: body.ownerTeam,
-    businessCriticality: body.businessCriticality,
-    environment: body.environment,
-    description: body.description || null,
-  }
-  const allFields = ['domain', 'ownerTeam', 'businessCriticality', 'environment', 'description']
-  const changes = JSON.stringify(buildAuditChanges(currentProps, incomingProps, allFields))
+    // Validate environment
+    if (!VALID_ENVIRONMENTS.includes(body.environment as SystemEnvironment)) {
+      throw createError({
+        statusCode: 422,
+        message: 'Invalid environment value. Must be one of: dev, test, staging, prod'
+      })
+    }
 
-  // Replace entire resource
-  const updateQuery = await loadQuery('systems/update-put.cypher')
-  const { records } = await driver.executeQuery(updateQuery, {
-    name,
-    domain: body.domain,
-    ownerTeam: body.ownerTeam,
-    businessCriticality: body.businessCriticality,
-    environment: body.environment,
-    description: body.description || null,
-    userId: user.id,
-    realUserId,
-    changes,
-  })
-  
-  if (records.length === 0) {
-    throw createError({
-      statusCode: 404,
-      message: `System '${name}' not found`
+    const driver = useDriver()
+
+    // Check if new owner team exists
+    const checkTeamQuery = await loadQuery('systems/check-team-exists.cypher')
+    const { records: teamRecords } = await driver.executeQuery(checkTeamQuery, { ownerTeam: body.ownerTeam })
+
+    if (teamRecords.length === 0) {
+      throw createError({
+        statusCode: 422,
+        message: `Team '${body.ownerTeam}' not found`
+      })
+    }
+
+    // Fetch current state before writing so we can diff it
+    const getCurrentStateQuery = await loadQuery('systems/get-current-state-full.cypher')
+    const { records: currentRecords } = await driver.executeQuery(getCurrentStateQuery, { name })
+
+    if (currentRecords.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: `System '${name}' not found`
+      })
+    }
+
+    const currentProps = currentRecords[0]!.get('props') as Record<string, unknown>
+    const incomingProps: Record<string, unknown> = {
+      domain: body.domain,
+      ownerTeam: body.ownerTeam,
+      businessCriticality: body.businessCriticality,
+      environment: body.environment,
+      description: body.description || null,
+    }
+    const allFields = ['domain', 'ownerTeam', 'businessCriticality', 'environment', 'description']
+    const changes = JSON.stringify(buildAuditChanges(currentProps, incomingProps, allFields))
+
+    // Replace entire resource
+    const updateQuery = await loadQuery('systems/update-put.cypher')
+    const { records } = await driver.executeQuery(updateQuery, {
+      name,
+      domain: body.domain,
+      ownerTeam: body.ownerTeam,
+      businessCriticality: body.businessCriticality,
+      environment: body.environment,
+      description: body.description || null,
+      userId: user.id,
+      realUserId,
+      changes,
     })
-  }
-  
-  return {
-    success: true,
-    data: records[0]!.get('system')
+
+    if (records.length === 0) {
+      throw createError({
+        statusCode: 404,
+        message: `System '${name}' not found`
+      })
+    }
+
+    return {
+      success: true,
+      data: records[0]!.get('system')
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'System',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to update system',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
 })

--- a/server/api/systems/[name]/health-refresh.post.ts
+++ b/server/api/systems/[name]/health-refresh.post.ts
@@ -1,7 +1,9 @@
 import { healthRefreshService } from '../../../services/singletons'
+import { auditFailedOperation } from '../../../utils/audit'
 
 export default defineEventHandler(async (event) => {
-  await requireAuthorization(event)
+  const user = await requireAuthorization(event)
+  const realUserId = await getImpersonatorId(event)
 
   const rawName = getRouterParam(event, 'name')
 
@@ -11,7 +13,19 @@ export default defineEventHandler(async (event) => {
 
   const name = decodeURIComponent(rawName)
 
-  const jobId = await healthRefreshService.enqueueForSystem(name)
+  try {
+    const jobId = await healthRefreshService.enqueueForSystem(name)
 
-  return { success: true, data: { jobId } }
+    return { success: true, data: { jobId } }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'HEALTH_REFRESH',
+      entityType: 'System',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to enqueue health refresh',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
 })

--- a/server/api/systems/[name]/repositories.post.ts
+++ b/server/api/systems/[name]/repositories.post.ts
@@ -1,4 +1,5 @@
 import { systemService } from '../../../services/singletons'
+import { auditFailedOperation } from '../../../utils/audit'
 
 /**
  * @openapi
@@ -100,30 +101,42 @@ export default defineEventHandler(async (event) => {
   await validateTeamOwnership(event, 'System', systemName)
   
   const body = await readBody<{ url: string; name?: string }>(event)
-  
-  // Validate URL
-  if (!body.url) {
-    throw createError({
-      statusCode: 400,
-      message: 'Repository URL is required'
-    })
-  }
-  
+
   try {
-    new URL(body.url)
-  } catch {
-    throw createError({
-      statusCode: 400,
-      message: 'Invalid repository URL'
+    // Validate URL
+    if (!body.url) {
+      throw createError({
+        statusCode: 400,
+        message: 'Repository URL is required'
+      })
+    }
+
+    try {
+      new URL(body.url)
+    } catch {
+      throw createError({
+        statusCode: 400,
+        message: 'Invalid repository URL'
+      })
+    }
+
+    const repository = await systemService.addRepository(systemName, body, user.id, realUserId)
+
+    setResponseStatus(event, 201)
+    return {
+      success: true,
+      data: repository,
+      message: `Repository registered for system ${systemName}`
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'ADD_REPOSITORY',
+      entityType: 'System',
+      entityId: systemName,
+      reason: error instanceof Error ? error.message : 'Failed to register repository',
+      userId: user.id,
+      realUserId
     })
-  }
-  
-  const repository = await systemService.addRepository(systemName, body, user.id, realUserId)
-  
-  setResponseStatus(event, 201)
-  return {
-    success: true,
-    data: repository,
-    message: `Repository registered for system ${systemName}`
+    throw error
   }
 })

--- a/server/api/teams.post.ts
+++ b/server/api/teams.post.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse } from '~~/types/api'
 import { teamService } from '../services/singletons'
+import { auditFailedOperation } from '../utils/audit'
 
 /**
  * @openapi
@@ -65,6 +66,15 @@ export default defineEventHandler(async (event): Promise<ApiResponse<CreateTeamR
       count: 1
     }
   } catch (error: unknown) {
+    await auditFailedOperation(event, {
+      operation: 'CREATE',
+      entityType: 'Team',
+      entityId: body?.name,
+      reason: error instanceof Error ? error.message : 'Failed to create team',
+      userId: user.id,
+      realUserId
+    })
+
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }

--- a/server/api/teams/[name].delete.ts
+++ b/server/api/teams/[name].delete.ts
@@ -1,4 +1,5 @@
 import { teamService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * @openapi
@@ -58,9 +59,21 @@ export default defineEventHandler(async (event) => {
   }
   
   const name = decodeURIComponent(rawName)
-  
-  await teamService.delete(name, user.id, realUserId)
-  
-  setResponseStatus(event, 204)
-  return null
+
+  try {
+    await teamService.delete(name, user.id, realUserId)
+
+    setResponseStatus(event, 204)
+    return null
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE',
+      entityType: 'Team',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to delete team',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
 })

--- a/server/api/teams/[name].put.ts
+++ b/server/api/teams/[name].put.ts
@@ -1,4 +1,5 @@
 import { teamService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * @openapi
@@ -59,17 +60,29 @@ export default defineEventHandler(async (event) => {
   const name = decodeURIComponent(rawName)
   const body = await readBody(event)
 
-  const updatedName = await teamService.update({
-    name,
-    newName: body?.name,
-    email: body?.email,
-    responsibilityArea: body?.responsibilityArea,
-    userId: user.id,
-    realUserId
-  })
+  try {
+    const updatedName = await teamService.update({
+      name,
+      newName: body?.name,
+      email: body?.email,
+      responsibilityArea: body?.responsibilityArea,
+      userId: user.id,
+      realUserId
+    })
 
-  return {
-    success: true,
-    data: { name: updatedName }
+    return {
+      success: true,
+      data: { name: updatedName }
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'Team',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to update team',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
 })

--- a/server/api/technologies.post.ts
+++ b/server/api/technologies.post.ts
@@ -1,5 +1,6 @@
 import type { ApiResponse } from '~~/types/api'
 import { technologyService } from '../services/singletons'
+import { auditFailedOperation } from '../utils/audit'
 
 /**
  * @openapi
@@ -91,6 +92,15 @@ export default defineEventHandler(async (event): Promise<ApiResponse<CreateTechn
       count: 1
     }
   } catch (error: unknown) {
+    await auditFailedOperation(event, {
+      operation: 'CREATE',
+      entityType: 'Technology',
+      entityId: body.name,
+      reason: error instanceof Error ? error.message : 'Failed to create technology',
+      userId: user.id,
+      realUserId
+    })
+
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error
     }

--- a/server/api/technologies/[name].delete.ts
+++ b/server/api/technologies/[name].delete.ts
@@ -1,4 +1,5 @@
 import { technologyService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * @openapi
@@ -44,28 +45,40 @@ export default defineEventHandler(async (event) => {
 
   const name = decodeURIComponent(rawName)
 
-  const tech = await technologyService.findOwnerTeam(name)
-  if (!tech) {
-    throw createError({
-      statusCode: 404,
-      message: `Technology '${name}' not found`
-    })
-  }
-
-  // Superusers can delete any technology
-  if (user.role !== 'superuser') {
-    // Regular users must belong to the owner team
-    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
-    if (!tech.ownerTeam || !userTeamNames.includes(tech.ownerTeam)) {
+  try {
+    const tech = await technologyService.findOwnerTeam(name)
+    if (!tech) {
       throw createError({
-        statusCode: 403,
-        message: 'Access denied. You must be a superuser or a member of the technology\'s owner team to delete it.'
+        statusCode: 404,
+        message: `Technology '${name}' not found`
       })
     }
+
+    // Superusers can delete any technology
+    if (user.role !== 'superuser') {
+      // Regular users must belong to the owner team
+      const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+      if (!tech.ownerTeam || !userTeamNames.includes(tech.ownerTeam)) {
+        throw createError({
+          statusCode: 403,
+          message: 'Access denied. You must be a superuser or a member of the technology\'s owner team to delete it.'
+        })
+      }
+    }
+
+    await technologyService.delete(name, user.id, realUserId)
+
+    setResponseStatus(event, 204)
+    return null
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE',
+      entityType: 'Technology',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to delete technology',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
-
-  await technologyService.delete(name, user.id, realUserId)
-
-  setResponseStatus(event, 204)
-  return null
 })

--- a/server/api/technologies/[name].put.ts
+++ b/server/api/technologies/[name].put.ts
@@ -1,4 +1,5 @@
 import { technologyService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 /**
  * @openapi
@@ -68,37 +69,49 @@ export default defineEventHandler(async (event) => {
 
   const name = decodeURIComponent(rawName)
 
-  const tech = await technologyService.findOwnerTeam(name)
-  if (!tech) {
-    throw createError({
-      statusCode: 404,
-      message: `Technology '${name}' not found`
-    })
-  }
-
-  // Superusers can update any technology
-  if (user.role !== 'superuser') {
-    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
-    if (!tech.ownerTeam || !userTeamNames.includes(tech.ownerTeam)) {
+  try {
+    const tech = await technologyService.findOwnerTeam(name)
+    if (!tech) {
       throw createError({
-        statusCode: 403,
-        message: 'Access denied. You must be a superuser or a member of the technology\'s owner team to update it.'
+        statusCode: 404,
+        message: `Technology '${name}' not found`
       })
     }
+
+    // Superusers can update any technology
+    if (user.role !== 'superuser') {
+      const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+      if (!tech.ownerTeam || !userTeamNames.includes(tech.ownerTeam)) {
+        throw createError({
+          statusCode: 403,
+          message: 'Access denied. You must be a superuser or a member of the technology\'s owner team to update it.'
+        })
+      }
+    }
+
+    const body = await readBody(event)
+
+    const result = await technologyService.update({
+      name,
+      type: body.type,
+      domain: body.domain,
+      vendor: body.vendor,
+      ownerTeam: body.ownerTeam,
+      lastReviewed: body.lastReviewed,
+      userId: user.id,
+      realUserId
+    })
+
+    return { name: result }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'Technology',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to update technology',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
-
-  const body = await readBody(event)
-
-  const result = await technologyService.update({
-    name,
-    type: body.type,
-    domain: body.domain,
-    vendor: body.vendor,
-    ownerTeam: body.ownerTeam,
-    lastReviewed: body.lastReviewed,
-    userId: user.id,
-    realUserId
-  })
-
-  return { name: result }
 })

--- a/server/api/technologies/[name]/approvals.post.ts
+++ b/server/api/technologies/[name]/approvals.post.ts
@@ -1,4 +1,5 @@
 import { technologyService } from '../../../services/singletons'
+import { auditFailedOperation } from '../../../utils/audit'
 
 /**
  * @openapi
@@ -68,29 +69,41 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, message: 'teamName and time are required' })
   }
 
-  // Verify user is a member of the team or a superuser
-  if (user.role !== 'superuser') {
-    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
-    if (!userTeamNames.includes(body.teamName)) {
-      throw createError({
-        statusCode: 403,
-        message: `You must be a member of '${body.teamName}' to set its TIME approval`
-      })
+  try {
+    // Verify user is a member of the team or a superuser
+    if (user.role !== 'superuser') {
+      const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+      if (!userTeamNames.includes(body.teamName)) {
+        throw createError({
+          statusCode: 403,
+          message: `You must be a member of '${body.teamName}' to set its TIME approval`
+        })
+      }
     }
-  }
 
-  const result = await technologyService.setApproval({
-    technologyName,
-    teamName: body.teamName,
-    time: body.time,
-    environment: body.environment ?? null,
-    notes: body.notes,
-    userId: user.id,
-    realUserId
-  })
+    const result = await technologyService.setApproval({
+      technologyName,
+      teamName: body.teamName,
+      time: body.time,
+      environment: body.environment ?? null,
+      notes: body.notes,
+      userId: user.id,
+      realUserId
+    })
 
-  return {
-    success: true,
-    data: result
+    return {
+      success: true,
+      data: result
+    }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'APPROVE',
+      entityType: 'Technology',
+      entityId: technologyName,
+      reason: error instanceof Error ? error.message : 'Failed to set technology approval',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
 })

--- a/server/api/technologies/[name]/components.post.ts
+++ b/server/api/technologies/[name]/components.post.ts
@@ -1,4 +1,5 @@
 import { technologyService } from '../../../services/singletons'
+import { auditFailedOperation } from '../../../utils/audit'
 
 /**
  * @openapi
@@ -57,48 +58,65 @@ export default defineEventHandler(async (event) => {
 
   const body = await readBody(event)
 
-  // Handle PURL-based linking (single component) or component name (all versions)
-  if (body?.purl) {
-    const user = await requireSuperuser(event)
-    const realUserId = await getImpersonatorId(event)
+  let userId = 'anonymous'
+  let realUserId: string | null = null
 
-    // Check if purl looks like a PURL (starts with pkg:) or is a component name
-    if (body.purl.startsWith('pkg:')) {
-      // Full PURL - link specific component
-      const result = await technologyService.linkComponentByPurl({
-        technologyName,
-        purl: body.purl,
-        userId: user.id,
-        realUserId
-      })
-      return { success: true, data: result }
-    } else {
-      // Component name - link all versions of this component
-      const result = await technologyService.linkComponentByName({
-        technologyName,
-        componentName: body.purl,
-        userId: user.id,
-        realUserId
-      })
-      return { success: true, data: result }
+  try {
+    // Handle PURL-based linking (single component) or component name (all versions)
+    if (body?.purl) {
+      const user = await requireSuperuser(event)
+      realUserId = await getImpersonatorId(event)
+      userId = user.id
+
+      // Check if purl looks like a PURL (starts with pkg:) or is a component name
+      if (body.purl.startsWith('pkg:')) {
+        // Full PURL - link specific component
+        const result = await technologyService.linkComponentByPurl({
+          technologyName,
+          purl: body.purl,
+          userId: user.id,
+          realUserId
+        })
+        return { success: true, data: result }
+      } else {
+        // Component name - link all versions of this component
+        const result = await technologyService.linkComponentByName({
+          technologyName,
+          componentName: body.purl,
+          userId: user.id,
+          realUserId
+        })
+        return { success: true, data: result }
+      }
     }
+
+    const user = await requireAuth(event)
+    realUserId = await getImpersonatorId(event)
+    userId = user.id
+
+    if (!body?.componentName || !body?.componentVersion) {
+      throw createError({ statusCode: 400, message: 'componentName and componentVersion are required (or provide purl)' })
+    }
+
+    const result = await technologyService.linkComponent({
+      technologyName,
+      componentName: body.componentName,
+      componentVersion: body.componentVersion,
+      userId: user.id,
+      realUserId
+    })
+
+    return { success: true, data: result }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'LINK',
+      entityType: 'Technology',
+      entityId: technologyName,
+      reason: error instanceof Error ? error.message : 'Failed to link component',
+      userId,
+      realUserId
+    })
+    throw error
   }
-
-  const user = await requireAuth(event)
-  const realUserId = await getImpersonatorId(event)
-
-  if (!body?.componentName || !body?.componentVersion) {
-    throw createError({ statusCode: 400, message: 'componentName and componentVersion are required (or provide purl)' })
-  }
-
-  const result = await technologyService.linkComponent({
-    technologyName,
-    componentName: body.componentName,
-    componentVersion: body.componentVersion,
-    userId: user.id,
-    realUserId
-  })
-
-  return { success: true, data: result }
 })
 

--- a/server/api/users/[id].get.ts
+++ b/server/api/users/[id].get.ts
@@ -1,6 +1,7 @@
 import { UserRepository } from '../../repositories/user.repository'
 import { tokenService } from '../../services/singletons'
 import { AuditLogRepository } from '../../repositories/audit-log.repository'
+import { auditSensitiveRead } from '../../utils/audit'
 
 /**
  * @openapi
@@ -23,7 +24,8 @@ import { AuditLogRepository } from '../../repositories/audit-log.repository'
  *         description: User not found
  */
 export default defineEventHandler(async (event) => {
-  await requireSuperuser(event)
+  const currentUser = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   const id = getRouterParam(event, 'id')
   if (!id) {
@@ -46,6 +48,15 @@ export default defineEventHandler(async (event) => {
   // Get recent audit activity by this user
   const auditRepo = new AuditLogRepository()
   const auditLogs = await auditRepo.findAll({ userId: id, limit: 10, offset: 0 })
+
+  await auditSensitiveRead(event, {
+    entityType: 'User',
+    entityId: id,
+    entityLabel: user.name || user.email,
+    reason: 'Viewed user detail including tokens and audit activity',
+    userId: currentUser.id,
+    realUserId
+  })
 
   return {
     success: true,

--- a/server/api/users/index.get.ts
+++ b/server/api/users/index.get.ts
@@ -1,5 +1,6 @@
 import { userService } from '../../services/singletons'
 import { parseSearchParam } from '../../utils/query-params'
+import { auditSensitiveRead } from '../../utils/audit'
 
 /**
  * @openapi
@@ -71,7 +72,8 @@ import { parseSearchParam } from '../../utils/query-params'
  *         description: Failed to fetch users
  */
 export default defineEventHandler(async (event) => {
-  await requireSuperuser(event)
+  const currentUser = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
 
   try {
     const query = getQuery(event)
@@ -84,7 +86,15 @@ export default defineEventHandler(async (event) => {
     }, parseSearchParam(query.search))
     const total = allUsers.length
     const paginatedUsers = allUsers.slice(offset, offset + limit)
-    
+
+    await auditSensitiveRead(event, {
+      entityType: 'User',
+      entityId: 'all',
+      reason: 'Listed users',
+      userId: currentUser.id,
+      realUserId
+    })
+
     return {
       success: true,
       data: paginatedUsers,

--- a/server/api/version-constraints.post.ts
+++ b/server/api/version-constraints.post.ts
@@ -1,4 +1,5 @@
 import { versionConstraintService } from '../services/singletons'
+import { auditFailedOperation } from '../utils/audit'
 
 interface CreateRequest {
   name: string
@@ -76,6 +77,14 @@ export default defineEventHandler(async (event) => {
     if (error && typeof error === 'object' && 'statusCode' in error) {
       const httpError = error as { statusCode: number; message: string }
       setResponseStatus(event, httpError.statusCode)
+      await auditFailedOperation(event, {
+        operation: 'CREATE',
+        entityType: 'VersionConstraint',
+        entityId: body.name,
+        reason: httpError.message,
+        userId: user.id,
+        realUserId
+      })
       return {
         success: false,
         error: httpError.statusCode === 409 ? 'conflict' : 'validation_error',
@@ -85,6 +94,14 @@ export default defineEventHandler(async (event) => {
 
     event.context.logger.error({ err: error }, 'Version constraint creation error')
     setResponseStatus(event, 500)
+    await auditFailedOperation(event, {
+      operation: 'CREATE',
+      entityType: 'VersionConstraint',
+      entityId: body.name,
+      reason: error instanceof Error ? error.message : 'Internal server error',
+      userId: user.id,
+      realUserId
+    })
     return { success: false, error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' }
   }
 })

--- a/server/api/version-constraints/[name].delete.ts
+++ b/server/api/version-constraints/[name].delete.ts
@@ -1,5 +1,6 @@
 import { versionConstraintService } from '../../services/singletons'
 import { VersionConstraintRepository } from '../../repositories/version-constraint.repository'
+import { auditFailedOperation } from '../../utils/audit'
 
 export default defineEventHandler(async (event) => {
   const user = await requireAuth(event)
@@ -12,16 +13,28 @@ export default defineEventHandler(async (event) => {
 
   const name = decodeURIComponent(rawName)
 
-  if (user.role !== 'superuser') {
-    const repo = new VersionConstraintRepository()
-    const creator = await repo.getCreator(name)
-    if (creator !== user.id) {
-      throw createError({ statusCode: 403, message: 'Only superusers or the creator can delete this version constraint' })
+  try {
+    if (user.role !== 'superuser') {
+      const repo = new VersionConstraintRepository()
+      const creator = await repo.getCreator(name)
+      if (creator !== user.id) {
+        throw createError({ statusCode: 403, message: 'Only superusers or the creator can delete this version constraint' })
+      }
     }
+
+    await versionConstraintService.delete(name, user.id, realUserId)
+
+    setResponseStatus(event, 204)
+    return null
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE',
+      entityType: 'VersionConstraint',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to delete version constraint',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
-
-  await versionConstraintService.delete(name, user.id, realUserId)
-
-  setResponseStatus(event, 204)
-  return null
 })

--- a/server/api/version-constraints/[name].patch.ts
+++ b/server/api/version-constraints/[name].patch.ts
@@ -1,5 +1,6 @@
 import { versionConstraintService } from '../../services/singletons'
 import { VersionConstraintRepository } from '../../repositories/version-constraint.repository'
+import { auditFailedOperation } from '../../utils/audit'
 
 export default defineEventHandler(async (event) => {
   const user = await requireAuth(event)
@@ -13,12 +14,24 @@ export default defineEventHandler(async (event) => {
 
   const name = decodeURIComponent(rawName)
 
-  if (user.role !== 'superuser') {
-    const repo = new VersionConstraintRepository()
-    const creator = await repo.getCreator(name)
-    if (creator !== user.id) {
-      throw createError({ statusCode: 403, message: 'Only superusers or the creator can update this version constraint' })
+  try {
+    if (user.role !== 'superuser') {
+      const repo = new VersionConstraintRepository()
+      const creator = await repo.getCreator(name)
+      if (creator !== user.id) {
+        throw createError({ statusCode: 403, message: 'Only superusers or the creator can update this version constraint' })
+      }
     }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'VersionConstraint',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to update version constraint',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
 
   let body: { status?: 'active' | 'draft' | 'archived'; reason?: string }
@@ -48,9 +61,25 @@ export default defineEventHandler(async (event) => {
     if (error && typeof error === 'object' && 'statusCode' in error) {
       const httpError = error as { statusCode: number; message: string }
       setResponseStatus(event, httpError.statusCode)
+      await auditFailedOperation(event, {
+        operation: 'UPDATE',
+        entityType: 'VersionConstraint',
+        entityId: name,
+        reason: httpError.message,
+        userId: user.id,
+        realUserId
+      })
       return { success: false, error: httpError.statusCode === 404 ? 'not_found' : 'validation_error', message: httpError.message }
     }
     setResponseStatus(event, 500)
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'VersionConstraint',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Internal server error',
+      userId: user.id,
+      realUserId
+    })
     return { success: false, error: 'internal_error', message: error instanceof Error ? error.message : 'Internal server error' }
   }
 })

--- a/server/api/version-constraints/[name].put.ts
+++ b/server/api/version-constraints/[name].put.ts
@@ -1,4 +1,5 @@
 import { versionConstraintService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
 
 interface UpdateRequest {
   description?: string
@@ -20,49 +21,61 @@ export default defineEventHandler(async (event) => {
   }
   const name = decodeURIComponent(rawName)
 
-  const existing = await versionConstraintService.findByName(name)
-  if (!existing) {
-    throw createError({ statusCode: 404, message: `Version constraint '${name}' not found` })
-  }
-
-  let body: UpdateRequest
   try {
-    body = await readBody(event)
-  } catch {
-    throw createError({ statusCode: 400, message: 'Invalid JSON in request body' })
-  }
+    const existing = await versionConstraintService.findByName(name)
+    if (!existing) {
+      throw createError({ statusCode: 404, message: `Version constraint '${name}' not found` })
+    }
 
-  // Authorization: superuser can edit anything; team member can edit team-scoped constraints
-  if (user.role !== 'superuser') {
-    if (existing.scope !== 'team' || !existing.subjectTeam) {
-      throw createError({ statusCode: 403, message: 'Only superusers can edit organization-scoped version constraints' })
+    let body: UpdateRequest
+    try {
+      body = await readBody(event)
+    } catch {
+      throw createError({ statusCode: 400, message: 'Invalid JSON in request body' })
     }
-    const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
-    if (!userTeamNames.includes(existing.subjectTeam)) {
-      throw createError({ statusCode: 403, message: `You must be a member of team "${existing.subjectTeam}" to edit this version constraint` })
-    }
-    if (body.subjectTeam && body.subjectTeam !== existing.subjectTeam) {
-      if (!userTeamNames.includes(body.subjectTeam)) {
-        throw createError({ statusCode: 403, message: 'You must be a member of the target team to reassign this constraint' })
+
+    // Authorization: superuser can edit anything; team member can edit team-scoped constraints
+    if (user.role !== 'superuser') {
+      if (existing.scope !== 'team' || !existing.subjectTeam) {
+        throw createError({ statusCode: 403, message: 'Only superusers can edit organization-scoped version constraints' })
+      }
+      const userTeamNames = user.teams?.map((t: { name: string }) => t.name) || []
+      if (!userTeamNames.includes(existing.subjectTeam)) {
+        throw createError({ statusCode: 403, message: `You must be a member of team "${existing.subjectTeam}" to edit this version constraint` })
+      }
+      if (body.subjectTeam && body.subjectTeam !== existing.subjectTeam) {
+        if (!userTeamNames.includes(body.subjectTeam)) {
+          throw createError({ statusCode: 403, message: 'You must be a member of the target team to reassign this constraint' })
+        }
       }
     }
+
+    if (user.role !== 'superuser' && body.scope === 'organization') {
+      throw createError({ statusCode: 403, message: 'Only superusers can set organization scope' })
+    }
+
+    const constraint = await versionConstraintService.update(name, {
+      description: body.description,
+      severity: body.severity,
+      scope: body.scope,
+      subjectTeam: body.subjectTeam,
+      versionRange: body.versionRange,
+      governsTechnology: body.governsTechnology,
+      status: body.status,
+      userId: user.id,
+      realUserId
+    })
+
+    return { success: true, message: 'Version constraint updated successfully', constraint }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'UPDATE',
+      entityType: 'VersionConstraint',
+      entityId: name,
+      reason: error instanceof Error ? error.message : 'Failed to update version constraint',
+      userId: user.id,
+      realUserId
+    })
+    throw error
   }
-
-  if (user.role !== 'superuser' && body.scope === 'organization') {
-    throw createError({ statusCode: 403, message: 'Only superusers can set organization scope' })
-  }
-
-  const constraint = await versionConstraintService.update(name, {
-    description: body.description,
-    severity: body.severity,
-    scope: body.scope,
-    subjectTeam: body.subjectTeam,
-    versionRange: body.versionRange,
-    governsTechnology: body.governsTechnology,
-    status: body.status,
-    userId: user.id,
-    realUserId
-  })
-
-  return { success: true, message: 'Version constraint updated successfully', constraint }
 })

--- a/server/utils/audit.ts
+++ b/server/utils/audit.ts
@@ -1,0 +1,76 @@
+import type { H3Event } from 'h3'
+import { AuditLogRepository } from '../repositories/audit-log.repository'
+import { logger as baseLogger } from './logger'
+
+const auditLogRepo = new AuditLogRepository()
+
+export interface AuditFailureParams {
+  /** Base operation being attempted, e.g. 'CREATE', 'UPDATE', 'DELETE' — stored as '<operation>_FAILED' */
+  operation: string
+  entityType: string
+  entityId: string
+  entityLabel?: string
+  reason: string
+  /** Acting user id, or 'anonymous' if the attempt failed before authentication resolved */
+  userId: string
+  realUserId?: string | null
+}
+
+/**
+ * Records a failed CRUD attempt so compliance/security teams can see who tried
+ * to do what and failed (unauthorized access attempts, malformed requests, etc).
+ *
+ * Never throws: a broken audit write must not mask the original error being
+ * returned to the caller, so failures here are logged and swallowed.
+ *
+ * Takes the acting user id directly rather than re-deriving it from `event`
+ * — every call site already has it from the auth guard it ran first, and
+ * re-deriving would mean importing server/utils/auth (which pulls in the
+ * Nuxt-only '#auth' module) into every handler test that exercises a failure path.
+ */
+export async function auditFailedOperation(event: H3Event, params: AuditFailureParams): Promise<void> {
+  try {
+    await auditLogRepo.create({
+      operation: `${params.operation}_FAILED`,
+      entityType: params.entityType,
+      entityId: params.entityId,
+      entityLabel: params.entityLabel || params.entityId,
+      reason: params.reason,
+      source: 'API',
+      userId: params.userId,
+      realUserId: params.realUserId ?? null
+    })
+  } catch (auditError) {
+    ;(event.context.logger ?? baseLogger).error({ err: auditError }, 'Failed to write audit log for failed operation')
+  }
+}
+
+export interface AuditSensitiveReadParams {
+  entityType: string
+  entityId: string
+  entityLabel?: string
+  reason: string
+  userId: string
+  realUserId?: string | null
+}
+
+/**
+ * Records a read of sensitive data (PII, tokens, approval reasoning, audit
+ * history) by an authenticated user.
+ */
+export async function auditSensitiveRead(event: H3Event, params: AuditSensitiveReadParams): Promise<void> {
+  try {
+    await auditLogRepo.create({
+      operation: 'READ_SENSITIVE',
+      entityType: params.entityType,
+      entityId: params.entityId,
+      entityLabel: params.entityLabel || params.entityId,
+      reason: params.reason,
+      source: 'API',
+      userId: params.userId,
+      realUserId: params.realUserId ?? null
+    })
+  } catch (auditError) {
+    ;(event.context.logger ?? baseLogger).error({ err: auditError }, 'Failed to write audit log for sensitive read')
+  }
+}

--- a/test/server/api/audit-on-failure.spec.ts
+++ b/test/server/api/audit-on-failure.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import createTechnologyHandler from '../../../server/api/technologies.post'
+import listAdminUsersHandler from '../../../server/api/admin/users/index.get'
+import { technologyService, userService } from '../../../server/services/singletons'
+
+const { mockAuditCreate, mockRequireSuperuser, mockGetCurrentUser, mockGetImpersonatorId } = vi.hoisted(() => ({
+  mockAuditCreate: vi.fn(),
+  mockRequireSuperuser: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
+  mockGetImpersonatorId: vi.fn().mockResolvedValue(null)
+}))
+
+vi.mock('../../../server/repositories/audit-log.repository', () => ({
+  AuditLogRepository: vi.fn().mockImplementation(function (this: { create: typeof mockAuditCreate }) {
+    this.create = mockAuditCreate
+  })
+}))
+
+vi.mock('../../../server/services/singletons', () => ({
+  technologyService: { createFromComponent: vi.fn() },
+  userService: { findAll: vi.fn() }
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('requireSuperuser', mockRequireSuperuser)
+  vi.stubGlobal('getCurrentUser', mockGetCurrentUser)
+  vi.stubGlobal('getImpersonatorId', mockGetImpersonatorId)
+})
+
+const mockSuperuser = { id: 'admin-1', email: 'admin@example.com', role: 'superuser' as const, teams: [] }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetImpersonatorId.mockResolvedValue(null)
+  mockGetCurrentUser.mockResolvedValue(mockSuperuser)
+  mockRequireSuperuser.mockResolvedValue(mockSuperuser)
+})
+
+describe('POST /api/technologies — failed CRUD attempts are audited', () => {
+  it('writes a CREATE_FAILED audit entry when the service rejects, then still surfaces the error', async () => {
+    vi.mocked(technologyService.createFromComponent).mockRejectedValue(new Error('No unlinked component named "react" was found'))
+
+    await expect(
+      createTechnologyHandler(mockEvent({
+        method: 'POST',
+        body: { name: 'react', type: 'library', componentName: 'react' }
+      }))
+    ).rejects.toThrow()
+
+    expect(mockAuditCreate).toHaveBeenCalledWith(expect.objectContaining({
+      operation: 'CREATE_FAILED',
+      entityType: 'Technology',
+      entityId: 'react',
+      reason: 'No unlinked component named "react" was found',
+      userId: 'admin-1'
+    }))
+  })
+
+  it('does not write a failure audit entry when creation succeeds', async () => {
+    vi.mocked(technologyService.createFromComponent).mockResolvedValue('react')
+
+    await createTechnologyHandler(mockEvent({
+      method: 'POST',
+      body: { name: 'react', type: 'library', componentName: 'react' }
+    }))
+
+    expect(mockAuditCreate).not.toHaveBeenCalled()
+  })
+})
+
+describe('GET /admin/users — sensitive reads are audited', () => {
+  it('writes a READ_SENSITIVE audit entry when the user list is retrieved', async () => {
+    vi.mocked(userService.findAll).mockResolvedValue({ data: [], count: 0 })
+
+    await listAdminUsersHandler(mockEvent())
+
+    expect(mockAuditCreate).toHaveBeenCalledWith(expect.objectContaining({
+      operation: 'READ_SENSITIVE',
+      entityType: 'User',
+      entityId: 'all',
+      userId: 'admin-1'
+    }))
+  })
+})

--- a/test/server/utils/audit.spec.ts
+++ b/test/server/utils/audit.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import { auditFailedOperation, auditSensitiveRead } from '../../../server/utils/audit'
+
+const mockCreate = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../server/repositories/audit-log.repository', () => ({
+  AuditLogRepository: vi.fn().mockImplementation(function (this: { create: typeof mockCreate }) {
+    this.create = mockCreate
+  })
+}))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('auditFailedOperation', () => {
+  it('records a failed operation with the operation suffixed _FAILED', async () => {
+    await auditFailedOperation(mockEvent(), {
+      operation: 'DELETE',
+      entityType: 'System',
+      entityId: 'payments',
+      reason: 'System not found',
+      userId: 'user-1'
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      operation: 'DELETE_FAILED',
+      entityType: 'System',
+      entityId: 'payments',
+      entityLabel: 'payments',
+      reason: 'System not found',
+      source: 'API',
+      userId: 'user-1',
+      realUserId: null
+    }))
+  })
+
+  it('attributes to "anonymous" when the caller passes that as the actor', async () => {
+    await auditFailedOperation(mockEvent(), {
+      operation: 'CREATE',
+      entityType: 'Technology',
+      entityId: 'react',
+      reason: 'Superuser access required',
+      userId: 'anonymous'
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      operation: 'CREATE_FAILED',
+      userId: 'anonymous',
+      realUserId: null
+    }))
+  })
+
+  it('carries the real (impersonator) user id when impersonating', async () => {
+    await auditFailedOperation(mockEvent(), {
+      operation: 'UPDATE',
+      entityType: 'Team',
+      entityId: 'frontend-team',
+      reason: 'Conflict',
+      userId: 'user-1',
+      realUserId: 'super-1'
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ realUserId: 'super-1' }))
+  })
+
+  it('never throws when the audit write itself fails', async () => {
+    mockCreate.mockRejectedValue(new Error('Neo4j unavailable'))
+
+    await expect(auditFailedOperation(mockEvent(), {
+      operation: 'DELETE',
+      entityType: 'System',
+      entityId: 'payments',
+      reason: 'boom',
+      userId: 'user-1'
+    })).resolves.toBeUndefined()
+  })
+})
+
+describe('auditSensitiveRead', () => {
+  it('records a READ_SENSITIVE entry for the given actor', async () => {
+    await auditSensitiveRead(mockEvent(), {
+      entityType: 'User',
+      entityId: 'all',
+      reason: 'Listed all users',
+      userId: 'user-1'
+    })
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({
+      operation: 'READ_SENSITIVE',
+      entityType: 'User',
+      entityId: 'all',
+      reason: 'Listed all users',
+      userId: 'user-1'
+    }))
+  })
+
+  it('never throws when the audit write itself fails', async () => {
+    mockCreate.mockRejectedValue(new Error('Neo4j unavailable'))
+
+    await expect(auditSensitiveRead(mockEvent(), {
+      entityType: 'User',
+      entityId: 'all',
+      reason: 'boom',
+      userId: 'user-1'
+    })).resolves.toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Phase 1 of #756, scoped down after investigation. Two of the issue's three claimed gaps checked out; one didn't:

- **Failed CRUD attempts were never audited** — real gap, fixed here.
- **Sensitive-data reads were never audited** — real gap, fixed here.
- **Role changes were "completely invisible"** — false. `CHANGE_ROLE` auditing already exists in `server/database/queries/users/update-role.cypher`. No work needed; left as-is.

Most success-path CRUD auditing (create/update/delete) also already existed at the Cypher/repository layer for the major entities (technologies, systems, teams, platforms, version constraints) — that part of the issue's description was also stale. This PR only adds what was actually missing: audit entries on **failure**, and audit entries on **sensitive reads**.

## Changes

- New `server/utils/audit.ts` with two helpers:
  - `auditFailedOperation` — writes a `<OPERATION>_FAILED` entry (e.g. `CREATE_FAILED`, `DELETE_FAILED`) on catch, then rethrows so the original error still reaches the client. Never throws itself — a broken audit write can't mask the real error.
  - `auditSensitiveRead` — writes a `READ_SENSITIVE` entry for authenticated reads of PII/tokens/audit history.
- Wrapped ~38 mutating endpoints (technologies, systems, teams, platforms, version constraints, users, tokens, SBOM/GitHub imports, impersonation, license whitelisting, component-link dismissal) in try/catch to call `auditFailedOperation` on failure.
- Added `auditSensitiveRead` to 5 endpoints that are both auth-gated and expose real sensitive data: `GET /admin/users`, `GET /users`, `GET /users/{id}`, `GET /admin/users/{userId}/tokens`, and `GET /audit-logs` (only when viewing someone else's or the org-wide trail, not your own history).
- Endpoints that expose similarly sensitive data (team emails, approval notes) but have **no auth guard at all** were intentionally left alone — there's no actor to attribute an anonymous read to, and adding auth to previously-public endpoints is a bigger, separate change.

### Design note

The helpers take the acting user id as an explicit parameter rather than re-deriving it internally via `getCurrentUser`/`getImpersonatorId`. Every call site already has that identity from the auth guard it ran first, and re-deriving it would mean importing `server/utils/auth` (which pulls in the Nuxt-only `#auth` module) into every handler test that exercises a failure path — that broke 8 existing test files on the first pass, fixed by this design.

## Test plan

- [x] `server/utils/audit.spec.ts` — unit tests for both helpers (failure attribution, anonymous fallback, impersonation, audit-write-itself-fails doesn't throw)
- [x] `test/server/api/audit-on-failure.spec.ts` — end-to-end: a real handler failure produces a `CREATE_FAILED` entry and still surfaces the original error; a sensitive read produces a `READ_SENSITIVE` entry
- [x] Full suite: `npx vitest run` → 1001/1001 passing
- [x] `npm run lint` clean
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)