### PR TITLE
Implement technology impact graph and compliance gap visualization

### DIFF
--- a/app/components/TechnologyImpactGraph.vue
+++ b/app/components/TechnologyImpactGraph.vue
@@ -1,0 +1,403 @@
+<template>
+  <div class="space-y-4">
+    <!-- Empty state -->
+    <div v-if="!hasNodes" class="text-center py-12 text-(--ui-text-muted)">
+      <UIcon name="i-lucide-share-2" class="text-4xl mb-3" />
+      <p>No systems use this technology.</p>
+    </div>
+
+    <template v-else>
+      <!-- Legend -->
+      <div class="flex flex-wrap gap-3 text-sm">
+        <div v-for="ring in TIME_RINGS" :key="ring.key" class="flex items-center gap-1.5">
+          <span class="inline-block w-3 h-3 rounded-full flex-shrink-0" :style="{ background: ring.color }" />
+          <span class="text-(--ui-text-muted)">{{ ring.label }}</span>
+        </div>
+        <div class="flex items-center gap-1.5">
+          <span
+            class="inline-block w-3 h-3 rounded-full flex-shrink-0"
+            :style="{ background: GAP_COLOR, border: `1.5px dashed ${GAP_STROKE}` }"
+          />
+          <span class="text-(--ui-text-muted)">Compliance gap (no approval)</span>
+        </div>
+      </div>
+
+      <!-- SVG canvas -->
+      <div
+        ref="containerRef"
+        class="relative border border-(--ui-border) rounded-lg bg-(--ui-bg-elevated)"
+        style="height:520px;overflow:hidden;"
+        @dblclick="resetZoom"
+      >
+        <svg ref="svgRef" style="width:100%;height:100%;" />
+
+        <div
+          v-if="tooltip.visible"
+          class="absolute pointer-events-none z-10 px-2 py-1 rounded text-xs bg-(--ui-bg) border border-(--ui-border) shadow-sm text-(--ui-text) max-w-56"
+          :style="{ left: tooltip.x + 'px', top: tooltip.y + 'px' }"
+        >{{ tooltip.text }}</div>
+
+        <p class="absolute bottom-2 right-3 text-xs text-(--ui-text-muted) pointer-events-none select-none">
+          Scroll to zoom · Drag to pan · Double-click to reset
+        </p>
+      </div>
+
+      <!-- Detail panel -->
+      <UCard v-if="selectedNode">
+        <template #header>
+          <div class="flex justify-between items-start">
+            <div>
+              <h3 class="font-semibold text-base">{{ selectedNode.label }}</h3>
+              <p v-if="selectedNode.type === 'system' && selectedNode.versions?.length" class="text-sm text-(--ui-text-muted)">
+                v{{ selectedNode.versions.join(', v') }}
+              </p>
+              <p v-else-if="selectedNode.type === 'team'" class="text-sm text-(--ui-text-muted)">
+                {{ selectedNode.systemCount }} system{{ selectedNode.systemCount === 1 ? '' : 's' }}
+              </p>
+            </div>
+            <UButton icon="i-lucide-x" variant="ghost" size="xs" color="neutral" @click="selectedNode = null" />
+          </div>
+        </template>
+
+        <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+          <div v-if="selectedNode.type === 'system' && selectedNode.ownerTeamName">
+            <span class="text-(--ui-text-muted) block">Owning Team</span>
+            <NuxtLink
+              :to="`/teams/${encodeURIComponent(selectedNode.ownerTeamName)}`"
+              class="font-medium hover:underline text-(--ui-primary)"
+            >{{ selectedNode.ownerTeamName }}</NuxtLink>
+          </div>
+          <div v-if="selectedNode.type === 'system'">
+            <span class="text-(--ui-text-muted) block">System</span>
+            <NuxtLink
+              :to="`/systems/${encodeURIComponent(selectedNode.label)}`"
+              class="font-medium hover:underline text-(--ui-primary)"
+            >{{ selectedNode.label }}</NuxtLink>
+          </div>
+          <div v-if="selectedNode.type === 'system' && selectedNode.environment">
+            <span class="text-(--ui-text-muted) block">Environment</span>
+            <span class="font-medium">{{ selectedNode.environment }}</span>
+          </div>
+          <div v-if="!selectedNode.complianceGap">
+            <span class="text-(--ui-text-muted) block">TIME</span>
+            <UBadge :color="getTimeCategoryColor(selectedNode.time)" variant="subtle">{{ selectedNode.time ?? 'unclassified' }}</UBadge>
+          </div>
+        </div>
+
+        <UAlert
+          v-if="selectedNode.complianceGap"
+          class="mt-4"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-alert-triangle"
+          :title="selectedNode.type === 'system'
+            ? `No approval from ${selectedNode.ownerTeamName ?? 'an owning team'} for this technology`
+            : 'No system under this team has an approval for this technology'"
+        />
+      </UCard>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import {
+  select,
+  zoom,
+  zoomIdentity,
+  drag,
+  forceSimulation,
+  forceLink,
+  forceManyBody,
+  forceCenter,
+  forceCollide,
+} from 'd3'
+import type { Selection, Simulation, ZoomBehavior } from 'd3'
+import type { ImpactGraphNode, ImpactGraphEdge } from '../utils/technology-impact-graph'
+
+type SimNode = ImpactGraphNode & { x?: number; y?: number; fx?: number | null; fy?: number | null }
+
+// ── Props ──────────────────────────────────────────────────────────────────
+
+const props = defineProps<{
+  technologyName: string
+  nodes: ImpactGraphNode[]
+  edges: ImpactGraphEdge[]
+}>()
+
+// ── Template refs ──────────────────────────────────────────────────────────
+
+const svgRef = ref<SVGSVGElement | null>(null)
+const containerRef = ref<HTMLDivElement | null>(null)
+
+const hasNodes = computed(() => props.nodes.length > 0)
+
+// ── Colors ─────────────────────────────────────────────────────────────────
+
+const TIME_RINGS: Array<{ key: string; label: string; color: string }> = [
+  { key: 'invest', label: 'Invest', color: 'var(--ui-color-success-500, #22c55e)' },
+  { key: 'tolerate', label: 'Tolerate', color: 'var(--ui-color-warning-500, #f59e0b)' },
+  { key: 'migrate', label: 'Migrate', color: 'var(--ui-color-warning-600, #d97706)' },
+  { key: 'eliminate', label: 'Eliminate', color: 'var(--ui-color-error-500, #ef4444)' },
+]
+const TIME_COLORS: Record<string, string> = Object.fromEntries(TIME_RINGS.map(r => [r.key, r.color]))
+const GAP_COLOR = 'var(--ui-color-neutral-400, #9ca3af)'
+const GAP_STROKE = 'var(--ui-color-neutral-500, #6b7280)'
+
+function nodeColor(n: ImpactGraphNode): string {
+  if (n.complianceGap) return GAP_COLOR
+  return (n.time && TIME_COLORS[n.time]) || GAP_COLOR
+}
+
+// ── D3 state ───────────────────────────────────────────────────────────────
+
+const positionCache = new Map<string, { x: number; y: number }>()
+let simulation: Simulation<SimNode, undefined> | null = null
+let zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> | null = null
+let gRoot: Selection<SVGGElement, unknown, null, undefined> | null = null
+let gLink: Selection<SVGGElement, unknown, null, undefined> | null = null
+let gNode: Selection<SVGGElement, unknown, null, undefined> | null = null
+
+const tooltip = ref({ visible: false, x: 0, y: 0, text: '' })
+const selectedNode = ref<ImpactGraphNode | null>(null)
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function nodeRadius(n: ImpactGraphNode): number {
+  if (n.type === 'technology') return 22
+  if (n.type === 'team') return 16
+  return 8
+}
+
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s
+}
+
+function tooltipText(n: ImpactGraphNode): string {
+  const status = n.complianceGap ? 'Compliance gap — no approval' : (n.time ?? 'unclassified')
+  if (n.type === 'technology') return n.label
+  if (n.type === 'team') return `${n.label} — ${n.systemCount} system${n.systemCount === 1 ? '' : 's'} — ${status}`
+  const versions = n.versions?.length ? ` v${n.versions.join(', v')}` : ''
+  return `${n.label}${versions} — ${n.ownerTeamName ?? 'No owning team'} — ${status}`
+}
+
+// ── SVG init ───────────────────────────────────────────────────────────────
+
+function initSvg(): boolean {
+  const svgEl = svgRef.value
+  if (!svgEl) return false
+
+  const svg = select(svgEl)
+  svg.selectAll('*').remove()
+
+  gRoot = svg.append('g').attr('class', 'root')
+  gLink = gRoot.append('g').attr('class', 'links')
+  gNode = gRoot.append('g').attr('class', 'nodes')
+
+  zoomBehavior = zoom<SVGSVGElement, unknown>()
+    .scaleExtent([0.15, 4])
+    .on('zoom', event => gRoot!.attr('transform', event.transform))
+
+  svg.call(zoomBehavior)
+  return true
+}
+
+// ── Graph update ───────────────────────────────────────────────────────────
+
+function updateGraph() {
+  if (!gLink || !gNode) return
+  if (props.nodes.length === 0) return
+
+  const containerEl = containerRef.value
+  const width = containerEl?.clientWidth || 800
+  const height = containerEl?.clientHeight || 520
+
+  const simNodes: SimNode[] = props.nodes.map(n => {
+    const cached = positionCache.get(n.id)
+    return {
+      ...n,
+      x: cached?.x ?? width / 2 + (Math.random() - 0.5) * 80,
+      y: cached?.y ?? height / 2 + (Math.random() - 0.5) * 80,
+    }
+  })
+
+  const simNodeById = new Map(simNodes.map(n => [n.id, n]))
+  const simEdges = props.edges
+    .map(e => ({ ...e, source: simNodeById.get(e.source)!, target: simNodeById.get(e.target)! }))
+    .filter(e => e.source && e.target) as unknown as Array<{ source: SimNode; target: SimNode; complianceGap?: boolean }>
+
+  const dragBehavior = drag<SVGGElement, SimNode>()
+    .on('start', (event, d) => {
+      if (!event.active) simulation?.alphaTarget(0.3).restart()
+      d.fx = d.x; d.fy = d.y
+    })
+    .on('drag', (event, d) => { d.fx = event.x; d.fy = event.y })
+    .on('end', (event, d) => {
+      if (!event.active) simulation?.alphaTarget(0)
+      d.fx = null; d.fy = null
+    })
+
+  const linkSel = gLink!
+    .selectAll<SVGLineElement, { source: SimNode; target: SimNode; complianceGap?: boolean }>('line')
+    .data(simEdges, d => `${d.source.id}→${d.target.id}`)
+  linkSel.exit().remove()
+  const links = linkSel.enter().append('line')
+    .merge(linkSel)
+    .attr('stroke', d => d.complianceGap ? GAP_STROKE : 'var(--ui-border)')
+    .attr('stroke-width', 1.5)
+    .attr('stroke-opacity', 0.7)
+    .attr('stroke-dasharray', d => d.complianceGap ? '4,2' : null)
+
+  const nodeSel = gNode!
+    .selectAll<SVGGElement, SimNode>('g.node')
+    .data(simNodes, d => d.id)
+  nodeSel.exit().remove()
+
+  const nodeEnter = nodeSel.enter().append('g')
+    .attr('class', 'node')
+    .attr('cursor', 'pointer')
+    .call(dragBehavior)
+    .on('click', (_event, d) => {
+      if (d.type === 'technology') return
+      selectedNode.value = selectedNode.value?.id === d.id ? null : d
+    })
+    .on('mouseover', (event: MouseEvent, d: SimNode) => {
+      const cEl = containerRef.value
+      if (!cEl) return
+      const r = cEl.getBoundingClientRect()
+      tooltip.value = {
+        visible: true,
+        x: event.clientX - r.left + 12,
+        y: event.clientY - r.top - 8,
+        text: tooltipText(d),
+      }
+    })
+    .on('mousemove', (event: MouseEvent) => {
+      const cEl = containerRef.value
+      if (!cEl) return
+      const r = cEl.getBoundingClientRect()
+      tooltip.value.x = event.clientX - r.left + 12
+      tooltip.value.y = event.clientY - r.top - 8
+    })
+    .on('mouseout', () => { tooltip.value.visible = false })
+
+  const nodes = nodeEnter.merge(nodeSel)
+  nodes.selectAll('*').remove()
+  nodes.each(function(d) {
+    const g = select(this)
+    if (d.type === 'technology') {
+      g.append('polygon').attr('points', `0,${-22} ${22},0 0,${22} ${-22},0`)
+        .attr('fill', 'var(--ui-primary)').attr('stroke', 'var(--ui-bg)').attr('stroke-width', 2)
+    } else if (d.type === 'team') {
+      g.append('circle').attr('r', 16)
+        .attr('fill', nodeColor(d)).attr('fill-opacity', 0.85)
+        .attr('stroke', d.complianceGap ? GAP_STROKE : 'var(--ui-bg)')
+        .attr('stroke-width', 2)
+        .attr('stroke-dasharray', d.complianceGap ? '3,2' : null)
+    } else {
+      g.append('circle').attr('r', 8)
+        .attr('fill', nodeColor(d)).attr('fill-opacity', 0.9)
+        .attr('stroke', d.complianceGap ? GAP_STROKE : 'var(--ui-bg)')
+        .attr('stroke-width', 1.5)
+        .attr('stroke-dasharray', d.complianceGap ? '3,2' : null)
+    }
+    g.append('text')
+      .attr('dy', d.type === 'technology' ? 34 : d.type === 'team' ? 28 : 18)
+      .attr('text-anchor', 'middle').attr('font-size', 10)
+      .attr('fill', 'var(--ui-text)').attr('pointer-events', 'none').attr('user-select', 'none')
+      .text(truncate(d.label, 16))
+  })
+
+  if (!simulation) {
+    simulation = forceSimulation<SimNode>(simNodes)
+      .force('link', forceLink<SimNode, { source: SimNode; target: SimNode }>(simEdges)
+        .id(d => d.id)
+        .distance(d => {
+          const s = d.source as SimNode; const t = d.target as SimNode
+          if (s.type === 'technology' || t.type === 'technology') return 140
+          return 80
+        })
+      )
+      .force('charge', forceManyBody<SimNode>().strength(d => {
+        if (d.type === 'technology') return -700
+        if (d.type === 'team') return -350
+        return -100
+      }))
+      .force('center', forceCenter(width / 2, height / 2))
+      .force('collide', forceCollide<SimNode>().radius(d => nodeRadius(d) + 8))
+      .on('tick', () => {
+        simNodes.forEach(n => {
+          if (n.x !== undefined && n.y !== undefined) positionCache.set(n.id, { x: n.x, y: n.y })
+        })
+        links
+          .attr('x1', d => (d.source as SimNode).x ?? 0)
+          .attr('y1', d => (d.source as SimNode).y ?? 0)
+          .attr('x2', d => (d.target as SimNode).x ?? 0)
+          .attr('y2', d => (d.target as SimNode).y ?? 0)
+        nodes.attr('transform', d => `translate(${d.x ?? 0},${d.y ?? 0})`)
+      })
+  } else {
+    simulation.nodes(simNodes)
+    ;(simulation.force('link') as ReturnType<typeof forceLink<SimNode, { source: SimNode; target: SimNode }>>)
+      ?.links(simEdges)
+    simulation.force('center', forceCenter(width / 2, height / 2))
+    simulation
+      .on('tick', () => {
+        simNodes.forEach(n => {
+          if (n.x !== undefined && n.y !== undefined) positionCache.set(n.id, { x: n.x, y: n.y })
+        })
+        links
+          .attr('x1', d => (d.source as SimNode).x ?? 0)
+          .attr('y1', d => (d.source as SimNode).y ?? 0)
+          .attr('x2', d => (d.target as SimNode).x ?? 0)
+          .attr('y2', d => (d.target as SimNode).y ?? 0)
+        nodes.attr('transform', d => `translate(${d.x ?? 0},${d.y ?? 0})`)
+      })
+      .alpha(0.3)
+      .restart()
+  }
+}
+
+// ── Reset zoom ─────────────────────────────────────────────────────────────
+
+function resetZoom() {
+  const svgEl = svgRef.value
+  if (!svgEl || !zoomBehavior) return
+  select(svgEl).transition().duration(400).call(zoomBehavior.transform, zoomIdentity)
+}
+
+// ── Render ─────────────────────────────────────────────────────────────────
+
+function render() {
+  if (!hasNodes.value) return
+  if (!gLink || !gNode) {
+    if (!initSvg()) return
+  }
+  updateGraph()
+}
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+
+let resizeObserver: ResizeObserver | null = null
+
+onMounted(() => {
+  render()
+  if (containerRef.value) {
+    resizeObserver = new ResizeObserver(() => render())
+    resizeObserver.observe(containerRef.value)
+  }
+})
+
+watch(svgRef, (el) => { if (el) render() }, { flush: 'post' })
+
+watch(
+  [() => props.nodes, () => props.edges],
+  () => render(),
+  { flush: 'post' }
+)
+
+onBeforeUnmount(() => {
+  resizeObserver?.disconnect()
+  simulation?.stop()
+})
+</script>

