### PR TITLE
Add granular per-component SBOM audit entries and improve logging

### DIFF
--- a/server/database/queries/sboms/create-component-added-audit-logs.cypher
+++ b/server/database/queries/sboms/create-component-added-audit-logs.cypher
@@ -1,0 +1,25 @@
+// One AuditLog entry per newly-added component, so "who introduced component
+// X into system Y" can be answered directly. Deliberately does NOT audit
+// components that were merely re-seen/updated on a re-scan — that would
+// create one AuditLog node per component on every periodic import for an
+// already-tracked system, with no compliance benefit since nothing changed.
+MATCH (s:System {name: $systemName})
+UNWIND $components AS comp
+OPTIONAL MATCH (c:Component {purl: comp.purl})
+CREATE (a:AuditLog {
+  id: randomUUID(),
+  timestamp: datetime(),
+  operation: 'ADD_COMPONENT',
+  entityType: 'Component',
+  entityId: coalesce(comp.purl, comp.name + '@' + coalesce(comp.version, 'unknown')),
+  entityLabel: comp.name + '@' + coalesce(comp.version, 'unknown'),
+  newStatus: $systemName,
+  changedFields: ['system'],
+  source: 'API',
+  userId: $userId,
+  realUserId: $realUserId
+})
+CREATE (a)-[:AUDITS]->(s)
+FOREACH (_ IN CASE WHEN c IS NOT NULL THEN [1] ELSE [] END |
+  CREATE (a)-[:AUDITS]->(c)
+)

--- a/server/database/queries/sboms/persist-components-core.cypher
+++ b/server/database/queries/sboms/persist-components-core.cypher
@@ -47,9 +47,14 @@ MERGE (s)-[r:USES]->(c)
 ON CREATE SET r.addedAt = $timestamp, r.scope = comp.scope, r.isDirect = comp.isDirect, r._new = true
 ON MATCH SET r.lastSeenAt = $timestamp, r.scope = comp.scope, r.isDirect = comp.isDirect
 
-WITH isNew, r, (r._new IS NOT NULL) AS relIsNew
+WITH c, isNew, r, (r._new IS NOT NULL) AS relIsNew
 REMOVE r._new
 
-RETURN sum(CASE WHEN isNew THEN 1 ELSE 0 END) AS componentsAdded,
-       sum(CASE WHEN isNew THEN 0 ELSE 1 END) AS componentsUpdated,
-       sum(CASE WHEN relIsNew THEN 1 ELSE 0 END) AS relationshipsCreated
+// One row per input component (not aggregated) so the caller can tell which
+// specific components were newly added — needed for granular per-component
+// audit entries ("who introduced component X into system Y").
+RETURN c.name AS componentName,
+       c.version AS componentVersion,
+       c.purl AS componentPurl,
+       isNew,
+       relIsNew

--- a/server/database/queries/technologies/link-components-by-name.cypher
+++ b/server/database/queries/technologies/link-components-by-name.cypher
@@ -13,6 +13,19 @@ WITH t, c, $componentName AS componentName, count(c) AS linkedCount
 MATCH (s:System)-[uses:USES]->(c)
 WITH t, componentName, linkedCount, collect(DISTINCT s.name) AS affectedSystems
 
+CREATE (al:AuditLog {
+  id: randomUUID(),
+  timestamp: datetime(),
+  operation: 'LINK',
+  entityType: 'TechnologyComponent',
+  entityId: t.name,
+  entityLabel: componentName + ' -> ' + t.name,
+  source: 'API',
+  userId: $userId,
+  realUserId: $realUserId
+})
+CREATE (al)-[:AUDITS]->(t)
+
 RETURN
   t.name AS technologyName,
   componentName AS name,

--- a/server/repositories/sbom.repository.ts
+++ b/server/repositories/sbom.repository.ts
@@ -1,5 +1,5 @@
 import { BaseRepository } from './base.repository'