--- a/app/pages/technologies/[name]/impact.vue
+++ b/app/pages/technologies/[name]/impact.vue
@@ -1,0 +1,154 @@
+<template>
+  <div class="space-y-6">
+    <USkeleton v-if="pending" class="h-96 w-full" />
+
+    <UAlert
+      v-else-if="error"
+      color="error"
+      variant="subtle"
+      icon="i-lucide-alert-circle"
+      title="Error Loading Impact Graph"
+      :description="error.message"
+    >
+      <template #actions>
+        <UButton label="Back to Technology" :to="`/technologies/${encodeURIComponent(name)}`" variant="outline" />
+      </template>
+    </UAlert>
+
+    <template v-else>
+      <UPageHeader
+        :title="`${name} — Impact`"
+        description="Systems using this technology, their owning teams, and TIME governance status."
+        :links="[{ label: 'Back to Technology', to: `/technologies/${encodeURIComponent(name)}`, icon: 'i-lucide-arrow-left', variant: 'outline' as const }]"
+      />
+
+      <UAlert
+        v-if="overCap"
+        color="warning"
+        variant="subtle"
+        icon="i-lucide-alert-triangle"
+        title="Too many systems to graph"
+        :description="`${systemRows.length} systems use ${name} — showing the table only. Graph view is limited to ${IMPACT_GRAPH_SYSTEM_LIMIT} systems to stay readable.`"
+      />
+
+      <UCard v-else-if="systemRows.length > 0">
+        <template #header>
+          <div class="flex items-center gap-2">
+            <UIcon name="i-lucide-share-2" class="w-5 h-5 text-(--ui-primary)" />
+            <h2 class="text-lg font-semibold">Impact Graph</h2>
+          </div>
+          <p class="text-sm text-(--ui-text-muted) mt-1">
+            Diamond = technology. Circles = owning teams, colored by TIME status. Smaller circles = systems using it;
+            dashed gray = no approval from the owning team.
+          </p>
+        </template>
+        <ClientOnly>
+          <AsyncTechnologyImpactGraph
+            :technology-name="name"
+            :nodes="impactGraph.nodes"
+            :edges="impactGraph.edges"
+          />
+        </ClientOnly>
+      </UCard>
+
+      <PaginatedTable
+        v-model:sorting="tableSorting"
+        :data="systemRows"
+        :columns="columns"
+      >
+        <template #header>
+          <h2 class="text-lg font-semibold">Affected Systems ({{ systemRows.length }})</h2>
+        </template>
+        <template #empty>
+          <div class="text-center text-(--ui-text-muted) py-8">
+            No systems use this technology.
+          </div>
+        </template>
+      </PaginatedTable>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { defineAsyncComponent, h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import {
+  buildImpactGraph,
+  IMPACT_GRAPH_SYSTEM_LIMIT,
+  type TechnologyImpactSystemRow
+} from '../../../utils/technology-impact-graph'
+
+const route = useRoute()
+const { getSortableHeader } = useSortableTable()
+const name = computed(() => route.params.name as string)
+
+const AsyncTechnologyImpactGraph = defineAsyncComponent(() => import('../../../components/TechnologyImpactGraph.vue'))
+
+interface GraphResponse {
+  success: boolean
+  data: { technology: string; systems: TechnologyImpactSystemRow[] }
+}
+
+const { data, pending, error } = await useFetch<GraphResponse>(
+  () => `/api/technologies/${encodeURIComponent(name.value)}/graph`
+)
+
+const systemRows = computed<TechnologyImpactSystemRow[]>(() => data.value?.data?.systems ?? [])
+const overCap = computed(() => systemRows.value.length > IMPACT_GRAPH_SYSTEM_LIMIT)
+const impactGraph = computed(() => buildImpactGraph(name.value, systemRows.value))
+
+const tableSorting = ref([])
+
+const columns: TableColumn<TechnologyImpactSystemRow>[] = [
+  {
+    accessorKey: 'systemName',
+    header: ({ column }) => getSortableHeader(column, 'System'),
+    cell: ({ row }) => h(resolveComponent('NuxtLink'), {
+      to: `/systems/${encodeURIComponent(row.original.systemName)}`,
+      class: 'font-medium hover:underline'
+    }, () => row.original.systemName)
+  },
+  {
+    accessorKey: 'ownerTeamName',
+    header: ({ column }) => getSortableHeader(column, 'Owning Team'),
+    cell: ({ row }) => {
+      const team = row.original.ownerTeamName
+      if (!team) return h('span', { class: 'text-(--ui-text-muted)' }, 'Unowned')
+      return h(resolveComponent('NuxtLink'), {
+        to: `/teams/${encodeURIComponent(team)}`,
+        class: 'font-medium hover:underline'
+      }, () => team)
+    }
+  },
+  {
+    accessorKey: 'time',
+    header: ({ column }) => getSortableHeader(column, 'TIME'),
+    cell: ({ row }) => {
+      const time = row.original.time
+      if (!time) return h('span', { class: 'text-(--ui-text-muted)' }, '—')
+      return h(resolveComponent('UBadge'), { color: getTimeCategoryColor(time), variant: 'subtle' }, () => time)
+    }
+  },
+  {
+    accessorKey: 'approved',
+    header: ({ column }) => getSortableHeader(column, 'Compliance'),
+    cell: ({ row }) => {
+      const approved = row.original.approved
+      return h(
+        resolveComponent('UBadge'),
+        { color: approved ? 'success' : 'error', variant: 'subtle' },
+        () => approved ? 'Approved' : 'Compliance Gap'
+      )
+    }
+  },
+  {
+    accessorKey: 'versions',
+    header: 'Versions',
+    cell: ({ row }) => h('code', { class: 'text-xs' }, row.original.versions.join(', '))
+  }
+]
+
+useHead({
+  title: computed(() => `${name.value} Impact - Polaris`)
+})
+</script>

--- a/app/pages/technologies/[name]/index.vue
+++ b/app/pages/technologies/[name]/index.vue
@@ -19,7 +19,10 @@
       <div class="flex justify-between items-center">
         <UPageHeader
           :title="tech.name"
-          :links="[{ label: 'Back to Technologies', to: '/technologies', icon: 'i-lucide-arrow-left', variant: 'outline' as const }]"
+          :links="[
+            { label: 'Back to Technologies', to: '/technologies', icon: 'i-lucide-arrow-left', variant: 'outline' as const },
+            { label: 'View Impact Graph', to: `/technologies/${encodeURIComponent(tech.name)}/impact`, icon: 'i-lucide-share-2', variant: 'outline' as const },
+          ]"
         />
         <div class="flex gap-2">
           <UBadge v-if="tech.type" color="neutral" variant="subtle">

--- a/app/utils/technology-impact-graph.ts
+++ b/app/utils/technology-impact-graph.ts
@@ -1,0 +1,108 @@
+import type { TimeValue } from '~~/types/api'
+
+export const IMPACT_GRAPH_SYSTEM_LIMIT = 75
+
+export const UNOWNED_TEAM_ID = 'team:__unowned__'
+export const UNOWNED_TEAM_LABEL = 'No owning team'
+
+export interface TechnologyImpactSystemRow {
+  systemName: string
+  ownerTeamName: string | null
+  environment: string | null
+  approved: boolean
+  time: TimeValue | null
+  versions: string[]
+}
+
+export interface ImpactGraphNode {
+  id: string
+  label: string
+  type: 'technology' | 'team' | 'system'
+  time?: TimeValue | null
+  complianceGap?: boolean
+  /** Team nodes only */
+  systemCount?: number
+  /** System nodes only */
+  ownerTeamName?: string | null
+  environment?: string | null
+  versions?: string[]
+}
+
+export interface ImpactGraphEdge {
+  source: string
+  target: string
+  complianceGap?: boolean
+}
+
+export interface BuildImpactGraphResult {
+  nodes: ImpactGraphNode[]
+  edges: ImpactGraphEdge[]
+}
+
+const TIME_SEVERITY_ORDER: TimeValue[] = ['eliminate', 'migrate', 'tolerate', 'invest']
+
+function mostSevereTime(times: TimeValue[]): TimeValue | undefined {
+  return TIME_SEVERITY_ORDER.find(t => times.includes(t))
+}
+
+/**
+ * Shape a technology's per-system impact rows into a three-tier
+ * technology -> team -> system graph. Kept free of Vue/D3/DOM so the
+ * compliance-gap and TIME-tie-break logic can be unit tested directly.
+ */
+export function buildImpactGraph(
+  technologyName: string,
+  rows: TechnologyImpactSystemRow[]
+): BuildImpactGraphResult {
+  const techId = `tech:${technologyName}`
+  const nodes: ImpactGraphNode[] = [{ id: techId, label: technologyName, type: 'technology' }]
+  const edges: ImpactGraphEdge[] = []
+
+  const teams = new Map<string, { label: string; rows: TechnologyImpactSystemRow[] }>()
+  for (const row of rows) {
+    const teamId = row.ownerTeamName ? `team:${row.ownerTeamName}` : UNOWNED_TEAM_ID
+    const label = row.ownerTeamName ?? UNOWNED_TEAM_LABEL
+    if (!teams.has(teamId)) teams.set(teamId, { label, rows: [] })
+    teams.get(teamId)!.rows.push(row)
+  }
+
+  for (const [teamId, team] of teams) {
+    // A system with no owning team can't have an owner-scoped approval, so
+    // "no owner" is a strict superset of "owner hasn't approved" -- always
+    // a compliance gap.
+    const isUnowned = teamId === UNOWNED_TEAM_ID
+    const approvedTimes = team.rows
+      .filter(r => r.approved && r.time)
+      .map(r => r.time as TimeValue)
+    const teamGap = isUnowned || team.rows.every(r => !r.approved)
+
+    nodes.push({
+      id: teamId,
+      label: team.label,
+      type: 'team',
+      complianceGap: teamGap,
+      time: teamGap ? undefined : mostSevereTime(approvedTimes),
+      systemCount: team.rows.length,
+    })
+    edges.push({ source: techId, target: teamId, complianceGap: teamGap })
+
+    for (const row of team.rows) {
+      const systemId = `system:${row.systemName}`
+      const complianceGap = isUnowned || !row.approved
+
+      nodes.push({
+        id: systemId,
+        label: row.systemName,
+        type: 'system',
+        time: row.time,
+        complianceGap,
+        ownerTeamName: row.ownerTeamName,
+        environment: row.environment,
+        versions: row.versions,
+      })
+      edges.push({ source: teamId, target: systemId, complianceGap })
+    }
+  }
+
+  return { nodes, edges }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "patch-package": "^8.0.1",
         "swagger-jsdoc": "^6.3.0",
         "tailwindcss": "^4.3.2",
-        "typescript": "^7.0.2",
+        "typescript": "^6.0.3",
         "vitest": "^4.1.10"
       }
     },
@@ -173,6 +173,52 @@
         "url": "https://github.com/sponsors/philsturgeon"
       }
     },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.0.tgz",
+      "integrity": "sha512-aN3Oq8r1J3gPJtCwErP664gM0+HhM1I1lujPr9TMTCcEl/joQQbpGpeMdts9B1+W2wHMsvioDMv5F4PvMWE6gw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.1.tgz",
+      "integrity": "sha512-Yidf5GOl60db80UxUtNdKK3pnY7obU/gs0xOfA0SCdnvVLMCvfYIer/egC3TqpPiT0Jg22eg3RlzcO+zKfPMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
+      }
+    },
     "node_modules/@appthreat/atom": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@appthreat/atom/-/atom-2.5.6.tgz",
@@ -216,20 +262,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@appthreat/atom-parsetools/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1354,6 +1386,416 @@
         "devframe": "0.5.4"
       }
     },
+    "node_modules/@devframes/hub/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
+      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
+      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
+      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
+      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
+      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
+      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
+      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
+      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
+      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
+      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
+      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
+      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
+      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
+      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
+      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
+      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
+      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
+      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
+      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
+      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/nostics": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nostics/-/nostics-0.2.0.tgz",
+      "integrity": "sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==",
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.21",
+        "oxc-parser": "^0.132.0",
+        "unplugin": "^3.0.0"
+      }
+    },
+    "node_modules/@devframes/hub/node_modules/oxc-parser": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
+      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
+        "@oxc-parser/binding-android-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-x64": "0.132.0",
+        "@oxc-parser/binding-freebsd-x64": "0.132.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
+      }
+    },
     "node_modules/@dxup/nuxt": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/@dxup/nuxt/-/nuxt-0.5.3.tgz",
@@ -1378,20 +1820,20 @@
       "license": "MIT"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1399,9 +1841,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1409,9 +1851,9 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.87.0.tgz",
-      "integrity": "sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.88.0.tgz",
+      "integrity": "sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1943,16 +2385,16 @@
       }
     },
     "node_modules/@eslint/config-inspector": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@eslint/config-inspector/-/config-inspector-3.0.4.tgz",
-      "integrity": "sha512-qyb1cjiiwD2mlg5GJC4JiO/EOO/rvEtm+GgLtgJ054bu8ZPj6hK1PLCRzxOnBghlPKWVqSjs4i+fXoPkt488Yw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-inspector/-/config-inspector-3.1.0.tgz",
+      "integrity": "sha512-miBAPkS/jN/c5RG/aEYhQaS64wlLXeo2EXXQ2w3SdCWux5icdrHyXnZyiF9dW8TukLURqK6xgzyIdgE1uGx5Vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "ansis": "^4.3.0",
+        "ansis": "^4.3.1",
         "cac": "^7.0.0",
         "chokidar": "^5.0.0",
-        "devframe": "^0.5.2",
+        "devframe": "^0.6.0",
         "jiti": "^2.7.0",
         "tinyglobby": "^0.2.16"
       },
@@ -2254,9 +2696,9 @@
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.3.tgz",
-      "integrity": "sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
       "license": "MIT",
       "dependencies": {
         "@antfu/install-pkg": "^1.1.0",
@@ -3502,38 +3944,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/kit/node_modules/nostics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
-      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
-      "license": "MIT"
-    },
-    "node_modules/@nuxt/kit/node_modules/unctx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
-      "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "magic-string": ">=0.30.21",
-        "oxc-parser": ">=0.140.0",
-        "rolldown": "^1.1.5",
-        "unplugin": "^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "magic-string": {
-          "optional": true
-        },
-        "oxc-parser": {
-          "optional": true
-        },
-        "rolldown": {
-          "optional": true
-        },
-        "unplugin": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nuxt/nitro-server": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/@nuxt/nitro-server/-/nitro-server-4.5.0.tgz",
@@ -3576,7 +3986,7 @@
         "@babel/plugin-proposal-decorators": "^7.25.0 || ^8.0.0",
         "@babel/plugin-syntax-typescript": "^7.25.0 || ^8.0.0",
         "@rollup/plugin-babel": "^6.0.0 || ^7.0.0",
-        "nuxt": "4.5.0"
+        "nuxt": "^4.5.0"
       },
       "peerDependenciesMeta": {
         "@babel/plugin-proposal-decorators": {
@@ -3630,12 +4040,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@nuxt/nitro-server/node_modules/nostics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
-      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
-      "license": "MIT"
-    },
     "node_modules/@nuxt/nitro-server/node_modules/rou3": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.1.tgz",
@@ -3647,32 +4051,6 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "license": "MIT"
-    },
-    "node_modules/@nuxt/nitro-server/node_modules/unctx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
-      "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "magic-string": ">=0.30.21",
-        "oxc-parser": ">=0.140.0",
-        "rolldown": "^1.1.5",
-        "unplugin": "^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "magic-string": {
-          "optional": true
-        },
-        "oxc-parser": {
-          "optional": true
-        },
-        "rolldown": {
-          "optional": true
-        },
-        "unplugin": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@nuxt/nitro-server/node_modules/unhead": {
       "version": "3.2.1",
@@ -3711,12 +4089,6 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
-    },
-    "node_modules/@nuxt/schema/node_modules/nostics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
-      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
-      "license": "MIT"
     },
     "node_modules/@nuxt/schema/node_modules/std-env": {
       "version": "4.2.0",
@@ -3759,9 +4131,9 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/telemetry/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "license": "MIT"
     },
     "node_modules/@nuxt/test-utils": {
@@ -3887,9 +4259,9 @@
       }
     },
     "node_modules/@nuxt/test-utils/node_modules/@nuxt/kit": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.8.tgz",
-      "integrity": "sha512-kg63DUPY5AHPn+9XM7u8rYcdWHXjzwfUscgRDuiC5YUciQ+xdLRhdwXelYFxEAx2nxJHossliiQXbMm/Fleivw==",
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.9.tgz",
+      "integrity": "sha512-SJ3W7INBJLwnmFQPm2BACiqS25enc6QIm87aLQCcxo/TFtRnWanYtgDdwyHqUHgOAGmq9pYjgk83B2bpBKnDTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3898,8 +4270,8 @@
         "defu": "^6.1.7",
         "destr": "^2.0.5",
         "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
+        "exsolve": "^1.1.0",
+        "ignore": "^7.0.6",
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "knitwork": "^1.3.0",
@@ -3909,8 +4281,8 @@
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.0",
-        "tinyglobby": "^0.2.16",
+        "semver": "^7.8.5",
+        "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^2.5.0",
         "untyped": "^2.0.0"
@@ -3947,11 +4319,40 @@
       }
     },
     "node_modules/@nuxt/test-utils/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@nuxt/test-utils/node_modules/unctx": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21",
+        "unplugin": "^2.3.11"
+      }
+    },
+    "node_modules/@nuxt/test-utils/node_modules/unctx/node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
     },
     "node_modules/@nuxt/ui": {
       "version": "4.10.0",
@@ -4215,572 +4616,120 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-      "integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
       },
       "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/context-async-hooks": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.30.1.tgz",
-      "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
-      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.9.0.tgz",
+      "integrity": "sha512-m2nckMT80NnmjTYSPjJQObBJ+8dgkoajEOUbznL8AHZ3T3yHRk2P7gI1PhEBc1+lOnrYE9UWrWHqJDsmqjmNbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-      "integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.57.2",
-        "@types/shimmer": "^1.2.0",
-        "import-in-the-middle": "^1.8.1",
-        "require-in-the-middle": "^7.1.1",
-        "semver": "^7.5.2",
-        "shimmer": "^1.2.1"
+        "@opentelemetry/api-logs": "0.220.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-amqplib": {
-      "version": "0.46.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.46.1.tgz",
-      "integrity": "sha512-AyXVnlCf/xV3K/rNumzKxZqsULyITJH6OVLiW6730JPRqWA7Zc9bvYoVNpN6iOpTU8CasH34SU/ksVJmObFibQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-connect": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.43.1.tgz",
-      "integrity": "sha512-ht7YGWQuV5BopMcw5Q2hXn3I8eG8TH0J/kc/GMcW4CuNTgiP6wCu44BOnucJWL3CmFWaRHI//vWyAhaC8BwePw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/connect": "3.4.38"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-dataloader": {
-      "version": "0.16.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.16.1.tgz",
-      "integrity": "sha512-K/qU4CjnzOpNkkKO4DfCLSQshejRNAJtd4esgigo/50nxCB6XCyi1dhAblUHM9jG5dRm8eu0FB+t87nIo99LYQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-express": {
-      "version": "0.47.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.47.1.tgz",
-      "integrity": "sha512-QNXPTWteDclR2B4pDFpz0TNghgB33UMjUt14B+BZPmtH1MwUFAfLHBaP5If0Z5NZC+jaH8oF2glgYjrmhZWmSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-fs": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.19.1.tgz",
-      "integrity": "sha512-6g0FhB3B9UobAR60BGTcXg4IHZ6aaYJzp0Ki5FhnxyAPt8Ns+9SSvgcrnsN2eGmk3RWG5vYycUGOEApycQL24A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-generic-pool": {
-      "version": "0.43.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.43.1.tgz",
-      "integrity": "sha512-M6qGYsp1cURtvVLGDrPPZemMFEbuMmCXgQYTReC/IbimV5sGrLBjB+/hANUpRZjX67nGLdKSVLZuQQAiNz+sww==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-graphql": {
-      "version": "0.47.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.47.1.tgz",
-      "integrity": "sha512-EGQRWMGqwiuVma8ZLAZnExQ7sBvbOx0N/AE/nlafISPs8S+QtXX+Viy6dcQwVWwYHQPAcuY3bFt3xgoAwb4ZNQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-hapi": {
-      "version": "0.45.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.45.2.tgz",
-      "integrity": "sha512-7Ehow/7Wp3aoyCrZwQpU7a2CnoMq0XhIcioFuKjBb0PLYfBfmTsFTUyatlHu0fRxhwcRsSQRTvEhmZu8CppBpQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http": {
-      "version": "0.57.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.57.2.tgz",
-      "integrity": "sha512-1Uz5iJ9ZAlFOiPuwYg29Bf7bJJc/GeoeJIFKJYQf67nTVKFe8RHbEtxgkOmK4UGZNHKXcpW4P8cWBYzBn1USpg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/instrumentation": "0.57.2",
-        "@opentelemetry/semantic-conventions": "1.28.0",
-        "forwarded-parse": "2.1.2",
-        "semver": "^7.5.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.47.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.47.1.tgz",
-      "integrity": "sha512-OtFGSN+kgk/aoKgdkKQnBsQFDiG8WdCxu+UrHr0bXScdAmtSzLSraLo7wFIb25RVHfRWvzI5kZomqJYEg/l1iA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/redis-common": "^0.36.2",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-kafkajs": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.7.1.tgz",
-      "integrity": "sha512-OtjaKs8H7oysfErajdYr1yuWSjMAectT7Dwr+axIoZqT9lmEOkD/H/3rgAs8h/NIuEi2imSXD+vL4MZtOuJfqQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-knex": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.44.1.tgz",
-      "integrity": "sha512-U4dQxkNhvPexffjEmGwCq68FuftFK15JgUF05y/HlK3M6W/G2iEaACIfXdSnwVNe9Qh0sPfw8LbOPxrWzGWGMQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-koa": {
-      "version": "0.47.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.47.1.tgz",
-      "integrity": "sha512-l/c+Z9F86cOiPJUllUCt09v+kICKvT+Vg1vOAJHtHPsJIzurGayucfCMq2acd/A/yxeNWunl9d9eqZ0G+XiI6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.44.1.tgz",
-      "integrity": "sha512-5MPkYCvG2yw7WONEjYj5lr5JFehTobW7wX+ZUFy81oF2lr9IPfZk9qO+FTaM0bGEiymwfLwKe6jE15nHn1nmHg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mongodb": {
-      "version": "0.52.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.52.0.tgz",
-      "integrity": "sha512-1xmAqOtRUQGR7QfJFfGV/M2kC7wmI2WgZdpru8hJl3S0r4hW0n3OQpEHlSGXJAaNFyvT+ilnwkT+g5L4ljHR6g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mongoose": {
-      "version": "0.46.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.46.1.tgz",
-      "integrity": "sha512-3kINtW1LUTPkiXFRSSBmva1SXzS/72we/jL22N+BnF3DFcoewkdkHPYOIdAAk9gSicJ4d5Ojtt1/HeibEc5OQg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mysql": {
-      "version": "0.45.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.45.1.tgz",
-      "integrity": "sha512-TKp4hQ8iKQsY7vnp/j0yJJ4ZsP109Ht6l4RHTj0lNEG1TfgTrIH5vJMbgmoYXWzNHAqBH2e7fncN12p3BP8LFg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/mysql": "2.15.26"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-mysql2": {
-      "version": "0.45.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.45.2.tgz",
-      "integrity": "sha512-h6Ad60FjCYdJZ5DTz1Lk2VmQsShiViKe0G7sYikb0GHI0NVvApp2XQNRHNjEMz87roFttGPLHOYVPlfy+yVIhQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@opentelemetry/sql-common": "^0.40.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-pg": {
-      "version": "0.51.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.51.1.tgz",
-      "integrity": "sha512-QxgjSrxyWZc7Vk+qGSfsejPVFL1AgAJdSBMYZdDUbwg730D09ub3PXScB9d04vIqPriZ+0dqzjmQx0yWKiCi2Q==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.26.0",
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@opentelemetry/sql-common": "^0.40.1",
-        "@types/pg": "8.6.1",
-        "@types/pg-pool": "2.0.6"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-redis-4": {
-      "version": "0.46.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.46.1.tgz",
-      "integrity": "sha512-UMqleEoabYMsWoTkqyt9WAzXwZ4BlFZHO40wr3d5ZvtjKCHlD4YXLm+6OLCeIi/HkX7EXvQaz8gtAwkwwSEvcQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/redis-common": "^0.36.2",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-tedious": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.18.1.tgz",
-      "integrity": "sha512-5Cuy/nj0HBaH+ZJ4leuD7RjgvA844aY2WW+B5uLcWtxGjRZl3MNLuxnNg5DYWZNPO+NafSSnra0q49KWAHsKBg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.57.1",
-        "@opentelemetry/semantic-conventions": "^1.27.0",
-        "@types/tedious": "^4.0.14"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
-    "node_modules/@opentelemetry/instrumentation-undici": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.10.1.tgz",
-      "integrity": "sha512-rkOGikPEyRpMCmNu9AQuV5dtRlDmJp2dK5sw8roVshAGoB6hH/3QjDtRhdwd75SsJwgynWUNRUYe0wAkTo16tQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.8.0",
-        "@opentelemetry/instrumentation": "^0.57.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.7.0"
-      }
-    },
-    "node_modules/@opentelemetry/redis-common": {
-      "version": "0.36.2",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.36.2.tgz",
-      "integrity": "sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
-      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.9.0.tgz",
+      "integrity": "sha512-jyA5MBLQ+Dkl3+JsZkUoUvL7yHvU64kLsvpXKarWm6347Sl1t1bXFTFykUePNpT5WH5pm9a2Qtt03iIYQhZ1Fg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.9.0.tgz",
+      "integrity": "sha512-sGA19HvtrrSKYsseHphluH6j3p6Xa3fqc7c7y8f/7mYWejc1lyDFcpSdD1kYa50HCLUeEo4zA5bW0pniaPszuw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
-      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.9.0.tgz",
+      "integrity": "sha512-cp9zmTl62R8PJrpvFcmc8N2JQU/xfa0S+61q511Nji+QxCfZ8Ifvg7H27G8cANe4crg4RTrWsVvanHiXjSp6ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "1.30.1",
-        "@opentelemetry/resources": "1.30.1",
-        "@opentelemetry/semantic-conventions": "1.28.0"
+        "@opentelemetry/core": "2.9.0",
+        "@opentelemetry/resources": "2.9.0",
+        "@opentelemetry/sdk-trace": "2.9.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@opentelemetry/api": ">=1.0.0 <1.10.0"
-      }
-    },
-    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
-      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=14"
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@opentelemetry/sql-common": {
-      "version": "0.40.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.40.1.tgz",
-      "integrity": "sha512-nSDlnHSqzC3pXn/wZEZVLuAuJ1MYMXPBwtv2qAbCa3847SaHItdE7SzUq/Jtb0KZmh1zfAbNi3AAMjztTT4Ugg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.1.0"
       }
     },
     "node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
-      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.140.0.tgz",
+      "integrity": "sha512-ZfjDZ422mo7eo3b3VltqNsV9kmv1qt/sPEAMSl64iOSwhVfd0eIZ9LB79Mbs1xYXJnk7WSROwzBCKDIiVxPTvQ==",
       "cpu": [
         "arm"
       ],
@@ -4794,9 +4743,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
-      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.140.0.tgz",
+      "integrity": "sha512-Ia8jSvikUX6Sf+Ht+KOCUF/k1HpR0VlmqIYymubmWDebOEGtsyliHDR6JxsZ4IX3/c/GbrB1uh09aVGQv/LQmQ==",
       "cpu": [
         "arm64"
       ],
@@ -4810,9 +4759,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
-      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.140.0.tgz",
+      "integrity": "sha512-G6VK0nK61pH0d0mBjUqSZbVxGqqO5uzeginLDQj+gOO6ObfJjXRwgkD/ol0w1INcnFeAb6YGGO7qc3ueGHaycQ==",
       "cpu": [
         "arm64"
       ],
@@ -4826,9 +4775,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
-      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.140.0.tgz",
+      "integrity": "sha512-HazBOuZzd2pO1C2uMmp8Gv7mhzMHqKSKDS1OZfcLEvpIcgA+48J92HEtNanVHDIzRD9PRPCV6aS6fkZIWOVl8Q==",
       "cpu": [
         "x64"
       ],
@@ -4842,9 +4791,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
-      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.140.0.tgz",
+      "integrity": "sha512-9hSUU+HmTUyOe4JzMHxNGgLWNY7rrO+6ShicZwImNJacEAACDMIkuEQQkvXSL+WJN50jaNtLYJv8s4OcBdpyUQ==",
       "cpu": [
         "x64"
       ],
@@ -4858,9 +4807,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
-      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.140.0.tgz",
+      "integrity": "sha512-RAEuQsYtS0KcDFqN0ABTjyyNlokS91JeuDuoW9tEbG0JTbRNXnpQUdbYc/16JoA6Z/2ALbNrE3KmxtqDiuIjCQ==",
       "cpu": [
         "arm"
       ],
@@ -4874,9 +4823,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
-      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.140.0.tgz",
+      "integrity": "sha512-c4CkHvPvqfojouredJ0w3e6+jiBq0SbFyhH61kr/zPb/7XsaYTNKQ54vmlSsopfdQbNDX40ZeK9Abs2Qet6wcw==",
       "cpu": [
         "arm"
       ],
@@ -4890,9 +4839,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
-      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.140.0.tgz",
+      "integrity": "sha512-yrjmLj8ixPB25yqvPGr28meGjb+keed7m1GqqY/0uqkhZIoT4t9zmfwUgFEtC33C7dtE+UQ7TU0IaVxf97SWJg==",
       "cpu": [
         "arm64"
       ],
@@ -4906,9 +4855,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
-      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.140.0.tgz",
+      "integrity": "sha512-ggGMQTN8Agwxp2WiLMpdY671dt0qTDJWiWlJeig3HnUwTnerRl0J2JdGVghWBeDcss2D9S2V2Js6dZHEiVabVA==",
       "cpu": [
         "arm64"
       ],
@@ -4922,9 +4871,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
-      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.140.0.tgz",
+      "integrity": "sha512-IgTs8xYAFgAUGNmR65tIqjlJ8vKgrfXzC515e9goSdfMyKQV4aJpd2pUUudU4u51G64H0/DSEJEXKOraxm9ZCA==",
       "cpu": [
         "ppc64"
       ],
@@ -4938,9 +4887,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
-      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.140.0.tgz",
+      "integrity": "sha512-A1x+PMWZmSGaFVOx2YeNTFau8uD+QO14/vLP4GrcuvUPs3+nBkUOjy9Lus86ftHsDojjYMbvBelmKc3F7Rv08g==",
       "cpu": [
         "riscv64"
       ],
@@ -4954,9 +4903,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
-      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.140.0.tgz",
+      "integrity": "sha512-zBqpfRo2myWPrPo5xUjeZqlnPXPXsX8BcWtWff66/eGRQdbPjhzPgXa/F+AtxT2afUViPxbuDlwscMKzQ5tg+g==",
       "cpu": [
         "riscv64"
       ],
@@ -4970,9 +4919,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
-      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.140.0.tgz",
+      "integrity": "sha512-2M1DPm/8w9I//YzFlFC9qXw+r2tJFh5CYwRlYTq2vUJQS7qoQftEDeCZ8EnN7KHtvSiXvYj8mZI5pR7DpXmcEw==",
       "cpu": [
         "s390x"
       ],
@@ -4986,9 +4935,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
-      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.140.0.tgz",
+      "integrity": "sha512-8aRDbZ/U/jO8N7go1MO72jtbpb4uswV8d7vOkMvt/BPgZiyEYvl1VIWK4ESxZZhnJ4tqwVldgX7dNiP/eB1Jdg==",
       "cpu": [
         "x64"
       ],
@@ -5002,9 +4951,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
-      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.140.0.tgz",
+      "integrity": "sha512-xRqpeI8U2sQQS1W5BMWRyMTxtagkuLG2dEWruet5lFsWHTvBth11/TpSaJatHdqVVwHN0q3uuoS9zRsGinq8hg==",
       "cpu": [
         "x64"
       ],
@@ -5018,9 +4967,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
-      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.140.0.tgz",
+      "integrity": "sha512-GbGRe26MqAKciFRvXeHNQJ6VAHYs9R4miP89sEAncysM3n+f4lnyLWgsa9kklJNpfnxdq2yRoNYHFqwBckVimw==",
       "cpu": [
         "arm64"
       ],
@@ -5034,27 +4983,27 @@
       }
     },
     "node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
-      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.140.0.tgz",
+      "integrity": "sha512-vFiC1hqys+hkX1GnQkIoiTQJNiUm43Z0lO35ETKXTw0YtpW7+cN58YRRXFAQQ+TgpkIi3lrhcxdlnqz+Oi3ptQ==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.10.0",
-        "@emnapi/runtime": "1.10.0",
-        "@napi-rs/wasm-runtime": "^1.1.4"
+        "@emnapi/core": "1.11.2",
+        "@emnapi/runtime": "1.11.2",
+        "@napi-rs/wasm-runtime": "^1.1.6"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
-      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.140.0.tgz",
+      "integrity": "sha512-fGSQldwEYKhM+H8uLt76Op8hh5+FYaR6lvvQ1Txw3Mhn86DyQXLcI0fi1EkFlTK7F+46OCk/j0AJMzZQm6g5Xg==",
       "cpu": [
         "arm64"
       ],
@@ -5068,9 +5017,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
-      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.140.0.tgz",
+      "integrity": "sha512-sDS2Bai+g3ZWYwfZqmosiSuFDBcVnZ3Ta6pszzsiJoLMqsJEWKcxXXbGa7b7yXr++W2lQNPb3ZRJ8czseqL7RA==",
       "cpu": [
         "ia32"
       ],
@@ -5084,9 +5033,9 @@
       }
     },
     "node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
-      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.140.0.tgz",
+      "integrity": "sha512-kHbE1zWyb5OQgJA6/5P4WjiuB01sYdQwtZnSSyE58FQEXDAMnyeeq4vj7KgN75i5SlBzOs8A5MrtlD3gOlDKqQ==",
       "cpu": [
         "x64"
       ],
@@ -5100,9 +5049,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
+      "integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -5117,245 +5066,10 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/@parcel/watcher": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.3",
-        "is-glob": "^4.0.3",
-        "node-addon-api": "^7.0.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "@parcel/watcher-android-arm64": "2.5.6",
-        "@parcel/watcher-darwin-arm64": "2.5.6",
-        "@parcel/watcher-darwin-x64": "2.5.6",
-        "@parcel/watcher-freebsd-x64": "2.5.6",
-        "@parcel/watcher-linux-arm-glibc": "2.5.6",
-        "@parcel/watcher-linux-arm-musl": "2.5.6",
-        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
-        "@parcel/watcher-linux-arm64-musl": "2.5.6",
-        "@parcel/watcher-linux-x64-glibc": "2.5.6",
-        "@parcel/watcher-linux-x64-musl": "2.5.6",
-        "@parcel/watcher-win32-arm64": "2.5.6",
-        "@parcel/watcher-win32-ia32": "2.5.6",
-        "@parcel/watcher-win32-x64": "2.5.6"
-      }
-    },
-    "node_modules/@parcel/watcher-android-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-darwin-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-freebsd-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-arm64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-glibc": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-linux-x64-musl": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/@parcel/watcher-wasm": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.5.6.tgz",
-      "integrity": "sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-wasm/-/watcher-wasm-2.6.0.tgz",
+      "integrity": "sha512-dtjbDxKSDPQ8AmA+pS4OFaHE1FKrjtGpLGBxw85uKFkRorjNbvDM/aFPgqosu40wprbp1xw2ZSxIKqghCUHe2w==",
       "bundleDependencies": [
         "napi-wasm"
       ],