-import type { PersistSBOMParams, PersistSBOMResult, ComponentDependency } from '../types/sbom'
+import type { PersistSBOMParams, PersistSBOMResult, AddedComponent, ComponentDependency } from '../types/sbom'
 
 /**
  * Repository for SBOM-related data access
@@ -68,6 +68,7 @@ export class SBOMRepository extends BaseRepository {
     let componentsAdded = 0
     let componentsUpdated = 0
     let relationshipsCreated = 0
+    const addedComponents: AddedComponent[] = []
 
     // Phase 1: MERGE components and USES edges — batch of 50
     for (let i = 0; i < coreComponents.length; i += SBOMRepository.BATCH_SIZE) {
@@ -77,10 +78,18 @@ export class SBOMRepository extends BaseRepository {
         components: batch,
         timestamp,
       })
-      if (records.length > 0) {
-        componentsAdded += records[0]!.get('componentsAdded').toNumber()
-        componentsUpdated += records[0]!.get('componentsUpdated').toNumber()
-        relationshipsCreated += records[0]!.get('relationshipsCreated').toNumber()
+      for (const record of records) {
+        const isNew = record.get('isNew') as boolean
+        componentsAdded += isNew ? 1 : 0
+        componentsUpdated += isNew ? 0 : 1
+        relationshipsCreated += (record.get('relIsNew') as boolean) ? 1 : 0
+        if (isNew) {
+          addedComponents.push({
+            name: record.get('componentName'),
+            version: record.get('componentVersion'),
+            purl: record.get('componentPurl')
+          })
+        }
       }
     }
 
@@ -100,7 +109,7 @@ export class SBOMRepository extends BaseRepository {
 
 
 
-    return { componentsAdded, componentsUpdated, relationshipsCreated }
+    return { componentsAdded, componentsUpdated, relationshipsCreated, addedComponents }
   }
 
 
@@ -154,5 +163,30 @@ export class SBOMRepository extends BaseRepository {
       realUserId: params.realUserId ?? null,
       metadata: JSON.stringify({ format: params.format, added: params.componentsAdded, updated: params.componentsUpdated })
     })
+  }
+
+  /**
+   * Create one granular AuditLog entry per newly-added component, so
+   * "who introduced component X into system Y" can be answered directly.
+   * Only called with newly-added components — see create-component-added-audit-logs.cypher.
+   */
+  async createComponentAddedAuditLogs(params: {
+    systemName: string
+    userId: string
+    realUserId?: string | null
+    components: AddedComponent[]
+  }): Promise<void> {
+    if (params.components.length === 0) return
+
+    const query = await loadQuery('sboms/create-component-added-audit-logs.cypher')
+    for (let i = 0; i < params.components.length; i += SBOMRepository.BATCH_SIZE) {
+      const batch = params.components.slice(i, i + SBOMRepository.BATCH_SIZE)
+      await this.executeQuery(query, {
+        systemName: params.systemName,
+        userId: params.userId,
+        realUserId: params.realUserId ?? null,
+        components: batch
+      })
+    }
   }
 }