@@ -5363,7 +5077,7 @@
       "dependencies": {
         "is-glob": "^4.0.3",
         "napi-wasm": "^1.1.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">= 10.0.0"
@@ -5377,66 +5091,6 @@
       "version": "1.1.0",
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/@parcel/watcher-win32-arm64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-ia32": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/@parcel/watcher-win32-x64": {
-      "version": "2.5.6",
-      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
     },
     "node_modules/@paulirish/trace_engine": {
       "version": "0.0.65",
@@ -5513,23 +5167,10 @@
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
       "license": "MIT"
     },
-    "node_modules/@prisma/instrumentation": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.11.1.tgz",
-      "integrity": "sha512-mrZOev24EDhnefmnZX7WVVT7v+r9LttPRqf54ONvj6re4XMF7wFTpK2tLJi4XHB7fFp/6xhYbgRel8YV7gQiyA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.8"
-      }
-    },
     "node_modules/@puppeteer/browsers": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.5.tgz",
-      "integrity": "sha512-xYXNuEQmHNIPWWcbL/skf2KF7seyp7c1xmKFRk3wmdFx7VwBsKVrtOLKs8ecaezsKPsWeF1YsgwIiElAscaryA==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-3.0.6.tgz",
+      "integrity": "sha512-B/gKoqlFkzhvzsI6jo9K1cZz9o5ypviVv/xu8CwA4grZzyVwN+XfkT+tu8T1zrauuEXv6VhS2oGX+6NL95WcKA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5543,10 +5184,14 @@
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "proxy-agent": ">=8.0.1"
+        "proxy-agent": ">=8.0.1",
+        "yauzl": "^2.10.0 || ^3.4.0"
       },
       "peerDependenciesMeta": {
         "proxy-agent": {
+          "optional": true
+        },
+        "yauzl": {
           "optional": true
         }
       }
@@ -5638,9 +5283,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5656,9 +5298,6 @@
       "integrity": "sha512-wUqdwJBbAv0APN87GecstdMUtLjjNTs0hBALpxETD73mccFxdmt/XeizXDtN5RAlBwNKmI+Tg+blect2G+8IeQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5676,9 +5315,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5694,9 +5330,6 @@
       "integrity": "sha512-RzuHrBh8X8Hntd2N4VR02QGEciq/9JhcZoTpR/Cee6otRrlILGCf3cg2ygHuih+ZebUnWmMrDX6ITI85btO6rQ==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5714,9 +5347,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5732,9 +5362,6 @@
       "integrity": "sha512-gyrxLQ9NfGb/9LoVnC4kb9miUghw1mghnkfYvNHSnVIXriabnfgGPUP4RLcJm87q3KgYz4FYUG8IDiWUT+CpSw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5777,37 +5404,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -6365,138 +5961,123 @@
         "win32"
       ]
     },
-    "node_modules/@sentry/core": {
-      "version": "9.47.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-9.47.1.tgz",
-      "integrity": "sha512-KX62+qIt4xgy8eHKHiikfhz2p5fOciXd0Cl+dNzhgPFq8klq4MGMNaf148GB3M/vBqP4nw/eFvRMAayFCgdRQw==",
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.67.0.tgz",
+      "integrity": "sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node": {
-      "version": "9.47.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-9.47.1.tgz",
-      "integrity": "sha512-CDbkasBz3fnWRKSFs6mmaRepM2pa+tbZkrqhPWifFfIkJDidtVW40p6OnquTvPXyPAszCnDZRnZT14xyvNmKPQ==",
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.67.0.tgz",
+      "integrity": "sha512-SFKpZGqOCEFSmP93NdDP6ikZp4NS7A/JR8+2ofK3jF6Y9Vyox7pX0pxdOnPLpFcPtMybMahfWqSAWJvsFs4RmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1",
-        "@opentelemetry/core": "^1.30.1",
-        "@opentelemetry/instrumentation": "^0.57.2",
-        "@opentelemetry/instrumentation-amqplib": "^0.46.1",
-        "@opentelemetry/instrumentation-connect": "0.43.1",
-        "@opentelemetry/instrumentation-dataloader": "0.16.1",
-        "@opentelemetry/instrumentation-express": "0.47.1",
-        "@opentelemetry/instrumentation-fs": "0.19.1",
-        "@opentelemetry/instrumentation-generic-pool": "0.43.1",
-        "@opentelemetry/instrumentation-graphql": "0.47.1",
-        "@opentelemetry/instrumentation-hapi": "0.45.2",
-        "@opentelemetry/instrumentation-http": "0.57.2",
-        "@opentelemetry/instrumentation-ioredis": "0.47.1",
-        "@opentelemetry/instrumentation-kafkajs": "0.7.1",
-        "@opentelemetry/instrumentation-knex": "0.44.1",
-        "@opentelemetry/instrumentation-koa": "0.47.1",
-        "@opentelemetry/instrumentation-lru-memoizer": "0.44.1",
-        "@opentelemetry/instrumentation-mongodb": "0.52.0",
-        "@opentelemetry/instrumentation-mongoose": "0.46.1",
-        "@opentelemetry/instrumentation-mysql": "0.45.1",
-        "@opentelemetry/instrumentation-mysql2": "0.45.2",
-        "@opentelemetry/instrumentation-pg": "0.51.1",
-        "@opentelemetry/instrumentation-redis-4": "0.46.1",
-        "@opentelemetry/instrumentation-tedious": "0.18.1",
-        "@opentelemetry/instrumentation-undici": "0.10.1",
-        "@opentelemetry/resources": "^1.30.1",
-        "@opentelemetry/sdk-trace-base": "^1.30.1",
-        "@opentelemetry/semantic-conventions": "^1.34.0",
-        "@prisma/instrumentation": "6.11.1",
-        "@sentry/core": "9.47.1",
-        "@sentry/node-core": "9.47.1",
-        "@sentry/opentelemetry": "9.47.1",
-        "import-in-the-middle": "^1.14.2",
-        "minimatch": "^9.0.0"
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0",
+        "@sentry/node-core": "10.67.0",
+        "@sentry/opentelemetry": "10.67.0",
+        "@sentry/server-utils": "10.67.0",
+        "import-in-the-middle": "^3.0.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "9.47.1",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-9.47.1.tgz",
-      "integrity": "sha512-7TEOiCGkyShJ8CKtsri9lbgMCbB+qNts2Xq37itiMPN2m+lIukK3OX//L8DC5nfKYZlgikrefS63/vJtm669hQ==",
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.67.0.tgz",
+      "integrity": "sha512-dBHHRwZyan1pOnFJ+sNBvR8TkXbZAfZU/jpxmALS3JZ2/8AGR7cQKL+b7SleKuJ7iUDZyklN3Nqi0i5JkcA+HA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.47.1",
-        "@sentry/opentelemetry": "9.47.1",
-        "import-in-the-middle": "^1.14.2"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0",
+        "@sentry/opentelemetry": "10.67.0",
+        "import-in-the-middle": "^3.0.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
         "@opentelemetry/instrumentation": ">=0.57.1 <1",
-        "@opentelemetry/resources": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.34.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@sentry/node/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@sentry/node/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
       },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        }
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "9.47.1",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-9.47.1.tgz",
-      "integrity": "sha512-STtFpjF7lwzeoedDJV+5XA6P89BfmFwFftmHSGSe3UTI8z8IoiR5yB6X2vCjSPvXlfeOs13qCNNCEZyznxM8Xw==",
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.67.0.tgz",
+      "integrity": "sha512-oLTOrAK1rOqmYRktOJZwz37B1seXPx1W2FTMVtzTVNjMFA/LZwGzePeZzhUOgzZgfLHixMd/ceWtGqoxAndcjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "9.47.1"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
-        "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/core": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
-        "@opentelemetry/semantic-conventions": "^1.34.0"
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
+      }
+    },
+    "node_modules/@sentry/server-utils": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.67.0.tgz",
+      "integrity": "sha512-GQ9t+RSTx5s3b/aZrLFuL4nrwPLMah5NiZk5cjxJmgmOSgm3nMdO8gdqCedDch5B13F3YsxtaQYjSJnzLz8M5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.1",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@sidebase/nuxt-auth": {
@@ -6528,9 +6109,9 @@
       }
     },
     "node_modules/@sidebase/nuxt-auth/node_modules/@nuxt/kit": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.8.tgz",
-      "integrity": "sha512-kg63DUPY5AHPn+9XM7u8rYcdWHXjzwfUscgRDuiC5YUciQ+xdLRhdwXelYFxEAx2nxJHossliiQXbMm/Fleivw==",
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.9.tgz",
+      "integrity": "sha512-SJ3W7INBJLwnmFQPm2BACiqS25enc6QIm87aLQCcxo/TFtRnWanYtgDdwyHqUHgOAGmq9pYjgk83B2bpBKnDTw==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -6538,8 +6119,8 @@
         "defu": "^6.1.7",
         "destr": "^2.0.5",
         "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
+        "exsolve": "^1.1.0",
+        "ignore": "^7.0.6",
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "knitwork": "^1.3.0",
@@ -6549,11 +6130,38 @@
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.0",
-        "tinyglobby": "^0.2.16",
+        "semver": "^7.8.5",
+        "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^2.5.0",
         "untyped": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@sidebase/nuxt-auth/node_modules/unctx": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21",
+        "unplugin": "^2.3.11"
+      }
+    },
+    "node_modules/@sidebase/nuxt-auth/node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -6778,9 +6386,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6796,9 +6401,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6816,9 +6418,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6834,9 +6433,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6875,66 +6471,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.3.3",
@@ -7656,16 +7192,6 @@
         "assertion-error": "^2.0.1"
       }
     },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/d3": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
@@ -7847,9 +7373,9 @@
       "license": "MIT"
     },
     "node_modules/@types/d3-random": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
-      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
+      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-scale": {
@@ -7982,16 +7508,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/mysql": {
-      "version": "2.15.26",
-      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.26.tgz",
-      "integrity": "sha512-DSLCOXhkvfS5WNNPbfn2KdICAmk8lLc+/PNvnPnF7gOdMZCxopXduqv0OQ13y/yA/zXTSikZZqVgybUxOEg6YQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/node": {
       "version": "26.1.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
@@ -8009,28 +7525,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/pg": {
-      "version": "8.6.1",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.6.1.tgz",
-      "integrity": "sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "pg-protocol": "*",
-        "pg-types": "^2.2.0"
-      }
-    },
-    "node_modules/@types/pg-pool": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
-      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/pg": "*"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -8044,29 +7538,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/shimmer": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/swagger-jsdoc": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
       "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/tedious": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
-      "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
@@ -8106,17 +7583,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
-      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/type-utils": "8.62.0",
-        "@typescript-eslint/utils": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -8129,22 +7606,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.62.0",
+        "@typescript-eslint/parser": "^8.65.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
-      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -8160,14 +7637,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
-      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.62.0",
-        "@typescript-eslint/types": "^8.62.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -8182,14 +7659,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
-      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8200,9 +7677,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
-      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8217,15 +7694,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
-      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0",
-        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -8242,9 +7719,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
-      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8256,16 +7733,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
-      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.62.0",
-        "@typescript-eslint/tsconfig-utils": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/visitor-keys": "8.62.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -8284,16 +7761,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
-      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.62.0",
-        "@typescript-eslint/types": "8.62.0",
-        "@typescript-eslint/typescript-estree": "8.62.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8308,13 +7785,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.62.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
-      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/types": "8.65.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -8336,346 +7813,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@typescript/typescript-aix-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-loong64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-mips64el": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-riscv64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-s390x": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-sunos-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=16.20.0"
       }
     },
     "node_modules/@unhead/bundler": {
@@ -8724,392 +7861,6 @@
         }
       }
     },
-    "node_modules/@unhead/bundler/node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-android-arm-eabi": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.140.0.tgz",
-      "integrity": "sha512-ZfjDZ422mo7eo3b3VltqNsV9kmv1qt/sPEAMSl64iOSwhVfd0eIZ9LB79Mbs1xYXJnk7WSROwzBCKDIiVxPTvQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-android-arm64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.140.0.tgz",
-      "integrity": "sha512-Ia8jSvikUX6Sf+Ht+KOCUF/k1HpR0VlmqIYymubmWDebOEGtsyliHDR6JxsZ4IX3/c/GbrB1uh09aVGQv/LQmQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-darwin-arm64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.140.0.tgz",
-      "integrity": "sha512-G6VK0nK61pH0d0mBjUqSZbVxGqqO5uzeginLDQj+gOO6ObfJjXRwgkD/ol0w1INcnFeAb6YGGO7qc3ueGHaycQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-darwin-x64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.140.0.tgz",
-      "integrity": "sha512-HazBOuZzd2pO1C2uMmp8Gv7mhzMHqKSKDS1OZfcLEvpIcgA+48J92HEtNanVHDIzRD9PRPCV6aS6fkZIWOVl8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-freebsd-x64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.140.0.tgz",
-      "integrity": "sha512-9hSUU+HmTUyOe4JzMHxNGgLWNY7rrO+6ShicZwImNJacEAACDMIkuEQQkvXSL+WJN50jaNtLYJv8s4OcBdpyUQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.140.0.tgz",
-      "integrity": "sha512-RAEuQsYtS0KcDFqN0ABTjyyNlokS91JeuDuoW9tEbG0JTbRNXnpQUdbYc/16JoA6Z/2ALbNrE3KmxtqDiuIjCQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.140.0.tgz",
-      "integrity": "sha512-c4CkHvPvqfojouredJ0w3e6+jiBq0SbFyhH61kr/zPb/7XsaYTNKQ54vmlSsopfdQbNDX40ZeK9Abs2Qet6wcw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.140.0.tgz",
-      "integrity": "sha512-yrjmLj8ixPB25yqvPGr28meGjb+keed7m1GqqY/0uqkhZIoT4t9zmfwUgFEtC33C7dtE+UQ7TU0IaVxf97SWJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-arm64-musl": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.140.0.tgz",
-      "integrity": "sha512-ggGMQTN8Agwxp2WiLMpdY671dt0qTDJWiWlJeig3HnUwTnerRl0J2JdGVghWBeDcss2D9S2V2Js6dZHEiVabVA==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.140.0.tgz",
-      "integrity": "sha512-IgTs8xYAFgAUGNmR65tIqjlJ8vKgrfXzC515e9goSdfMyKQV4aJpd2pUUudU4u51G64H0/DSEJEXKOraxm9ZCA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.140.0.tgz",
-      "integrity": "sha512-A1x+PMWZmSGaFVOx2YeNTFau8uD+QO14/vLP4GrcuvUPs3+nBkUOjy9Lus86ftHsDojjYMbvBelmKc3F7Rv08g==",
-      "cpu": [
-        "riscv64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.140.0.tgz",
-      "integrity": "sha512-zBqpfRo2myWPrPo5xUjeZqlnPXPXsX8BcWtWff66/eGRQdbPjhzPgXa/F+AtxT2afUViPxbuDlwscMKzQ5tg+g==",
-      "cpu": [
-        "riscv64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.140.0.tgz",
-      "integrity": "sha512-2M1DPm/8w9I//YzFlFC9qXw+r2tJFh5CYwRlYTq2vUJQS7qoQftEDeCZ8EnN7KHtvSiXvYj8mZI5pR7DpXmcEw==",
-      "cpu": [
-        "s390x"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-x64-gnu": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.140.0.tgz",
-      "integrity": "sha512-8aRDbZ/U/jO8N7go1MO72jtbpb4uswV8d7vOkMvt/BPgZiyEYvl1VIWK4ESxZZhnJ4tqwVldgX7dNiP/eB1Jdg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-linux-x64-musl": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.140.0.tgz",
-      "integrity": "sha512-xRqpeI8U2sQQS1W5BMWRyMTxtagkuLG2dEWruet5lFsWHTvBth11/TpSaJatHdqVVwHN0q3uuoS9zRsGinq8hg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-openharmony-arm64": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.140.0.tgz",
-      "integrity": "sha512-GbGRe26MqAKciFRvXeHNQJ6VAHYs9R4miP89sEAncysM3n+f4lnyLWgsa9kklJNpfnxdq2yRoNYHFqwBckVimw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-wasm32-wasi": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.140.0.tgz",
-      "integrity": "sha512-vFiC1hqys+hkX1GnQkIoiTQJNiUm43Z0lO35ETKXTw0YtpW7+cN58YRRXFAQQ+TgpkIi3lrhcxdlnqz+Oi3ptQ==",
-      "cpu": [
-        "wasm32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "1.11.2",
-        "@emnapi/runtime": "1.11.2",
-        "@napi-rs/wasm-runtime": "^1.1.6"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.140.0.tgz",
-      "integrity": "sha512-fGSQldwEYKhM+H8uLt76Op8hh5+FYaR6lvvQ1Txw3Mhn86DyQXLcI0fi1EkFlTK7F+46OCk/j0AJMzZQm6g5Xg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.140.0.tgz",
-      "integrity": "sha512-sDS2Bai+g3ZWYwfZqmosiSuFDBcVnZ3Ta6pszzsiJoLMqsJEWKcxXXbGa7b7yXr++W2lQNPb3ZRJ8czseqL7RA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-parser/binding-win32-x64-msvc": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.140.0.tgz",
-      "integrity": "sha512-kHbE1zWyb5OQgJA6/5P4WjiuB01sYdQwtZnSSyE58FQEXDAMnyeeq4vj7KgN75i5SlBzOs8A5MrtlD3gOlDKqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@unhead/bundler/node_modules/@oxc-project/types": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
-      "integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
     "node_modules/@unhead/bundler/node_modules/magic-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.0.0.tgz",
@@ -9119,51 +7870,14 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/@unhead/bundler/node_modules/oxc-parser": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.140.0.tgz",
-      "integrity": "sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@oxc-project/types": "^0.140.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      },
-      "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.140.0",
-        "@oxc-parser/binding-android-arm64": "0.140.0",
-        "@oxc-parser/binding-darwin-arm64": "0.140.0",
-        "@oxc-parser/binding-darwin-x64": "0.140.0",
-        "@oxc-parser/binding-freebsd-x64": "0.140.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.140.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.140.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.140.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.140.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.140.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.140.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.140.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.140.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.140.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.140.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.140.0"
-      }
-    },
     "node_modules/@unhead/vue": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.15.tgz",
-      "integrity": "sha512-SSByXfEjhzPn8gXdEdgpYqpLMPSkLUH2HVE0GxZfOtNsJ0GgOHQs0g9T67ZZ1z0kTELLKdtOtYrzrbv9+ffF7g==",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.16.tgz",
+      "integrity": "sha512-t6QykImeMJcrUTbFB0Coy0cB/OZItHdQFRFLoH8GAVXKWmQORGPrwvueP9me7adOCuMH2uVvrv0nCkbi6zksaA==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1",
-        "unhead": "2.1.15"
+        "unhead": "2.1.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -9443,6 +8157,40 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
       "version": "1.12.2",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
@@ -9555,11 +8303,464 @@
         "vite": "*"
       }
     },
-    "node_modules/@vitejs/devtools-kit/node_modules/nostics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
-      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
-      "license": "MIT"
+    "node_modules/@vitejs/devtools-kit/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-android-arm-eabi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.132.0.tgz",
+      "integrity": "sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-android-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm64/-/binding-android-arm64-0.132.0.tgz",
+      "integrity": "sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-darwin-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-arm64/-/binding-darwin-arm64-0.132.0.tgz",
+      "integrity": "sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-darwin-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-darwin-x64/-/binding-darwin-x64-0.132.0.tgz",
+      "integrity": "sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-freebsd-x64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-freebsd-x64/-/binding-freebsd-x64-0.132.0.tgz",
+      "integrity": "sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-arm-gnueabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-0.132.0.tgz",
+      "integrity": "sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-arm-musleabihf": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-0.132.0.tgz",
+      "integrity": "sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-arm64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-0.132.0.tgz",
+      "integrity": "sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-arm64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-arm64-musl/-/binding-linux-arm64-musl-0.132.0.tgz",
+      "integrity": "sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-ppc64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-0.132.0.tgz",
+      "integrity": "sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-riscv64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-0.132.0.tgz",
+      "integrity": "sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-riscv64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-0.132.0.tgz",
+      "integrity": "sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-s390x-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-0.132.0.tgz",
+      "integrity": "sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-x64-gnu": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-gnu/-/binding-linux-x64-gnu-0.132.0.tgz",
+      "integrity": "sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-linux-x64-musl": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-linux-x64-musl/-/binding-linux-x64-musl-0.132.0.tgz",
+      "integrity": "sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-openharmony-arm64": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-openharmony-arm64/-/binding-openharmony-arm64-0.132.0.tgz",
+      "integrity": "sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-wasm32-wasi": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-wasm32-wasi/-/binding-wasm32-wasi-0.132.0.tgz",
+      "integrity": "sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-win32-arm64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-0.132.0.tgz",
+      "integrity": "sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-win32-ia32-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-0.132.0.tgz",
+      "integrity": "sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-parser/binding-win32-x64-msvc": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-parser/binding-win32-x64-msvc/-/binding-win32-x64-msvc-0.132.0.tgz",
+      "integrity": "sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/devframe": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.5.4.tgz",
+      "integrity": "sha512-dbHU/LuptR1aMXcizjHUeY3gu7qVaRQoFYqbbyyGuO6Y+avFA4uQtwinHtG1qa7lRel/7b8JrBDm0nbnxU3vqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@valibot/to-json-schema": "^1.7.0",
+        "birpc": "^4.0.0",
+        "cac": "^7.0.0",
+        "h3": "2.0.1-rc.22",
+        "mrmime": "^2.0.1",
+        "nostics": "^0.2.0",
+        "pathe": "^2.0.3",
+        "valibot": "^1.4.1",
+        "ws": "^8.21.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/devframe/node_modules/nostics": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/nostics/-/nostics-0.2.0.tgz",
+      "integrity": "sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==",
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.21",
+        "oxc-parser": "^0.132.0",
+        "unplugin": "^3.0.0"
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/h3": {
+      "version": "2.0.1-rc.22",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
+      "integrity": "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==",
+      "license": "MIT",
+      "dependencies": {
+        "rou3": "^0.8.1",
+        "srvx": "^0.11.15"
+      },
+      "bin": {
+        "h3": "bin/h3.mjs"
+      },
+      "engines": {
+        "node": ">=20.11.1"
+      },
+      "peerDependencies": {
+        "crossws": "^0.4.1"
+      },
+      "peerDependenciesMeta": {
+        "crossws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitejs/devtools-kit/node_modules/oxc-parser": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
+      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "^0.132.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
+        "@oxc-parser/binding-android-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-arm64": "0.132.0",
+        "@oxc-parser/binding-darwin-x64": "0.132.0",
+        "@oxc-parser/binding-freebsd-x64": "0.132.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
+      }
     },
     "node_modules/@vitejs/plugin-vue": {
       "version": "6.0.8",
@@ -9629,9 +8830,9 @@
       }
     },
     "node_modules/@vitest/coverage-v8/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -9931,13 +9132,13 @@
       }
     },
     "node_modules/@vue/devtools-core": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.3.tgz",
-      "integrity": "sha512-xezkv5/CPH/o5C8PE2Len9MnTJMsctYYQbKbbUiNOJpKd+fRHj27nKDb/sbtYI8NSQduegeQhCJGKRgAiOV6Uw==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-core/-/devtools-core-8.1.5.tgz",
+      "integrity": "sha512-5e5jQOEssCdZA1wlFEUkIDtb+cAOWuLNWJ52fm4PBWbF7e3oTnM2fneaL42E5lJoolAaUQ678tv/XEb3h4e86Q==",
       "license": "MIT",
       "dependencies": {
-        "@vue/devtools-kit": "^8.1.3",
-        "@vue/devtools-shared": "^8.1.3"
+        "@vue/devtools-kit": "^8.1.5",
+        "@vue/devtools-shared": "^8.1.5"
       },
       "peerDependencies": {
         "vue": "^3.0.0"
@@ -10380,9 +9581,9 @@
       "license": "MIT"
     },
     "node_modules/archiver-utils/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -10526,9 +9727,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
-      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.5.tgz",
+      "integrity": "sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10559,6 +9760,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sxzz"
+      }
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
       }
     },
     "node_modules/async": {
@@ -10677,9 +9888,9 @@
       }
     },
     "node_modules/bare-fs": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
-      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.4.tgz",
+      "integrity": "sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -10700,23 +9911,11 @@
         }
       }
     },
-    "node_modules/bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
     "node_modules/bare-path": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
-      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
+      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/bare-stream": {
       "version": "2.13.3",
@@ -10775,9 +9974,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.43",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
-      "integrity": "sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==",
+      "version": "2.10.44",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.44.tgz",
+      "integrity": "sha512-T3ghW+sl/ZJ8w1v/yQx3qvJ9040DWoLBz8JT/CILbAKcFyG9b2MRe75v6W5uXjv6uH1lumK2Kv46y2zSkcej0Q==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -10836,9 +10035,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -10945,9 +10144,9 @@
       }
     },
     "node_modules/builtin-modules": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.2.0.tgz",
-      "integrity": "sha512-02yxLeyxF4dNl6SlY6/5HfRSrSdZ/sCPoxy2kZNP5dZZX8LSAD9aE2gtJIUgWrsQTiMPl3mxESyrobSwvRGisQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.3.0.tgz",
+      "integrity": "sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11337,9 +10536,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
-      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -11795,12 +10994,17 @@
       }
     },
     "node_modules/crossws": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
-      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.10.tgz",
+      "integrity": "sha512-pz3oubH/dt12KjqsUB0IuXW4nwRDQ583iDsP4555Cpdqx0NoU7pGlWBcayyFI8f/l/idRpgjMEfwuOxSWJYlIA==",
       "license": "MIT",
-      "dependencies": {
-        "uncrypto": "^0.1.3"
+      "peerDependencies": {
+        "srvx": ">=0.11.5"
+      },
+      "peerDependenciesMeta": {
+        "srvx": {
+          "optional": true
+        }
       }
     },
     "node_modules/csp_evaluator": {
@@ -12736,26 +11940,29 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
-      "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.2.tgz",
+      "integrity": "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA==",
       "license": "MIT"
     },
     "node_modules/devframe": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.5.4.tgz",
-      "integrity": "sha512-dbHU/LuptR1aMXcizjHUeY3gu7qVaRQoFYqbbyyGuO6Y+avFA4uQtwinHtG1qa7lRel/7b8JrBDm0nbnxU3vqg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/devframe/-/devframe-0.6.2.tgz",
+      "integrity": "sha512-/P2MPHZzCRyuzEqPOThTDbiCsvbT7OkL1lj9/p6yiUycmC5xfRx5lOhjURYggSyTzEpOSUuWtlicr53ohEFZ5Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@valibot/to-json-schema": "^1.7.0",
+        "@valibot/to-json-schema": "^1.7.1",
         "birpc": "^4.0.0",
         "cac": "^7.0.0",
+        "crossws": "^0.4.9",
+        "destr": "^2.0.5",
         "h3": "2.0.1-rc.22",
         "mrmime": "^2.0.1",
-        "nostics": "^0.2.0",
+        "nostics": "^1.1.4",
         "pathe": "^2.0.3",
-        "valibot": "^1.4.1",
-        "ws": "^8.21.0"
+        "ufo": "^1.6.4",
+        "valibot": "^1.4.2"
       },
       "peerDependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0"
@@ -12770,6 +11977,7 @@
       "version": "2.0.1-rc.22",
       "resolved": "https://registry.npmjs.org/h3/-/h3-2.0.1-rc.22.tgz",
       "integrity": "sha512-Esv0DMIuPkCTSWCA0vO73vcTqwzH1wjSrAO1TXNu/K3up1sZHa9EKMapbmxCDYBeymC3fVTk4qxp7ogQWQ+KgA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "rou3": "^0.8.1",
@@ -12805,9 +12013,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1625959",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1625959.tgz",
-      "integrity": "sha512-wRBSU330hwOLLcb3N4NIe3eFs6MgT6ku3AiZONjnTSJ7f3dVchJfn6nE0Lfos9jK1na15bgp7xLhaCx40Y47NQ==",
+      "version": "0.0.1663043",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1663043.tgz",
+      "integrity": "sha512-33aOY3ZnBP1dgZsshgaL+/XlsQleiFZgyUaDtdZkEa1nbZhVY1MoDeWjk+wxg25fU924l1ZJfoGNmjjeA/5s1w==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -12876,9 +12084,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -12993,9 +12201,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13044,9 +12252,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.393",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
-      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
+      "version": "1.5.394",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.394.tgz",
+      "integrity": "sha512-Wmt2Gm0o8JWBuGgmc4XZ0u9s1RaCRqhxP47phplmfg04+qypTUurpeJGP45A7Fhv7jdrrVH44PLlR9qXo37cVQ==",
       "license": "ISC"
     },
     "node_modules/embla-carousel": {
@@ -13262,9 +12470,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
@@ -13281,9 +12489,9 @@
       }
     },
     "node_modules/es-toolkit": {
-      "version": "1.48.1",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.48.1.tgz",
-      "integrity": "sha512-wfnXlwd5I75eXRtdD2vuEs50xHHESECDsGD7yiQnfFVNoa5522NwXEbmgo98LfiukSQHs+mBM7/YG3qKJB9/mQ==",
+      "version": "1.49.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.49.0.tgz",
+      "integrity": "sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==",
       "license": "MIT",
       "workspaces": [
         "docs",
@@ -13513,9 +12721,9 @@
       }
     },
     "node_modules/eslint-plugin-import-x": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.0.tgz",
-      "integrity": "sha512-aM7V25Bg6YuYxtEhwjafzfS0NTMds1D2PMQI0K4KqJxQJRtkP4CO+MQTWRdBq2qAnmPxTxLevhXUBtByxJqS1w==",
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
+      "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13550,13 +12758,13 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "63.0.7",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.7.tgz",
-      "integrity": "sha512-pxrqGO733F7xmVYB5vQOiciiT9uddxqehawnbPjZmW2YaJR6fT5cP3UQd2BNoE85ATspCMtNL8w/a5WDGX3Qwg==",
+      "version": "63.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.2.0.tgz",
+      "integrity": "sha512-tccz9igEV5mTKVAwo/KwXqKP7ENqa3a+LpRFuEPAP3k/+SXG4T0sOvA+c2wwTD/TLNrH9MCW4LIu4xEExkJdzg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.87.0",
+        "@es-joy/jsdoccomment": "~0.88.0",
         "@es-joy/resolve.exports": "1.2.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.7",
@@ -13567,7 +12775,7 @@
         "html-entities": "^2.6.0",
         "object-deep-merge": "^2.0.1",
         "parse-imports-exports": "^0.2.4",
-        "semver": "^7.8.2",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "to-valid-identifier": "^1.0.0"
       },
@@ -13621,9 +12829,9 @@
       }
     },
     "node_modules/eslint-plugin-regexp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-3.1.0.tgz",
-      "integrity": "sha512-qGXIC3DIKZHcK1H9A9+Byz9gmndY6TTSRkSMTZpNXdyCw2ObSehRgccJv35n9AdUakEjQp5VFNLas6BMXizCZg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-regexp/-/eslint-plugin-regexp-3.1.1.tgz",
+      "integrity": "sha512-MxR5nqoQCtVWmJwia0D2+NlXX1xzdpkslsVOZLEYQ4PQWEaL65PCZXURxaBc3lPnkNFpNxzMIRmYVxdl8giXRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13676,18 +12884,18 @@
       }
     },
     "node_modules/eslint-plugin-vue": {
-      "version": "10.9.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.9.2.tgz",
-      "integrity": "sha512-4g7ZP3pYcuqd7Zp0pzUKcos0W+RkjBz4EGdhJ92FcYk6v03Ti/GK5NwjgsjxHK+98eXDbHeK7VtX1az7/8doZA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-10.10.0.tgz",
+      "integrity": "sha512-dL9x9rBHqqNcByWiLOHK6L0SB97V82/NC0cZRn9cXPjM7pCuWlpQQP9bFH4vjBv80ej1ZpzAkuD8zWH1o9bZbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
+        "@eslint-community/eslint-utils": "^4.9.1",
         "natural-compare": "^1.4.0",
         "nth-check": "^2.1.1",
-        "postcss-selector-parser": "^7.1.0",
-        "semver": "^7.6.3",
-        "xml-name-validator": "^4.0.0"
+        "postcss-selector-parser": "^7.1.4",
+        "semver": "^7.8.5",
+        "xml-name-validator": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -14045,22 +13253,10 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/execa/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/expect-type": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
-      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -14165,9 +13361,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -14372,16 +13568,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/flat-cache/node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.1"
-      }
-    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -14488,13 +13674,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/forwarded-parse": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
-      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -14509,12 +13688,12 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.41.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.41.0.tgz",
-      "integrity": "sha512-OHAMNiCEON1RDBlRGuulsN5AD8ptMjvk5QWfFmYmBLPZ3zFGIJe60kQucQQf4cez1OzQmjYBWDY+dYfISkUdqg==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.42.2.tgz",
+      "integrity": "sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.41.0",
+        "motion-dom": "^12.42.2",
         "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
@@ -14778,9 +13957,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
-      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.2.tgz",
+      "integrity": "sha512-NLvV9ubZ6NDsJaOpKPy3cQeJpKi9DcWiyCiFUpJPA0YihRqiE6RWaLUmgNNPr8MgPpLZjnBjSmou7uZBRJv9wA==",
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -14884,6 +14063,15 @@
         "crossws": {
           "optional": true
         }
+      }
+    },
+    "node_modules/h3/node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
       }
     },
     "node_modules/hachure-fill": {
@@ -15124,9 +14312,9 @@
       }
     },
     "node_modules/http-link-header": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
-      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.4.tgz",
+      "integrity": "sha512-xT3GPW6/ZbGuw4UvwHqErSCEjNUlwbQJuZn9/q5U4WEKfp2kENVCAlousG1zLxHeaQ/ffOHUNpWamvkbBW0eNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15157,9 +14345,9 @@
       }
     },
     "node_modules/httpxy": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.3.tgz",
-      "integrity": "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
       "license": "MIT"
     },
     "node_modules/human-signals": {
@@ -15172,9 +14360,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -15231,16 +14419,18 @@
       "license": "MIT"
     },
     "node_modules/import-in-the-middle": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.15.0.tgz",
-      "integrity": "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
+      "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.14.0",
-        "acorn-import-attributes": "^1.9.5",
-        "cjs-module-lexer": "^1.2.2",
-        "module-details-from-path": "^1.0.3"
+        "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/import-meta-resolve": {
@@ -15620,6 +14810,18 @@
         "@types/estree": "*"
       }
     },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -15784,9 +14986,9 @@
       "license": "MIT"
     },
     "node_modules/js-beautify/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15879,9 +15081,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
       "funding": [
         {
@@ -16091,6 +15293,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/khroma": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
@@ -16226,19 +15438,19 @@
       }
     },
     "node_modules/lighthouse": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.4.0.tgz",
-      "integrity": "sha512-QumN5pLuQvLLGWpIeUe7+LBH7oHgd0BdD3wIIncVTXe+5wiLBiO2E7pQjNDUWu1si1r0iPKtXOPTZ0sUPXHivA==",
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-13.4.1.tgz",
+      "integrity": "sha512-fDu8lt3QLK/lTqIxtp1HkzQNJ32rsFHhbadYOepcMZFLgA8oINhxutMbMv8XXnpTOvZ0TXCo4JCk1LDTWaRLnA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@paulirish/trace_engine": "0.0.65",
-        "@sentry/node": "^9.28.1",
-        "axe-core": "^4.12.0",
+        "@sentry/node": "^10.0.0",
+        "axe-core": "^4.12.1",
         "chrome-launcher": "^1.2.1",
         "configstore": "^7.0.0",
         "csp_evaluator": "1.1.8",