--- a/server/services/github-import.service.ts
+++ b/server/services/github-import.service.ts
@@ -62,6 +62,7 @@ export class GitHubImportService {
    * 4. Run cdxgen on the clone and submit the SBOM
    */
   async import(input: GitHubImportInput): Promise<GitHubImportResult> {
+    const startedAt = Date.now()
     if (!input.githubToken) {
       throw new Error('GitHub authentication required — please sign in via GitHub to import repositories')
     }
@@ -97,6 +98,13 @@ export class GitHubImportService {
         rmSync(tempDir, { recursive: true, force: true })
       }
     }
+
+    logger.info({
+      repositoryUrl: repoUrl,
+      componentsAdded: sbomResult.componentsAdded,
+      componentsUpdated: sbomResult.componentsUpdated,
+      durationMs: Date.now() - startedAt
+    }, 'GitHub import workflow completed')
 
     return {
       systemName: input.systemName?.trim() || metadata.name,
@@ -158,6 +166,7 @@ export class GitHubImportService {
    */
   private async generateSBOM(repoDir: string, projectName: string): Promise<object | null> {
     logger.info({ projectName, repoDir }, 'Running cdxgen for GitHub import')
+    const startedAt = Date.now()
 
     try {
       const bom = await createBom(repoDir, {
@@ -166,11 +175,14 @@ export class GitHubImportService {
         projectVersion: '1.0.0',
         multiProject: true,
       })
+      const durationMs = Date.now() - startedAt
 
       if (!bom) {
-        logger.warn({ projectName }, 'cdxgen returned no BOM')
+        logger.warn({ projectName, durationMs }, 'cdxgen returned no BOM')
         return null
       }
+
+      logger.info({ projectName, durationMs }, 'cdxgen completed')
 
       if (typeof bom === 'string') {
         return JSON.parse(bom)
@@ -180,7 +192,7 @@ export class GitHubImportService {
 
       return bom as object
     } catch (err) {
-      logger.error({ err, projectName }, 'cdxgen threw during GitHub import')
+      logger.error({ err, projectName, durationMs: Date.now() - startedAt }, 'cdxgen threw during GitHub import')
       throw err
     }
   }

--- a/server/services/github-org-import.service.ts
+++ b/server/services/github-org-import.service.ts
@@ -96,6 +96,7 @@ export class GitHubOrgImportService {
   }
 
   async process(jobId: string, input: GitHubOrgImportInput): Promise<void> {
+    const startedAt = Date.now()
     await this.jobRepo.markRunning(jobId)
 
     try {
@@ -125,6 +126,12 @@ export class GitHubOrgImportService {
 
       await this.jobRepo.markCompleted(jobId)
       await this.createAuditLog(jobId, input)
+      logger.info({
+        jobId,
+        organization: input.organization,
+        repositoryCount: items.length,
+        durationMs: Date.now() - startedAt
+      }, 'GitHub org import job completed')
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'GitHub owner import failed'
       await this.jobRepo.markFailed(jobId, message)
@@ -146,6 +153,7 @@ export class GitHubOrgImportService {
     input: GitHubOrgImportInput
   ): Promise<void> {
     await this.jobRepo.markItemRunning(jobId, item.repositoryFullName)
+    const startedAt = Date.now()
 
     try {
       const result = await this.gitHubImportService.import({
@@ -167,6 +175,14 @@ export class GitHubOrgImportService {
         componentsUpdated: result.componentsUpdated,
         relationshipsCreated: result.relationshipsCreated
       })
+      logger.info({
+        jobId,
+        repository: item.repositoryFullName,
+        systemName: result.systemName,
+        componentsAdded: result.componentsAdded,
+        componentsUpdated: result.componentsUpdated,
+        durationMs: Date.now() - startedAt
+      }, 'GitHub repository imported')
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : 'Import failed'
       await this.jobRepo.markItemFinished(jobId, item.repositoryFullName, 'failed', { message })

--- a/server/services/health-refresh.service.ts
+++ b/server/services/health-refresh.service.ts
@@ -16,6 +16,7 @@ import {
   type HealthRefreshJobItem
 } from '../repositories/health-refresh.repository'
 import { calculateMaintenanceHealth } from '../utils/component-health'
+import { logger } from '../utils/logger'
 import { EOLService } from './eol.service'
 import { PackageMetadataService } from './package-metadata.service'
 import { SecurityScoreService } from './security-score.service'
@@ -95,7 +96,10 @@ export class HealthRefreshService {
   }
 
   async processJob(jobId: string, options: { batchSize?: number } = {}): Promise<void> {
+    const startedAt = Date.now()
     const batchSize = options.batchSize ?? 25
+    let processedCount = 0
+    let failedCount = 0
 
     while (true) {
       const items = await this.healthRepo.getPendingItems(jobId, batchSize)
@@ -105,14 +109,22 @@ export class HealthRefreshService {
         try {
           await this.processItem(jobId, item)
         } catch (error) {
+          failedCount++
           await this.healthRepo.markItemFinished(jobId, item.id, 'failed', {
             errorSummary: error instanceof Error ? error.message : String(error)
           })
         }
+        processedCount++
       }
     }
 
     await this.healthRepo.markJobCompletedIfDone(jobId)
+    logger.info({
+      jobId,
+      processedCount,
+      failedCount,
+      durationMs: Date.now() - startedAt
+    }, 'Health refresh job processed')
   }
 
   private async processItem(jobId: string, item: HealthRefreshJobItem): Promise<void> {

--- a/server/services/sbom.service.ts
+++ b/server/services/sbom.service.ts
@@ -100,6 +100,8 @@ export class SBOMService {
    * @throws Error if repository not found or processing fails
    */
   async processSBOM(input: ProcessSBOMInput): Promise<ProcessSBOMResult> {
+    const startedAt = Date.now()
+
     // 1. Normalize repository URL
     const normalizedUrl = normalizeRepoUrl(input.repositoryUrl)
     
@@ -129,6 +131,7 @@ export class SBOMService {
     }
     
     // 4. Extract components and dependency relationships from SBOM
+    const extractionStartedAt = Date.now()
     const sbomData = input.sbom as Record<string, unknown>
     const { bomRef: rootBomRef, name: rootName } = this.extractRootBomRef(sbomData, input.format)
     const components = this.extractComponents(sbomData, input.format, rootBomRef, rootName)
@@ -152,9 +155,11 @@ export class SBOMService {
       dependencies,
       input.format === 'spdx' ? scopedEdges! : null,
     )
+    const extractionDurationMs = Date.now() - extractionStartedAt
 
     // 5. Persist to database
-    const result = await this.sbomRepo.persistSBOM({
+    const persistStartedAt = Date.now()
+    const { addedComponents, ...result } = await this.sbomRepo.persistSBOM({
       systemName: system.name,
       repositoryUrl: normalizedUrl,
       components,
@@ -163,15 +168,19 @@ export class SBOMService {
       format: input.format,
       timestamp: new Date()
     })
-    
+    const persistDurationMs = Date.now() - persistStartedAt
+
     // 6. Upsert (Team)-[:USES]->(Technology) edges so compliance violation
     //    queries have current data after every SBOM submission.
     await this.sbomRepo.upsertTeamUsesTechnology(system.name)
 
     // 7. Update repository last scan timestamp
     await this.sourceRepoRepo.updateLastScan(normalizedUrl)
-    
-    // 8. Audit log for SBOM import
+
+    // 8. Audit log for SBOM import: one summary entry, plus one entry per
+    // newly-added component so "who introduced component X" can be answered
+    // directly. Updated (already-tracked) components are intentionally not
+    // audited individually — see create-component-added-audit-logs.cypher.
     await this.sbomRepo.createAuditLog({
       systemName: system.name,
       userId: input.userId,
@@ -179,6 +188,12 @@ export class SBOMService {
       format: input.format,
       componentsAdded: result.componentsAdded,
       componentsUpdated: result.componentsUpdated
+    })
+    await this.sbomRepo.createComponentAddedAuditLogs({
+      systemName: system.name,
+      userId: input.userId,
+      realUserId: input.realUserId ?? null,
+      components: addedComponents
     })
 
     // Queue health refresh after import persistence is complete. External
@@ -188,7 +203,19 @@ export class SBOMService {
     } catch (error) {
       logger.error({ err: error, systemName: system.name }, 'Failed to enqueue post-import health refresh')
     }
-    
+
+    logger.info({
+      systemName: system.name,
+      repositoryUrl: normalizedUrl,
+      format: input.format,
+      componentsAdded: result.componentsAdded,
+      componentsUpdated: result.componentsUpdated,
+      relationshipsCreated: result.relationshipsCreated,
+      extractionDurationMs,
+      persistDurationMs,
+      totalDurationMs: Date.now() - startedAt
+    }, 'SBOM processed successfully')
+
     return {
       systemName: system.name,
       repositoryUrl: normalizedUrl,

--- a/server/services/team.service.ts
+++ b/server/services/team.service.ts
@@ -3,6 +3,7 @@ import type { Team, TeamApprovalsResult, TeamConstraintsResult, TeamUsageResult,
 import type { SortParams } from '../utils/sorting'
 import { buildAuditChanges, buildDeleteChanges } from '../utils/audit-diff'
 import { toDateString } from '../utils/neo4j'
+import { logger } from '../utils/logger'
 
 /**
  * Service for team-related business logic
@@ -57,13 +58,15 @@ export class TeamService {
       })
     }
 
-    return await this.teamRepo.create({
+    const name = await this.teamRepo.create({
       name: input.name,
       email: input.email?.trim() || null,
       responsibilityArea: input.responsibilityArea?.trim() || null,
       userId: input.userId,
       realUserId: input.realUserId ?? null
     })
+    logger.info({ name, userId: input.userId }, 'Team created')
+    return name
   }
 
   /**
@@ -169,7 +172,7 @@ export class TeamService {
     }
     const changes = buildAuditChanges(before, after, changedFields)
 
-    return await this.teamRepo.update({
+    const result = await this.teamRepo.update({
       name: input.name,
       newName,
       email: input.email ?? null,
@@ -179,6 +182,8 @@ export class TeamService {
       userId: input.userId,
       realUserId: input.realUserId ?? null
     })
+    logger.info({ name: input.name, newName, changedFields, userId: input.userId }, 'Team updated')
+    return result
   }
 
   /**
@@ -220,6 +225,7 @@ export class TeamService {
     })
 
     await this.teamRepo.delete(name, userId, changes, realUserId)
+    logger.info({ name, userId }, 'Team deleted')
   }
 
   /**

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -3,6 +3,7 @@ import { SBOMRepository } from '../repositories/sbom.repository'
 import type { EOLStatus, EOLStatusValue, Technology, ComponentType, TechnologyDomain, TimeValue, TechnologyLifecycleSummary, TechnologyVersionLifecycle } from '~~/types/api'
 import type { SortParams } from '../utils/sorting'
 import { buildAuditChanges, buildDeleteChanges } from '../utils/audit-diff'
+import { logger } from '../utils/logger'
 import { EOLService } from './eol.service'
 
 const VALID_TYPES = [
@@ -195,7 +196,9 @@ export class TechnologyService {
       realUserId: input.realUserId ?? null
     }
 
-    return await this.techRepo.createFromComponent(params)
+    const name = await this.techRepo.createFromComponent(params)
+    logger.info({ name, type: input.type, componentName: params.componentName, userId: input.userId }, 'Technology created')
+    return name
   }
 
   /**
@@ -234,6 +237,7 @@ export class TechnologyService {
     })
 
     await this.techRepo.delete(name, userId, changes, realUserId)
+    logger.info({ name, userId }, 'Technology deleted')
   }
 
   /**
@@ -297,7 +301,9 @@ export class TechnologyService {
       realUserId: input.realUserId ?? null
     }
 
-    return await this.techRepo.update({ ...params, changes })
+    const name = await this.techRepo.update({ ...params, changes })
+    logger.info({ name, userId: input.userId }, 'Technology updated')
+    return name
   }
 
   /**
@@ -308,7 +314,9 @@ export class TechnologyService {
     if (!exists) {
       throw createError({ statusCode: 404, message: `Technology '${input.technologyName}' not found` })
     }
-    return await this.techRepo.linkComponent(input)
+    const result = await this.techRepo.linkComponent(input)
+    logger.info({ ...result, userId: input.userId }, 'Component linked to technology')
+    return result
   }
 
   /**
@@ -327,6 +335,13 @@ export class TechnologyService {
     for (const systemName of result.affectedSystems) {
       await this.sbomRepo.upsertTeamUsesTechnology(systemName)
     }
+    logger.info({
+      technologyName: result.technologyName,
+      name: result.name,
+      purl: result.purl,
+      affectedSystems: result.affectedSystems.length,
+      userId: input.userId
+    }, 'Component linked to technology by purl')
     return { technologyName: result.technologyName, name: result.name, purl: result.purl }
   }
 
@@ -346,6 +361,13 @@ export class TechnologyService {
     for (const systemName of result.affectedSystems) {
       await this.sbomRepo.upsertTeamUsesTechnology(systemName)
     }
+    logger.info({
+      technologyName: result.technologyName,
+      name: result.name,
+      count: result.count,
+      affectedSystems: result.affectedSystems.length,
+      userId: input.userId
+    }, 'Components linked to technology by name')
     return { technologyName: result.technologyName, name: result.name, count: result.count }
   }
 
@@ -400,7 +422,9 @@ export class TechnologyService {
       realUserId: input.realUserId ?? null
     }
 
-    return await this.techRepo.upsertApproval({ ...params, changes })
+    const result = await this.techRepo.upsertApproval({ ...params, changes })
+    logger.info({ technologyName: input.technologyName, teamName: input.teamName, time: input.time, userId: input.userId }, 'Technology approval set')
+    return result
   }
 
   /**

--- a/server/types/sbom.ts
+++ b/server/types/sbom.ts
@@ -118,4 +118,12 @@ export interface PersistSBOMResult {
   componentsAdded: number
   componentsUpdated: number
   relationshipsCreated: number
+  addedComponents: AddedComponent[]
+}
+
+/** Identity of a component newly created during SBOM persistence, used for granular per-component audit entries. */
+export interface AddedComponent {
+  name: string
+  version: string | null
+  purl: string | null
 }

--- a/test/server/repositories/sbom.repository.spec.ts
+++ b/test/server/repositories/sbom.repository.spec.ts
@@ -66,6 +66,93 @@ describe('SBOMRepository', () => {
 
       expect(check.records[0].get('count').toNumber()).toBeGreaterThanOrEqual(2)
     })
+
+    it('should report newly-added components in addedComponents, and none on a re-scan of the same components', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (:System { name: $sys })
+        CREATE (:Repository { url: $url, name: $repoName })
+      `, { sys: `${PREFIX}added-system`, url: `https://github.com/${PREFIX}org/added-repo`, repoName: `${PREFIX}added-repo` })
+
+      const component = {
+        name: `${PREFIX}newlib`, version: '1.0.0',
+        purl: `pkg:npm/${PREFIX}newlib@1.0.0`, packageManager: 'npm',
+        cpe: null, bomRef: null, type: 'library', group: null, scope: null,
+        hashes: [], licenses: [], copyright: null, supplier: null,
+        author: null, publisher: null, homepage: null, description: null,
+        externalReferences: []
+      }
+
+      const firstScan = await repo.persistSBOM({
+        systemName: `${PREFIX}added-system`,
+        repositoryUrl: `https://github.com/${PREFIX}org/added-repo`,
+        format: 'cyclonedx',
+        timestamp: new Date(),
+        dependencies: [],
+        componentUsage: new Map(),
+        components: [component]
+      })
+
+      expect(firstScan.addedComponents).toEqual([
+        { name: component.name, version: component.version, purl: component.purl }
+      ])
+
+      const secondScan = await repo.persistSBOM({
+        systemName: `${PREFIX}added-system`,
+        repositoryUrl: `https://github.com/${PREFIX}org/added-repo`,
+        format: 'cyclonedx',
+        timestamp: new Date(),
+        dependencies: [],
+        componentUsage: new Map(),
+        components: [component]
+      })
+
+      expect(secondScan.addedComponents).toEqual([])
+      expect(secondScan.componentsUpdated).toBeGreaterThanOrEqual(1)
+    })
+  })
+
+  describe('createComponentAddedAuditLogs()', () => {
+    it('should create one AuditLog per added component, linked to both the System and the Component', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (:System { name: $sys })
+        CREATE (:Component { name: $compName, version: '1.0.0', purl: $purl })
+      `, { sys: `${PREFIX}audit-added-system`, compName: `${PREFIX}audited-comp`, purl: `pkg:npm/${PREFIX}audited-comp@1.0.0` })
+
+      await repo.createComponentAddedAuditLogs({
+        systemName: `${PREFIX}audit-added-system`,
+        userId: `${PREFIX}user1`,
+        realUserId: null,
+        components: [
+          { name: `${PREFIX}audited-comp`, version: '1.0.0', purl: `pkg:npm/${PREFIX}audited-comp@1.0.0` }
+        ]
+      })
+
+      const check = await session.run(`
+        MATCH (a:AuditLog { operation: 'ADD_COMPONENT' })-[:AUDITS]->(x)
+        WHERE a.userId = $userId
+        RETURN labels(x) AS labels, a.entityId AS entityId
+      `, { userId: `${PREFIX}user1` })
+
+      expect(check.records).toHaveLength(2)
+      const labelSets = check.records.map(r => r.get('labels'))
+      expect(labelSets).toContainEqual(['System'])
+      expect(labelSets).toContainEqual(['Component'])
+      expect(check.records[0].get('entityId')).toBe(`pkg:npm/${PREFIX}audited-comp@1.0.0`)
+    })
+
+    it('should do nothing when components is empty', async () => {
+      if (!ctx.neo4jAvailable) return
+      await expect(
+        repo.createComponentAddedAuditLogs({
+          systemName: `${PREFIX}nonexistent-system`,
+          userId: `${PREFIX}user1`,
+          realUserId: null,
+          components: []
+        })
+      ).resolves.not.toThrow()
+    })
   })
 
   describe('isDirect on USES edges via persistSBOM()', () => {

--- a/test/server/repositories/technology.repository.spec.ts
+++ b/test/server/repositories/technology.repository.spec.ts
@@ -324,6 +324,29 @@ describe('TechnologyRepository', () => {
       expect(result.count).toBeGreaterThanOrEqual(1)
       expect(result.affectedSystems.length).toBeGreaterThanOrEqual(1)
     })
+
+    it('linkComponentsByName should create a LINK AuditLog entry', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Technology { name: $tech, type: 'library' })
+        CREATE (c:Component { name: $comp, version: '1.0.0' })
+        CREATE (s:System { name: $sys })-[:USES]->(c)
+      `, { tech: `${PREFIX}audit-link-tech`, comp: `${PREFIX}audit-link-comp`, sys: `${PREFIX}audit-link-sys` })
+
+      await repo.linkComponentsByName({
+        technologyName: `${PREFIX}audit-link-tech`,
+        componentName: `${PREFIX}audit-link-comp`,
+        userId: `${PREFIX}user1`,
+      })
+
+      const check = await session.run(`
+        MATCH (a:AuditLog { operation: 'LINK', entityType: 'TechnologyComponent' })-[:AUDITS]->(t:Technology { name: $tech })
+        WHERE a.userId = $userId
+        RETURN a
+      `, { tech: `${PREFIX}audit-link-tech`, userId: `${PREFIX}user1` })
+
+      expect(check.records).toHaveLength(1)
+    })
   })
 
   describe('upsertApproval()', () => {

--- a/test/server/services/sbom.service.spec.ts
+++ b/test/server/services/sbom.service.spec.ts
@@ -1215,5 +1215,55 @@ describe('SBOMService', () => {
 
       expect(callOrder).toEqual(['upsert', 'scan'])
     })
+
+    it('should audit newly-added components individually and pass counts to the summary audit log', async () => {
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1,
+        componentsUpdated: 0,
+        relationshipsCreated: 1,
+        addedComponents: [{ name: 'lodash', version: '4.17.21', purl: 'pkg:npm/lodash@4.17.21' }]
+      })
+      vi.mocked(SBOMRepository.prototype.createAuditLog).mockResolvedValue()
+      vi.mocked(SBOMRepository.prototype.createComponentAddedAuditLogs).mockResolvedValue()
+
+      await service.processSBOM({
+        sbom: validCycloneDxSbom,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx',
+        userId: 'user-1'
+      })
+
+      expect(SBOMRepository.prototype.createAuditLog).toHaveBeenCalledWith({
+        systemName: 'test-system',
+        userId: 'user-1',
+        realUserId: null,
+        format: 'cyclonedx',
+        componentsAdded: 1,
+        componentsUpdated: 0
+      })
+      expect(SBOMRepository.prototype.createComponentAddedAuditLogs).toHaveBeenCalledWith({
+        systemName: 'test-system',
+        userId: 'user-1',
+        realUserId: null,
+        components: [{ name: 'lodash', version: '4.17.21', purl: 'pkg:npm/lodash@4.17.21' }]
+      })
+    })
+
+    it('should not include addedComponents in the returned result', async () => {
+      vi.mocked(SBOMRepository.prototype.persistSBOM).mockResolvedValue({
+        componentsAdded: 1,
+        componentsUpdated: 0,
+        relationshipsCreated: 1,
+        addedComponents: [{ name: 'lodash', version: '4.17.21', purl: 'pkg:npm/lodash@4.17.21' }]
+      })
+
+      const result = await service.processSBOM({
+        sbom: validCycloneDxSbom,
+        repositoryUrl: 'https://github.com/org/repo',
+        format: 'cyclonedx'
+      })
+
+      expect(result).not.toHaveProperty('addedComponents')
+    })
   })
 })


### PR DESCRIPTION
## Description

Phase 2 of the audit/logging initiative. Adds granular per-component audit entries for SBOM imports, audits component-to-technology linking, and adds info-level logs plus timing instrumentation to key operational paths.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Fixes #757
Depends on #756 (merged)

## Changes Made

- New `create-component-added-audit-logs.cypher` query: one `AuditLog` entry per newly-added component (linked to both the `System` and `Component`), so "who introduced component X into system Y" is answerable directly. Re-seen/updated components on a re-scan are intentionally not audited individually — no compliance benefit, and would spam one node per component on every periodic import.
- `persist-components-core.cypher` now returns one row per input component (not aggregated) so the caller can identify exactly which components were new.
- `link-components-by-name.cypher` creates a new `LINK` operation `AuditLog` entry when components are linked to a technology.
- Added `logger.info()` calls on success paths: team create/update/delete, technology create/update/link/approve, and SBOM processing completion.
- Added timing instrumentation (`durationMs`) to GitHub import, GitHub org import, and health-refresh workflows.
- New/updated tests in `sbom.repository.spec.ts`, `technology.repository.spec.ts`, and `sbom.service.spec.ts` covering the new audit behavior.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [ ] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`

## Additional Notes

Full unit test suite (1007 tests, 77 files) and repository tests against live Neo4j pass. No database migrations needed; backward compatible per the issue's acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)