-        "devtools-protocol": "0.0.1625959",
+        "devtools-protocol": "0.0.1663043",
         "enquirer": "^2.3.6",
         "http-link-header": "^1.1.1",
         "intl-messageformat": "^10.5.3",
@@ -16249,12 +15461,12 @@
         "lodash-es": "^4.17.21",
         "lookup-closest-locale": "6.2.0",
         "open": "^8.4.0",
-        "puppeteer-core": "^25.0.2",
+        "puppeteer-core": "^25.3.0",
         "robots-parser": "^3.0.1",
         "speedline-core": "^1.4.3",
         "third-party-web": "^0.29.2",
-        "tldts-icann": "^7.4.2",
-        "web-features": "^3.30.0",
+        "tldts-icann": "^7.4.9",
+        "web-features": "^3.34.0",
         "ws": "^7.0.0",
         "yargs": "^17.3.1",
         "yargs-parser": "^21.0.0"
@@ -16320,9 +15532,9 @@
       }
     },
     "node_modules/lighthouse/node_modules/ws": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16648,33 +15860,39 @@
       "license": "MIT"
     },
     "node_modules/listhen": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.10.0.tgz",
-      "integrity": "sha512-kfz4C0OrC6IpaVMtYDJtf6PFjurxe9NBBoDAh/o2p587INryFOO4DQ9OetbCdDrWFt1m1CJKvYrzkGsuPHw8nQ==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/listhen/-/listhen-1.10.1.tgz",
+      "integrity": "sha512-6nt/86SkqUQSLW1ofz8MxC6RhRMqOl3ONISe6qqvJ3xj09aJWQx6DhgSZpugs3PX4PXdOas/WD6A9jx6J2N19A==",
       "license": "MIT",
       "dependencies": {
-        "@parcel/watcher": "^2.5.6",
         "@parcel/watcher-wasm": "^2.5.6",
         "citty": "^0.2.2",
         "consola": "^3.4.2",
-        "crossws": ">=0.2.0 <0.5.0",
+        "crossws": "^0.4.10",
         "defu": "^6.1.7",
         "get-port-please": "^3.2.0",
         "h3": "^1.15.11",
         "http-shutdown": "^1.2.2",
-        "jiti": "^2.6.1",
-        "mlly": "^1.8.2",
+        "jiti": "^2.7.0",
         "node-forge": "^1.4.0",
         "pathe": "^2.0.3",
-        "std-env": "^4.1.0",
-        "tinyclip": "^0.1.12",
+        "std-env": "^4.2.0",
+        "tinyclip": "^0.1.15",
         "ufo": "^1.6.4",
-        "untun": "^0.1.3",
+        "untun": "^0.2.2",
         "uqr": "^0.1.3"
       },
       "bin": {
         "listen": "bin/listhen.mjs",
         "listhen": "bin/listhen.mjs"
+      },
+      "peerDependencies": {
+        "@parcel/watcher": "^2.5.6"
+      },
+      "peerDependenciesMeta": {
+        "@parcel/watcher": {
+          "optional": true
+        }
       }
     },
     "node_modules/listhen/node_modules/citty": {
@@ -16684,9 +15902,9 @@
       "license": "MIT"
     },
     "node_modules/listhen/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "license": "MIT"
     },
     "node_modules/local-pkg": {
@@ -16763,9 +15981,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -17062,6 +16280,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/mermaid": {
@@ -17807,9 +17035,9 @@
       "license": "MIT"
     },
     "node_modules/modern-tar": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.6.tgz",
-      "integrity": "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg==",
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.7.tgz",
+      "integrity": "sha512-t9VmxaqrmANnEOBhpSDI6HD192Ge48k8vmWqQQL7hSFEqHEYwZbbsu49+aKLWZeRvFs3j1pMhXOqqF4kPlvjkQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17824,9 +17052,9 @@
       "license": "MIT"
     },
     "node_modules/motion-dom": {
-      "version": "12.41.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.41.0.tgz",
-      "integrity": "sha512-Lk3J39fOGg6xNr1KRZsN6usDyBf8aP7MEbUPez1VCughHt79OrP7VGqNrPyFL0riaT7WS8t9DRw1M3BHtM/xKw==",
+      "version": "12.42.2",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.42.2.tgz",
+      "integrity": "sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.39.0"
@@ -18519,6 +17747,15 @@
       "integrity": "sha512-aVf4A4hI2w70LnF7GG+7xDQUkliwiXWXFvTjkip4+b64ygDQ2sJPRSKFDHbxn8o0xu9QzPkMuuiWIXyFSE2slA==",
       "license": "MIT"
     },
+    "node_modules/nitropack/node_modules/crossws": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
+    },
     "node_modules/nitropack/node_modules/dot-prop": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-10.1.0.tgz",
@@ -18593,17 +17830,47 @@
       "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
       "license": "MIT"
     },
+    "node_modules/nitropack/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/nitropack/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "license": "MIT"
     },
-    "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+    "node_modules/nitropack/node_modules/unctx": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21",
+        "unplugin": "^2.3.11"
+      }
+    },
+    "node_modules/nitropack/node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -18720,15 +17987,10 @@
       }
     },
     "node_modules/nostics": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/nostics/-/nostics-0.2.0.tgz",
-      "integrity": "sha512-/WQpI46UMbqvy1okYb+V+9wW3J8/m6GJ33wm691n/tyi6YtJiZ6ssJjENAU7y4evfYrrgYN9HllKDzPvffil1w==",
-      "license": "MIT",
-      "dependencies": {
-        "magic-string": "^0.30.21",
-        "oxc-parser": "^0.132.0",
-        "unplugin": "^3.0.0"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
+      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
+      "license": "MIT"
     },
     "node_modules/npm-install-checks": {
       "version": "8.0.0",
@@ -18933,9 +18195,9 @@
       }
     },
     "node_modules/nuxt-neo4j/node_modules/@nuxt/kit": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.8.tgz",
-      "integrity": "sha512-kg63DUPY5AHPn+9XM7u8rYcdWHXjzwfUscgRDuiC5YUciQ+xdLRhdwXelYFxEAx2nxJHossliiQXbMm/Fleivw==",
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-3.21.9.tgz",
+      "integrity": "sha512-SJ3W7INBJLwnmFQPm2BACiqS25enc6QIm87aLQCcxo/TFtRnWanYtgDdwyHqUHgOAGmq9pYjgk83B2bpBKnDTw==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
@@ -18943,8 +18205,8 @@
         "defu": "^6.1.7",
         "destr": "^2.0.5",
         "errx": "^0.1.0",
-        "exsolve": "^1.0.8",
-        "ignore": "^7.0.5",
+        "exsolve": "^1.1.0",
+        "ignore": "^7.0.6",
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
         "knitwork": "^1.3.0",
@@ -18954,8 +18216,8 @@
         "pkg-types": "^2.3.1",
         "rc9": "^3.0.1",
         "scule": "^1.3.0",
-        "semver": "^7.8.0",
-        "tinyglobby": "^0.2.16",
+        "semver": "^7.8.5",
+        "tinyglobby": "^0.2.17",
         "ufo": "^1.6.4",
         "unctx": "^2.5.0",
         "untyped": "^2.0.0"
@@ -18965,16 +18227,16 @@
       }
     },
     "node_modules/nuxt-neo4j/node_modules/@nuxt/schema": {
-      "version": "3.21.8",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.21.8.tgz",
-      "integrity": "sha512-BMxtf2x0E9sFji4Txz1boeMiwkhjQQFixdB6+lZXvCGpExZou4TLz82LDcIAZkpJVL0IEcfs96hTLVVBkjGulQ==",
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-3.21.9.tgz",
+      "integrity": "sha512-Di5iWRFey7nwqdAzbHRrkom39cH6VY3cqxMBlGUw3jzVvcfLACkslOQIzhDgf0u7ADxweedABiqSDFaV2KtVxw==",
       "license": "MIT",
       "dependencies": {
-        "@vue/shared": "^3.5.34",
+        "@vue/shared": "^3.5.40",
         "defu": "^6.1.7",
         "pathe": "^2.0.3",
         "pkg-types": "^2.3.1",
-        "std-env": "^4.1.0"
+        "std-env": "^4.2.0"
       },
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
@@ -19024,18 +18286,6 @@
         "node": ">=14.18.0"
       }
     },
-    "node_modules/nuxt-neo4j/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/nuxt-neo4j/node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -19043,10 +18293,37 @@
       "license": "ISC"
     },
     "node_modules/nuxt-neo4j/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "license": "MIT"
+    },
+    "node_modules/nuxt-neo4j/node_modules/unctx": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
+      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21",
+        "unplugin": "^2.3.11"
+      }
+    },
+    "node_modules/nuxt-neo4j/node_modules/unplugin": {
+      "version": "2.3.11",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "acorn": "^8.15.0",
+        "picomatch": "^4.0.3",
+        "webpack-virtual-modules": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
     },
     "node_modules/nuxt/node_modules/@unhead/vue": {
       "version": "3.2.1",
@@ -19103,12 +18380,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/nuxt/node_modules/nostics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
-      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
-      "license": "MIT"
-    },
     "node_modules/nuxt/node_modules/rou3": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/rou3/-/rou3-0.9.1.tgz",
@@ -19121,36 +18392,10 @@
       "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "license": "MIT"
     },
-    "node_modules/nuxt/node_modules/unctx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
-      "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "magic-string": ">=0.30.21",
-        "oxc-parser": ">=0.140.0",
-        "rolldown": "^1.1.5",
-        "unplugin": "^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "magic-string": {
-          "optional": true
-        },
-        "oxc-parser": {
-          "optional": true
-        },
-        "rolldown": {
-          "optional": true
-        },
-        "unplugin": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/nuxt/node_modules/undici": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.7.0.tgz",
-      "integrity": "sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
+      "integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"
@@ -19252,9 +18497,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
-      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
       "funding": [
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
@@ -19424,12 +18669,12 @@
       "license": "MIT"
     },
     "node_modules/oxc-parser": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.132.0.tgz",
-      "integrity": "sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==",
+      "version": "0.140.0",
+      "resolved": "https://registry.npmjs.org/oxc-parser/-/oxc-parser-0.140.0.tgz",
+      "integrity": "sha512-h6QFWd6lBMfjESqgQ27GjzrSDb0qbznp7VDQqp2zvgsrWut4vcchyMIzOVXvGQ2GMZgKw9RWrFNWv9WqGL0p7Q==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "^0.132.0"
+        "@oxc-project/types": "^0.140.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -19438,26 +18683,26 @@
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-parser/binding-android-arm-eabi": "0.132.0",
-        "@oxc-parser/binding-android-arm64": "0.132.0",
-        "@oxc-parser/binding-darwin-arm64": "0.132.0",
-        "@oxc-parser/binding-darwin-x64": "0.132.0",
-        "@oxc-parser/binding-freebsd-x64": "0.132.0",
-        "@oxc-parser/binding-linux-arm-gnueabihf": "0.132.0",
-        "@oxc-parser/binding-linux-arm-musleabihf": "0.132.0",
-        "@oxc-parser/binding-linux-arm64-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-arm64-musl": "0.132.0",
-        "@oxc-parser/binding-linux-ppc64-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-riscv64-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-riscv64-musl": "0.132.0",
-        "@oxc-parser/binding-linux-s390x-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-x64-gnu": "0.132.0",
-        "@oxc-parser/binding-linux-x64-musl": "0.132.0",
-        "@oxc-parser/binding-openharmony-arm64": "0.132.0",
-        "@oxc-parser/binding-wasm32-wasi": "0.132.0",
-        "@oxc-parser/binding-win32-arm64-msvc": "0.132.0",
-        "@oxc-parser/binding-win32-ia32-msvc": "0.132.0",
-        "@oxc-parser/binding-win32-x64-msvc": "0.132.0"
+        "@oxc-parser/binding-android-arm-eabi": "0.140.0",
+        "@oxc-parser/binding-android-arm64": "0.140.0",
+        "@oxc-parser/binding-darwin-arm64": "0.140.0",
+        "@oxc-parser/binding-darwin-x64": "0.140.0",
+        "@oxc-parser/binding-freebsd-x64": "0.140.0",
+        "@oxc-parser/binding-linux-arm-gnueabihf": "0.140.0",
+        "@oxc-parser/binding-linux-arm-musleabihf": "0.140.0",
+        "@oxc-parser/binding-linux-arm64-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-arm64-musl": "0.140.0",
+        "@oxc-parser/binding-linux-ppc64-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-riscv64-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-riscv64-musl": "0.140.0",
+        "@oxc-parser/binding-linux-s390x-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-x64-gnu": "0.140.0",
+        "@oxc-parser/binding-linux-x64-musl": "0.140.0",
+        "@oxc-parser/binding-openharmony-arm64": "0.140.0",
+        "@oxc-parser/binding-wasm32-wasi": "0.140.0",
+        "@oxc-parser/binding-win32-arm64-msvc": "0.140.0",
+        "@oxc-parser/binding-win32-ia32-msvc": "0.140.0",
+        "@oxc-parser/binding-win32-x64-msvc": "0.140.0"
       }
     },
     "node_modules/oxc-walker": {
@@ -19532,9 +18777,9 @@
       "license": "BlueOak-1.0.0"
     },
     "node_modules/package-manager-detector": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
-      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
       "license": "MIT"
     },
     "node_modules/packageurl-js": {
@@ -19842,40 +19087,6 @@
       "integrity": "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==",
       "license": "MIT"
     },
-    "node_modules/pg-int8": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
-      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/pg-protocol": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.15.0.tgz",
-      "integrity": "sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/pg-types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
-      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pg-int8": "1.0.1",
-        "postgres-array": "~2.0.0",
-        "postgres-bytea": "~1.0.0",
-        "postgres-date": "~1.0.4",
-        "postgres-interval": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -20001,9 +19212,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -20460,49 +19671,6 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
-    "node_modules/postgres-array": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
-      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postgres-bytea": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
-      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-date": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
-      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/postgres-interval": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
-      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xtend": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -20516,13 +19684,21 @@
       }
     },
     "node_modules/preact": {
-      "version": "10.29.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.2.tgz",
-      "integrity": "sha512-7tNmwg/7mzzAoB/8kSg6Hl37JraAZw3Z3A0JSY7VXlZwo82Xn0G7wKbNNs2qoF4ZEEsQGTwDAroNdqKs1ofJxQ==",
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
       }
     },
     "node_modules/preact-render-to-string": {
@@ -20548,9 +19724,9 @@
       }
     },
     "node_modules/pretty-bytes": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.0.tgz",
-      "integrity": "sha512-nODzvTiYVRGRqAOvE84Vk5JDPyyxsVk0/fbA/bq7RqlnhksGpset09XTxbpvLTIjoaF7K8Z8DG8yHtKGTPSYRw==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-7.1.1.tgz",
+      "integrity": "sha512-X+vn9z8nOFZQlxOLmfJ0iKDdMD7jYTsTW12OAlCpdoE3Igik6L37pugIZi+N3usuyp5McfgKPWi12q3zvHLeGQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -20796,13 +19972,13 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.2.0.tgz",
-      "integrity": "sha512-jGhuGAlkgOcbyGRc0Cm9b/y4vvqoxhyAyl6a1diVe8F3sHsgTaQ60QQT5F3rGegTZV3prysgHVc+0LsvPZo3GA==",
+      "version": "25.3.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-25.3.0.tgz",
+      "integrity": "sha512-fm+wpUr2oigH1PXZvwgATrM2tYWHMDG8ASzTEe9uukCye4X5Ldx1K5BTHPFKITrIWvQQAQ256d1NpbEveBcKjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "3.0.5",
+        "@puppeteer/browsers": "3.0.6",
         "chromium-bidi": "16.0.1",
         "devtools-protocol": "0.0.1638949",
         "typed-query-selector": "^2.12.2",
@@ -20886,12 +20062,16 @@
       "license": "MIT"
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -21016,9 +20196,9 @@
       "license": "MIT"
     },
     "node_modules/readdir-glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -21193,18 +20373,17 @@
       }
     },
     "node_modules/require-in-the-middle": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
-      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
-        "module-details-from-path": "^1.0.3",
-        "resolve": "^1.22.8"
+        "module-details-from-path": "^1.0.3"
       },
       "engines": {
-        "node": ">=8.6.0"
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/requrl": {
@@ -21366,15 +20545,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/rolldown/node_modules/@oxc-project/types": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.140.0.tgz",
-      "integrity": "sha512-h5LUOzGArYemnW1NMz/DuuQhBi96J6JL2Bk8zE4kvqxB5Sg3jxmCiH4uyOWHDkiKSt5vWlG4FIwCR/DbstcNRQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Boshen"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
@@ -21479,6 +20649,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/rope-sequence": {
@@ -21653,6 +20832,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -21710,9 +20896,9 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.6.tgz",
-      "integrity": "sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=20.0.0"
@@ -21865,13 +21051,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
       "version": "1.1.1",
@@ -22049,12 +21228,12 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 12"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -22074,15 +21253,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/spdx-correct": {
@@ -22463,9 +21633,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-      "integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+      "integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
       "license": "MIT",
       "dependencies": {
         "commander": "^11.1.0",
@@ -22686,9 +21856,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.48.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-      "integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+      "version": "5.49.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+      "integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -22814,20 +21984,20 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.4.tgz",
-      "integrity": "sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts-icann": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.4.tgz",
-      "integrity": "sha512-dWoPOFTKO8ueaPsSpohPUsd5DWsRREa7P5WdKPVOwoLaNdSLfYatWtJEpS9DXRh/q/4ErhpqUF1Qp79qK1IzFA==",
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.4.9.tgz",
+      "integrity": "sha512-q6gyxCkcFPu5OZd2hi2quysxCG3ejIi53EACesbCEZHhH7FO3HnliqwO5zUs0TV6dA54SxhCrTGAc4ugl7rTiw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.4"
+        "tldts-core": "^7.4.9"
       }
     },
     "node_modules/tmp": {
@@ -23451,9 +22621,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -23498,38 +22668,17 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
-      "dev": true,
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "node": ">=14.17"
       }
     },
     "node_modules/uc.micro": {
@@ -23558,30 +22707,29 @@
       "license": "MIT"
     },
     "node_modules/unctx": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-2.5.0.tgz",
-      "integrity": "sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
+      "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
       "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.21",
-        "unplugin": "^2.3.11"
-      }
-    },
-    "node_modules/unctx/node_modules/unplugin": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "acorn": "^8.15.0",
-        "picomatch": "^4.0.3",
-        "webpack-virtual-modules": "^0.6.2"
+      "peerDependencies": {
+        "magic-string": ">=0.30.21",
+        "oxc-parser": ">=0.140.0",
+        "rolldown": "^1.1.5",
+        "unplugin": "^3.3.0"
       },
-      "engines": {
-        "node": ">=18.12.0"
+      "peerDependenciesMeta": {
+        "magic-string": {
+          "optional": true
+        },
+        "oxc-parser": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        },
+        "unplugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/undici": {
@@ -23610,9 +22758,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.15.tgz",
-      "integrity": "sha512-MCt5T90mCWyr3Z6pUCdM9lVRXoMoVBlL7z7U4CYVIiaDiuzad/UCfLuMqz5MeNmpZUgoBCQnrucJimU7EZR+XA==",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.16.tgz",
+      "integrity": "sha512-cD2Q4a6SQHhW9/bPp17NT4GJ1yS0DSLe75WEHKQ8bKa/wjB6cIki3KeL86hhllNBcpv8i6bxdwtwQunneXPqKQ==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1"
@@ -23645,9 +22793,9 @@
       }
     },
     "node_modules/unimport": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.3.0.tgz",
-      "integrity": "sha512-M+Dxk5W9WRd+8j56W9tp8lGW/dmMc7g5zj7BWQnEjKQhryBstqsi1V0izb0zHwSkEN8cSYV7K75/bykairV2tA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/unimport/-/unimport-6.3.1.tgz",
+      "integrity": "sha512-43BV4iELfhpZ0JNSedMNdBqomAIaJwBrmTqIUYRb8ly3XVQihcRPAVIOSwb23XVCJgtjSf+f82d5Qpdsxqh8iQ==",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.16.0",
@@ -24056,24 +23204,13 @@
       }
     },
     "node_modules/untun": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/untun/-/untun-0.1.3.tgz",
-      "integrity": "sha512-4luGP9LMYszMRZwsvyUd9MrxgEGZdZuZgpVQHEEX0lCYFESasVRvZd0EYpCkOIbJKHMuv0LskpXc/8Un+MJzEQ==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/untun/-/untun-0.2.2.tgz",
+      "integrity": "sha512-+NnOJcSiEtYsVgJmXUzQbJeRAFXJC4yPJYuh6kF9B0Rm6zunXcs/3GZOTllyocSbUDIxD6Bj7e/4ATw7sph1Sw==",
       "license": "MIT",
-      "dependencies": {
-        "citty": "^0.1.5",
-        "consola": "^3.2.3",
-        "pathe": "^1.1.1"
-      },
       "bin": {
-        "untun": "bin/untun.mjs"
+        "untun": "dist/cli.mjs"
       }
-    },
-    "node_modules/untun/node_modules/pathe": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-      "license": "MIT"
     },
     "node_modules/untyped": {
       "version": "2.0.0",
@@ -24188,9 +23325,9 @@
       }
     },
     "node_modules/valibot": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
-      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.2.tgz",
+      "integrity": "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==",
       "license": "MIT",
       "peerDependencies": {
         "typescript": ">=5"
@@ -24612,16 +23749,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/vite/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
-      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/vite/node_modules/@oxc-project/types": {
       "version": "0.139.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
@@ -24718,9 +23845,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24736,9 +23860,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -24756,9 +23877,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24774,9 +23892,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -24794,9 +23909,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24812,9 +23924,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -25039,9 +24148,9 @@
       }
     },
     "node_modules/vitest/node_modules/std-env": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
-      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -25250,12 +24359,6 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "node_modules/vue-router/node_modules/nostics": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nostics/-/nostics-1.2.0.tgz",
-      "integrity": "sha512-FGqEfhQjrvo1lL8KFifdTQiNwwQHJxC1jtYE1Rc54qF/jxONUNL+kC9gS1krX8Q65PgrQ5fCqH/I4NhWBvdSqg==",
-      "license": "MIT"
-    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
@@ -25272,9 +24375,9 @@
       }
     },
     "node_modules/web-features": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.31.0.tgz",
-      "integrity": "sha512-1idHNJCaQzzfLRofi/b2Vzm6OVyV1wFM5djpopXu+WbGbM7EsZWwPGT2ORHsD4ZbQf2QbP9vyagJYrfIAoN90w==",
+      "version": "3.34.1",
+      "resolved": "https://registry.npmjs.org/web-features/-/web-features-3.34.1.tgz",
+      "integrity": "sha512-x+TGFo3TzB8dmXHNvveQXmaoYhzNH6blW93TO0u1Ygvr8/Bk3KIFZC9LVofHNnkcEmeodh8P3Mes5fPWyO7ATA==",
       "dev": true,
       "license": "Apache-2.0"
     },
@@ -25485,9 +24588,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -25562,13 +24665,13 @@
       }
     },
     "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
-      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/xmlbuilder": {
@@ -25604,16 +24707,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "patch-package": "^8.0.1",
     "swagger-jsdoc": "^6.3.0",
     "tailwindcss": "^4.3.2",
-    "typescript": "^7.0.2",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.10"
   }
 }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -3471,6 +3471,68 @@
         }
       }
     },
+    "/technologies/{name}/graph": {
+      "get": {
+        "tags": [
+          "Technologies"
+        ],
+        "summary": "Get impact/blast-radius graph data for a technology",
+        "description": "Returns every system using this technology, that system's owning\nteam, and the owning team's own TIME approval for the technology\n(never an unrelated approving team's). Used to answer \"what's the\nblast radius if we eliminate this technology?\"\n",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Technology name",
+            "example": "React"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Graph data returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/ApiSingleResourceResponse"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "object",
+                          "properties": {
+                            "technology": {
+                              "type": "string"
+                            },
+                            "systems": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Technology name is required"
+          },
+          "404": {
+            "description": "Technology not found"
+          }
+        }
+      }
+    },
     "/technologies/{name}/components": {
       "post": {
         "tags": [

--- a/server/api/technologies/[name]/graph.get.ts
+++ b/server/api/technologies/[name]/graph.get.ts
@@ -1,0 +1,58 @@
+import { technologyService } from '../../../services/singletons'
+import { sendSuccess, sendNotFound, sendBadRequest } from '../../../utils/response'
+
+/**
+ * @openapi
+ * /technologies/{name}/graph:
+ *   get:
+ *     tags:
+ *       - Technologies
+ *     summary: Get impact/blast-radius graph data for a technology
+ *     description: |
+ *       Returns every system using this technology, that system's owning
+ *       team, and the owning team's own TIME approval for the technology
+ *       (never an unrelated approving team's). Used to answer "what's the
+ *       blast radius if we eliminate this technology?"
+ *     parameters:
+ *       - in: path
+ *         name: name
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Technology name
+ *         example: React
+ *     responses:
+ *       200:
+ *         description: Graph data returned
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiSingleResourceResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: object
+ *                       properties:
+ *                         technology:
+ *                           type: string
+ *                         systems:
+ *                           type: array
+ *                           items:
+ *                             type: object
+ *       400:
+ *         description: Technology name is required
+ *       404:
+ *         description: Technology not found
+ */
+export default defineEventHandler(async (event) => {
+  const rawName = getRouterParam(event, 'name')
+  if (!rawName) return sendBadRequest('Technology name is required')
+
+  const name = decodeURIComponent(rawName)
+  const systems = await technologyService.getGraph(name)
+
+  if (systems === null) return sendNotFound('Technology', name)
+
+  return sendSuccess(event, { technology: name, systems })
+})

--- a/server/database/queries/technologies/graph.cypher
+++ b/server/database/queries/technologies/graph.cypher
@@ -1,0 +1,41 @@
+// Impact/blast-radius graph: for every system using this technology, resolve
+// the system's owning team and that team's own TIME approval for the
+// technology (never an unrelated approving team's).
+//
+// Returns zero rows when the technology does not exist. Returns a single
+// row with systemName = null when the technology exists but no system uses
+// it (same not-found-vs-empty sentinel convention as systems/graph.cypher).
+MATCH (tech:Technology {name: $name})
+OPTIONAL MATCH (sys:System)-[:USES]->(comp:Component)-[:IS_VERSION_OF]->(tech)
+WITH tech, sys, collect(DISTINCT comp.version) AS versions
+
+// Pin exactly one owning team per system deterministically, same trick
+// find-by-name.cypher uses to pin the steward team (ORDER BY immediately
+// before collect() -- Cypher's collect() has no guaranteed order otherwise).
+OPTIONAL MATCH (owningTeam:Team)-[:OWNS]->(sys)
+WITH tech, sys, versions, owningTeam
+ORDER BY owningTeam.name
+WITH tech, sys, versions, collect(owningTeam)[0] AS team
+
+// Resolve the OWNING team's own APPROVES edge to this technology.
+// Environment-specific approval takes precedence over a blanket
+// (environment IS NULL) approval -- mirrors the precedence already
+// established in compliance/find-violations.cypher, so this graph agrees
+// with the violations page about which systems are "approved".
+OPTIONAL MATCH (team)-[envA:APPROVES]->(tech)
+  WHERE sys.environment IS NOT NULL AND envA.environment = sys.environment
+OPTIONAL MATCH (team)-[blankA:APPROVES]->(tech)
+  WHERE blankA.environment IS NULL
+WITH tech, sys, versions, team,
+     head(collect(DISTINCT envA)) AS envApproval,
+     head(collect(DISTINCT blankA)) AS blankApproval
+WITH tech, sys, versions, team, coalesce(envApproval, blankApproval) AS approval
+
+RETURN
+  sys.name AS systemName,
+  team.name AS ownerTeamName,
+  sys.environment AS environment,
+  approval IS NOT NULL AS approved,
+  approval.time AS time,
+  [v IN versions WHERE v IS NOT NULL | v] AS versions
+ORDER BY sys.name

--- a/server/repositories/technology.repository.ts
+++ b/server/repositories/technology.repository.ts
@@ -1,6 +1,6 @@
 import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
-import type { Technology, TechnologyLifecycleSummary, TechnologyVersionLifecycle } from '~~/types/api'
+import type { Technology, TechnologyLifecycleSummary, TechnologyVersionLifecycle, TimeValue } from '~~/types/api'
 import { buildOrderByClause, type SortParams, type SortConfig } from '../utils/sorting'
 import { buildCreateChanges } from '../utils/audit-diff'
 import { toDateString } from '../utils/neo4j'
@@ -54,6 +54,15 @@ export interface TechnologyVersionDetail {
   eolDate: string | null
   approved: boolean | null
   notes: string | null
+}
+
+export interface TechnologyGraphRow {
+  systemName: string
+  ownerTeamName: string | null
+  environment: string | null
+  approved: boolean
+  time: TimeValue | null
+  versions: string[]
 }
 
 export interface TechnologyDetail extends Omit<Technology, 'versions'> {
@@ -133,6 +142,37 @@ export class TechnologyRepository extends BaseRepository {
     }
     
     return this.mapToTechnologyDetail(records[0]!)
+  }
+
+  /**
+   * Get impact/blast-radius graph data for a technology: every system using
+   * it, that system's owning team, and the owning team's own TIME approval
+   * for this technology (never an unrelated approving team's).
+   *
+   * Returns null when the technology does not exist.
+   * Returns an empty array when the technology exists but no system uses it.
+   *
+   * @param name - Technology name
+   * @returns Array of per-system rows, or null if technology not found
+   */
+  async getGraph(name: string): Promise<TechnologyGraphRow[] | null> {
+    const query = await loadQuery('technologies/graph.cypher')
+    const { records } = await this.executeQuery(query, { name })
+
+    // Zero rows → technology not found
+    if (records.length === 0) return null
+
+    // One row with systemName = null → technology exists but no system uses it
+    if (records.length === 1 && records[0]!.get('systemName') === null) return []
+
+    return records.map(record => ({
+      systemName: record.get('systemName') as string,
+      ownerTeamName: record.get('ownerTeamName') as string | null,
+      environment: record.get('environment') as string | null,
+      approved: record.get('approved') as boolean,
+      time: record.get('time') as TimeValue | null,
+      versions: (record.get('versions') as string[]) ?? [],
+    }))
   }
 
   /**

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -1,4 +1,4 @@
-import { TechnologyRepository, type TechnologyDetail, type CreateTechnologyFromComponentParams, type UpdateTechnologyParams, type UpsertApprovalParams } from '../repositories/technology.repository'
+import { TechnologyRepository, type TechnologyDetail, type TechnologyGraphRow, type CreateTechnologyFromComponentParams, type UpdateTechnologyParams, type UpsertApprovalParams } from '../repositories/technology.repository'
 import { SBOMRepository } from '../repositories/sbom.repository'
 import type { EOLStatus, EOLStatusValue, Technology, ComponentType, TechnologyDomain, TimeValue, TechnologyLifecycleSummary, TechnologyVersionLifecycle } from '~~/types/api'
 import type { SortParams } from '../utils/sorting'
@@ -210,6 +210,21 @@ export class TechnologyService {
    */
   async findOwnerTeam(name: string): Promise<{ name: string; ownerTeam: string | null } | null> {
     return await this.techRepo.findOwnerTeam(name)
+  }
+
+  /**
+   * Get impact/blast-radius graph data for a technology: every system using
+   * it, that system's owning team, and the owning team's own TIME approval.
+   *
+   * A pure passthrough — deliberately does not merge EOL/lifecycle data the
+   * way findByName() does, since that's outside this view's scope and would
+   * add a per-version EOL lookup across potentially many systems.
+   *
+   * @param name - Technology name
+   * @returns Array of per-system rows, or null if technology not found
+   */
+  async getGraph(name: string): Promise<TechnologyGraphRow[] | null> {
+    return this.techRepo.getGraph(name)
   }
 
   /**

--- a/test/app/pages/technologies/impact.test.ts
+++ b/test/app/pages/technologies/impact.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment happy-dom
+
+import { flushPromises, mount } from '@vue/test-utils'
+import { computed, defineComponent, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import ImpactPage from '../../../../app/pages/technologies/[name]/impact.vue'
+import { IMPACT_GRAPH_SYSTEM_LIMIT, type TechnologyImpactSystemRow } from '../../../../app/utils/technology-impact-graph'
+
+function makeRow(overrides: Partial<TechnologyImpactSystemRow> = {}): TechnologyImpactSystemRow {
+  return {
+    systemName: 'sys-a',
+    ownerTeamName: 'Team A',
+    environment: 'prod',
+    approved: true,
+    time: 'invest',
+    versions: ['1.0.0'],
+    ...overrides
+  }
+}
+
+function mountPage(systems: TechnologyImpactSystemRow[]) {
+  vi.stubGlobal('computed', computed)
+  vi.stubGlobal('ref', ref)
+  vi.stubGlobal('useRoute', () => ({ params: { name: 'React' } }))
+  vi.stubGlobal('useFetch', vi.fn(async () => ({
+    data: ref({ success: true, data: { technology: 'React', systems } }),
+    pending: ref(false),
+    error: ref(null)
+  })))
+  vi.stubGlobal('useHead', vi.fn())
+  vi.stubGlobal('useSortableTable', () => ({ getSortableHeader: () => 'sortable' }))
+
+  return mount(defineComponent({
+    components: { ImpactPage },
+    template: '<Suspense><ImpactPage /></Suspense>'
+  }), {
+    global: {
+      stubs: {
+        AsyncTechnologyImpactGraph: {
+          props: ['technologyName', 'nodes', 'edges'],
+          template: '<div data-test="impact-graph" :data-node-count="nodes.length" />'
+        },
+        ClientOnly: { template: '<div><slot /></div>' },
+        NuxtLink: { props: ['to'], template: '<a><slot /></a>' },
+        UAlert: { props: ['title', 'description'], template: '<div data-test="alert"><strong>{{ title }}</strong><span>{{ description }}</span></div>' },
+        UBadge: { template: '<span><slot /></span>' },
+        UButton: { props: ['label'], template: '<button>{{ label }}<slot /></button>' },
+        UCard: { template: '<section data-test="card"><slot name="header" /><slot /></section>' },
+        UIcon: true,
+        UPageHeader: { props: ['title', 'description'], template: '<header><h1>{{ title }}</h1></header>' },
+        USkeleton: { template: '<div />' },
+        PaginatedTable: {
+          props: ['data'],
+          template: '<section><slot name="header" /><div data-test="row-count">{{ data.length }}</div><slot name="empty" /></section>'
+        }
+      }
+    }
+  })
+}
+
+describe('[pin] technology impact page', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('renders the impact graph and table when under the system limit', async () => {
+    const wrapper = mountPage([makeRow(), makeRow({ systemName: 'sys-b', ownerTeamName: 'Team B' })])
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="impact-graph"]').exists()).toBe(true)
+    expect(wrapper.find('[data-test="row-count"]').text()).toBe('2')
+  })
+
+  it('shows the over-cap alert and hides the graph when over the system limit, table still renders', async () => {
+    const systems = Array.from({ length: IMPACT_GRAPH_SYSTEM_LIMIT + 1 }, (_, i) => makeRow({ systemName: `sys-${i}` }))
+    const wrapper = mountPage(systems)
+    await flushPromises()
+
+    expect(wrapper.find('[data-test="impact-graph"]').exists()).toBe(false)
+    expect(wrapper.find('[data-test="alert"]').text()).toContain('Too many systems to graph')
+    expect(wrapper.find('[data-test="row-count"]').text()).toBe(String(IMPACT_GRAPH_SYSTEM_LIMIT + 1))
+  })
+})

--- a/test/app/utils/technology-impact-graph.test.ts
+++ b/test/app/utils/technology-impact-graph.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildImpactGraph,
+  UNOWNED_TEAM_ID,
+  type TechnologyImpactSystemRow
+} from '../../../app/utils/technology-impact-graph'
+
+function row(overrides: Partial<TechnologyImpactSystemRow> = {}): TechnologyImpactSystemRow {
+  return {
+    systemName: 'sys-a',
+    ownerTeamName: 'Team A',
+    environment: 'prod',
+    approved: true,
+    time: 'invest',
+    versions: ['1.0.0'],
+    ...overrides
+  }
+}
+
+describe('[pin] buildImpactGraph()', () => {
+  it('builds a technology root node, one team node, and one system node per row', () => {
+    const { nodes, edges } = buildImpactGraph('React', [row()])
+
+    expect(nodes.find(n => n.id === 'tech:React')).toMatchObject({ type: 'technology', label: 'React' })
+    expect(nodes.find(n => n.id === 'team:Team A')).toMatchObject({ type: 'team' })
+    expect(nodes.find(n => n.id === 'system:sys-a')).toMatchObject({ type: 'system' })
+    expect(edges).toContainEqual(expect.objectContaining({ source: 'tech:React', target: 'team:Team A' }))
+    expect(edges).toContainEqual(expect.objectContaining({ source: 'team:Team A', target: 'system:sys-a' }))
+  })
+
+  it('collapses multiple systems owned by the same team into a single team node', () => {
+    const { nodes } = buildImpactGraph('React', [
+      row({ systemName: 'sys-a' }),
+      row({ systemName: 'sys-b' })
+    ])
+
+    expect(nodes.filter(n => n.type === 'team')).toHaveLength(1)
+    expect(nodes.find(n => n.type === 'team')).toMatchObject({ systemCount: 2 })
+  })
+
+  it('passes versions through unchanged on the system node', () => {
+    const { nodes } = buildImpactGraph('React', [row({ versions: ['1.0.0', '2.0.0'] })])
+
+    expect(nodes.find(n => n.id === 'system:sys-a')).toMatchObject({ versions: ['1.0.0', '2.0.0'] })
+  })
+})
+
+describe('[contract] buildImpactGraph() compliance gap', () => {
+  it('marks a system node and its team->system edge as a compliance gap when approved is false', () => {
+    const { nodes, edges } = buildImpactGraph('React', [row({ approved: false, time: null })])
+
+    expect(nodes.find(n => n.id === 'system:sys-a')).toMatchObject({ complianceGap: true })
+    expect(edges.find(e => e.target === 'system:sys-a')).toMatchObject({ complianceGap: true })
+  })
+
+  it('does not mark a system as a compliance gap when approved is true', () => {
+    const { nodes, edges } = buildImpactGraph('React', [row({ approved: true, time: 'invest' })])
+
+    expect(nodes.find(n => n.id === 'system:sys-a')).toMatchObject({ complianceGap: false })
+    expect(edges.find(e => e.target === 'system:sys-a')).toMatchObject({ complianceGap: false })
+  })
+
+  it('buckets a system with no owning team under a synthetic unowned team node, always as a compliance gap', () => {
+    const { nodes, edges } = buildImpactGraph('React', [
+      row({ ownerTeamName: null, approved: true, time: 'invest' })
+    ])
+
+    const teamNode = nodes.find(n => n.type === 'team')
+    expect(teamNode).toMatchObject({ id: UNOWNED_TEAM_ID, complianceGap: true })
+    expect(nodes.find(n => n.type === 'system')).toMatchObject({ complianceGap: true })
+    expect(edges.find(e => e.source === UNOWNED_TEAM_ID)).toMatchObject({ complianceGap: true })
+  })
+
+  it('marks a team node as a gap only when ALL of its systems are gaps', () => {
+    const { nodes } = buildImpactGraph('React', [
+      row({ systemName: 'sys-a', approved: false, time: null }),
+      row({ systemName: 'sys-b', approved: true, time: 'invest' })
+    ])
+
+    expect(nodes.find(n => n.type === 'team')).toMatchObject({ complianceGap: false })
+  })
+
+  it('marks a team node as a gap when all of its systems are gaps', () => {
+    const { nodes } = buildImpactGraph('React', [
+      row({ systemName: 'sys-a', approved: false, time: null }),
+      row({ systemName: 'sys-b', approved: false, time: null })
+    ])
+
+    expect(nodes.find(n => n.type === 'team')).toMatchObject({ complianceGap: true })
+  })
+})
+
+describe('[pin] buildImpactGraph() mixed-TIME team severity', () => {
+  it('uses the eliminate > migrate > tolerate > invest tie-break for a team with mixed approved TIME values', () => {
+    const { nodes } = buildImpactGraph('React', [
+      row({ systemName: 'sys-a', approved: true, time: 'invest' }),
+      row({ systemName: 'sys-b', approved: true, time: 'migrate' }),
+      row({ systemName: 'sys-c', approved: true, time: 'tolerate' })
+    ])
+
+    expect(nodes.find(n => n.type === 'team')).toMatchObject({ time: 'migrate' })
+  })
+})

--- a/test/server/api/technology-graph.spec.ts
+++ b/test/server/api/technology-graph.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import handler from '../../../server/api/technologies/[name]/graph.get'
+import { technologyService } from '../../../server/services/singletons'
+
+vi.mock('../../../server/services/singletons', () => ({
+  technologyService: {
+    getGraph: vi.fn()
+  }
+}))
+
+describe('[pin] GET /api/technologies/{name}/graph', () => {
+  it('should return 400 when the name route param is missing', async () => {
+    await expect(
+      handler(mockEvent({ method: 'GET' }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should return 404 when the technology does not exist', async () => {
+    vi.mocked(technologyService.getGraph).mockResolvedValue(null)
+
+    await expect(
+      handler(mockEvent({ method: 'GET', params: { name: 'Nonexistent' } }))
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('should URI-decode the name param before passing it to the service', async () => {
+    vi.mocked(technologyService.getGraph).mockResolvedValue([])
+
+    await handler(mockEvent({ method: 'GET', params: { name: 'My%20Tech' } }))
+
+    expect(technologyService.getGraph).toHaveBeenCalledWith('My Tech')
+  })
+})
+
+describe('[contract] GET /api/technologies/{name}/graph — response shape', () => {
+  it('should return { success: true, data: { technology, systems } } with systems passed through unchanged', async () => {
+    const systems = [
+      { systemName: 'sys-a', ownerTeamName: 'Team A', environment: 'prod', approved: true, time: 'invest', versions: ['1.0.0'] },
+      { systemName: 'sys-b', ownerTeamName: null, environment: null, approved: false, time: null, versions: ['2.0.0'] }
+    ]
+    vi.mocked(technologyService.getGraph).mockResolvedValue(systems)
+
+    const result = await handler(mockEvent({ method: 'GET', params: { name: 'React' } }))
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { technology: 'React', systems }
+    })
+  })
+})

--- a/test/server/repositories/technology.repository.spec.ts
+++ b/test/server/repositories/technology.repository.spec.ts
@@ -349,6 +349,142 @@ describe('TechnologyRepository', () => {
     })
   })
 
+  describe('[pin] getGraph()', () => {
+    it('should return null for non-existent technology', async () => {
+      if (!ctx.neo4jAvailable) return
+      expect(await repo.getGraph(`${PREFIX}nonexistent`)).toBeNull()
+    })
+
+    it('should return an empty array when the technology exists but no system uses it', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `CREATE (:Technology { name: $tech, type: 'library' })`, { tech: `${PREFIX}unused-tech` })
+
+      expect(await repo.getGraph(`${PREFIX}unused-tech`)).toEqual([])
+    })
+
+    it('should deduplicate versions in use by a system', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Technology { name: $tech, type: 'library' })
+        CREATE (c1:Component { name: $comp, version: '1.0.0' })-[:IS_VERSION_OF]->(t)
+        CREATE (c2:Component { name: $comp, version: '2.0.0' })-[:IS_VERSION_OF]->(t)
+        CREATE (s:System { name: $sys })-[:USES]->(c1)
+        CREATE (s)-[:USES]->(c2)
+      `, { tech: `${PREFIX}versions-tech`, comp: `${PREFIX}versions-comp`, sys: `${PREFIX}versions-sys` })
+
+      const rows = await repo.getGraph(`${PREFIX}versions-tech`)
+
+      expect(rows).toHaveLength(1)
+      expect(rows![0]!.versions.sort()).toEqual(['1.0.0', '2.0.0'])
+    })
+
+    it('should deterministically pin one owning team when a system somehow has more than one OWNS edge', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Technology { name: $tech, type: 'library' })
+        CREATE (c:Component { name: $comp, version: '1.0.0' })-[:IS_VERSION_OF]->(t)
+        CREATE (a:Team { name: $a })
+        CREATE (b:Team { name: $b })
+        CREATE (s:System { name: $sys })-[:USES]->(c)
+        CREATE (b)-[:OWNS]->(s)
+        CREATE (a)-[:OWNS]->(s)
+      `, {
+        tech: `${PREFIX}multi-owns-tech`,
+        comp: `${PREFIX}multi-owns-comp`,
+        a: `${PREFIX}A-Team`,
+        b: `${PREFIX}B-Team`,
+        sys: `${PREFIX}multi-owns-sys`,
+      })
+
+      const rows1 = await repo.getGraph(`${PREFIX}multi-owns-tech`)
+      const rows2 = await repo.getGraph(`${PREFIX}multi-owns-tech`)
+
+      expect(rows1![0]!.ownerTeamName).toBe(`${PREFIX}A-Team`)
+      expect(rows2![0]!.ownerTeamName).toBe(`${PREFIX}A-Team`)
+    })
+  })
+
+  describe('[contract] getGraph() approval resolution', () => {
+    it('should resolve the TIME from the system\'s OWNING team, not an unrelated approving team', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Technology { name: $tech, type: 'library' })
+        CREATE (c:Component { name: $comp, version: '1.0.0' })-[:IS_VERSION_OF]->(t)
+        CREATE (owningTeam:Team { name: $owningTeam })
+        CREATE (otherTeam:Team { name: $otherTeam })
+        CREATE (s:System { name: $sys, environment: 'prod' })-[:USES]->(c)
+        CREATE (owningTeam)-[:OWNS]->(s)
+        CREATE (owningTeam)-[:APPROVES { time: 'tolerate' }]->(t)
+        CREATE (otherTeam)-[:APPROVES { time: 'eliminate' }]->(t)
+      `, {
+        tech: `${PREFIX}owning-team-tech`,
+        comp: `${PREFIX}owning-team-comp`,
+        owningTeam: `${PREFIX}owning-team`,
+        otherTeam: `${PREFIX}other-team`,
+        sys: `${PREFIX}owning-team-sys`,
+      })
+
+      const rows = await repo.getGraph(`${PREFIX}owning-team-tech`)
+      const row = rows!.find(r => r.systemName === `${PREFIX}owning-team-sys`)
+
+      expect(row).toBeDefined()
+      expect(row!.ownerTeamName).toBe(`${PREFIX}owning-team`)
+      expect(row!.approved).toBe(true)
+      expect(row!.time).toBe('tolerate')
+    })
+
+    it('should return approved=false and time=null when the owning team has no APPROVES edge at all', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Technology { name: $tech, type: 'library' })
+        CREATE (c:Component { name: $comp, version: '1.0.0' })-[:IS_VERSION_OF]->(t)
+        CREATE (owningTeam:Team { name: $owningTeam })
+        CREATE (s:System { name: $sys })-[:USES]->(c)
+        CREATE (owningTeam)-[:OWNS]->(s)
+      `, {
+        tech: `${PREFIX}gap-tech`,
+        comp: `${PREFIX}gap-comp`,
+        owningTeam: `${PREFIX}gap-team`,
+        sys: `${PREFIX}gap-sys`,
+      })
+
+      const rows = await repo.getGraph(`${PREFIX}gap-tech`)
+      const row = rows!.find(r => r.systemName === `${PREFIX}gap-sys`)
+
+      expect(row).toBeDefined()
+      expect(row!.approved).toBe(false)
+      expect(row!.time).toBeNull()
+    })
+
+    it('should prefer an environment-specific approval over a blanket one, and fall back to blanket when no environment-specific approval exists', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Technology { name: $tech, type: 'library' })
+        CREATE (c:Component { name: $comp, version: '1.0.0' })-[:IS_VERSION_OF]->(t)
+        CREATE (team:Team { name: $team })
+        CREATE (prodSys:System { name: $prodSys, environment: 'prod' })-[:USES]->(c)
+        CREATE (devSys:System { name: $devSys, environment: 'dev' })-[:USES]->(c)
+        CREATE (team)-[:OWNS]->(prodSys)
+        CREATE (team)-[:OWNS]->(devSys)
+        CREATE (team)-[:APPROVES { time: 'eliminate', environment: 'prod' }]->(t)
+        CREATE (team)-[:APPROVES { time: 'invest' }]->(t)
+      `, {
+        tech: `${PREFIX}env-tech`,
+        comp: `${PREFIX}env-comp`,
+        team: `${PREFIX}env-team`,
+        prodSys: `${PREFIX}env-prod-sys`,
+        devSys: `${PREFIX}env-dev-sys`,
+      })
+
+      const rows = await repo.getGraph(`${PREFIX}env-tech`)
+      const prodRow = rows!.find(r => r.systemName === `${PREFIX}env-prod-sys`)
+      const devRow = rows!.find(r => r.systemName === `${PREFIX}env-dev-sys`)
+
+      expect(prodRow!.time).toBe('eliminate')
+      expect(devRow!.time).toBe('invest')
+    })
+  })
+
   describe('[pin] upsertApproval()', () => {
     it('should create and then update approval for same environment', async () => {
       if (!ctx.neo4jAvailable) return


### PR DESCRIPTION
## Description

Implements a new technology impact graph: a cross-system "blast radius" view answering *"what happens if we eliminate this technology?"* A D3 graph plus companion table show every system using a technology, its owning team, and that team's own TIME approval (never an unrelated team's) — with systems whose owning team has no approval flagged as a distinct compliance gap.

This was reviewed and planned interactively with the repo owner before implementation. Key decisions:
- Separate `/technologies/{name}/impact` route (not a tab) — required converting `[name].vue` to directory-based routing.
- A brand-new `TechnologyImpactGraph.vue` component, not an extension of the existing `SystemDependencyGraph.vue` — avoids regression risk on the working system graph.
- Version/team/TIME info shown via hover tooltip + click-to-select panel, not permanent SVG edge labels.
- Systems whose owning team has no `APPROVES` relationship for the technology are rendered as a distinct "compliance gap" state (dashed gray), reusing the same signal the violations dashboard already tracks.

Also includes an unrelated but necessary fix: `typescript` was pinned back to `^6.0.3`. `typescript@7.0.2` (from a prior dependency bump) broke `@typescript-eslint` repo-wide — `npm run lint` was failing on `main` for everyone. `@nuxt/ui`'s peer dependency range also excludes 7.x.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Related Issues

Fixes #557

## Changes Made

- New `TechnologyImpactGraph.vue`: D3 force-directed graph, technology → team → system tiers, TIME-colored nodes, dashed-gray compliance-gap styling, hover tooltip + click detail panel.
- New `app/pages/technologies/[name]/impact.vue`: fetches the graph endpoint, renders the graph below a 75-system cap with an always-shown, sortable companion table; over-cap alert + table-only fallback above the cap.
- Converted `app/pages/technologies/[name].vue` → `[name]/index.vue` (directory-based routing) to host the new sibling route; added a "View Impact Graph" header link.
- New `app/utils/technology-impact-graph.ts`: pure, framework-free node/edge-shaping function — fully unit tested independent of D3/DOM.
- New `server/database/queries/technologies/graph.cypher`, `TechnologyRepository.getGraph()`, `technologyService.getGraph()`, `GET /api/technologies/{name}/graph` — resolves each system's owning team deterministically and that team's own TIME approval (environment-specific approval preferred over blanket).
- `public/openapi.json` regenerated to include the new endpoint.
- `package.json`: `typescript` pinned back to `^6.0.3` (see above).
- Tests: repository (`getGraph()` not-found/empty sentinels, owning-team-scoped TIME resolution, environment-precedence, deterministic owning-team pin), API handler (400/404/response shape), frontend utils (compliance-gap propagation, unowned-team bucketing, TIME severity tie-break), and page-level (cap/over-cap rendering).

## Screenshots

Manually verified in-browser against live seeded data (`TypeScript` technology, 10 systems, mixed approved/compliance-gap) via the `chrome-devtools` MCP tool — graph coloring, dashed compliance-gap styling, click-to-select detail panel, and table all confirmed working as designed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run `npm run lint` and fixed any issues
- [x] I have tested my changes locally with `npm run dev`
- [ ] I have tested the build with `npm run build`
- [x] I have updated documentation if needed

## Additional Notes

Full test suite (utils, services, repositories, api, app layers, plus `test/schema` and `test/app/e2e`) and lint pass. One repositories-layer test run via the `run_tests` MCP tool returned a hallucinated result referencing files that don't exist in this repo — re-verified directly with `npx vitest run test/server/repositories`, which passed (227/227).
