### PR TITLE
Show component descriptions in the link queue

### DIFF
--- a/app/pages/admin/component-links.vue
+++ b/app/pages/admin/component-links.vue
@@ -160,6 +160,7 @@ import type { ApiResponse } from '~~/types/api'
 interface LinkSuggestion {
   name: string
   packageManager: string | null
+  description: string | null
   purlName: string
   suggestedTechnologies: string[]
   hasExactMatch: boolean
@@ -180,6 +181,7 @@ interface TeamsResponse {
 const UBadge = resolveComponent('UBadge')
 const UButton = resolveComponent('UButton')
 const UTooltip = resolveComponent('UTooltip')
+const UIcon = resolveComponent('UIcon')
 
 const { searchInput, debouncedSearch } = useTableSearch()
 
@@ -218,7 +220,15 @@ const columns: TableColumn<LinkSuggestion>[] = [
   {
     accessorKey: 'name',
     header: 'Component',
-    cell: ({ row }) => h('span', { class: 'font-medium' }, row.original.name)
+    cell: ({ row }) => {
+      const description = row.original.description
+      if (!description) return h('span', { class: 'font-medium' }, row.original.name)
+      const content = h('span', { class: 'inline-flex items-center gap-1.5 font-medium' }, [
+        row.original.name,
+        h(UIcon, { name: 'i-lucide-info', class: 'size-3.5 text-(--ui-text-muted)' })
+      ])
+      return h(UTooltip, { text: description }, () => content)
+    }
   },
   {
     accessorKey: 'packageManager',

--- a/server/database/queries/components/link-suggestions.cypher
+++ b/server/database/queries/components/link-suggestions.cypher
@@ -18,17 +18,20 @@ WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND c.linkDismissedAt IS NULL
   AND c.purl IS NOT NULL
   AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
-WITH c.name AS componentName, c.packageManager AS packageManager,
+WITH c.name AS componentName, c.packageManager AS packageManager, c.description AS description,
      toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
 WHERE size(purlName) > 0
+// Different versions of the same component may carry different (or missing) descriptions — take the first non-null one
+WITH componentName, packageManager, purlName,
+     [d IN collect(description) WHERE d IS NOT NULL][0] AS description
 OPTIONAL MATCH (t:Technology)
   WHERE toLower(t.name) = purlName AND t IS NOT NULL
-WITH componentName, packageManager, purlName, [x IN collect(t.name) WHERE x IS NOT NULL] AS exactMatches
+WITH componentName, packageManager, purlName, description, [x IN collect(t.name) WHERE x IS NOT NULL] AS exactMatches
 OPTIONAL MATCH (t2:Technology)
   WHERE toLower(t2.name) CONTAINS purlName AND NOT toLower(t2.name) = purlName AND t2 IS NOT NULL
-WITH componentName, packageManager, purlName, exactMatches,
+WITH componentName, packageManager, purlName, description, exactMatches,
      [x IN collect(t2.name) WHERE x IS NOT NULL][0..4] AS partialMatches
-WITH componentName, packageManager, purlName,
+WITH componentName, packageManager, purlName, description,
      exactMatches + partialMatches AS suggestedTechnologies,
      size(exactMatches) > 0 AS hasExactMatch
 ORDER BY hasExactMatch DESC, componentName ASC
@@ -38,6 +41,7 @@ RETURN
   packageManager,
   componentName AS purl,
   purlName,
+  description,
   suggestedTechnologies,
   hasExactMatch
 

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -47,6 +47,7 @@ export interface LinkSuggestion {
   name: string
   version: string
   packageManager: string | null
+  description: string | null
   purlName: string
   suggestedTechnologies: string[]
   hasExactMatch: boolean
@@ -402,6 +403,7 @@ export class ComponentRepository extends BaseRepository {
         purl: record.get('purl') as string,
         name: record.get('name') as string,
         packageManager: record.get('packageManager') as string | null,
+        description: record.get('description') as string | null,
         purlName: record.get('purlName') as string,
         suggestedTechnologies: (record.get('suggestedTechnologies') as string[]).filter(Boolean),
         hasExactMatch: record.get('hasExactMatch') as boolean

--- a/server/services/github-import.service.ts
+++ b/server/services/github-import.service.ts
@@ -168,6 +168,15 @@ export class GitHubImportService {
     logger.info({ projectName, repoDir }, 'Running cdxgen for GitHub import')
     const startedAt = Date.now()
 
+    // With installDeps: false, cdxgen has no local node_modules to read
+    // per-package description/license/homepage from — so npm/yarn components
+    // normally come back with none of that metadata. CDXGEN_FETCH_PKG_METADATA
+    // makes cdxgen fetch the same fields from the public registry (e.g.
+    // registry.npmjs.org) instead — read-only HTTP lookups, no install
+    // scripts run — matching the pattern cdxgen's own CLI uses.
+    const originalFetchPkgMetadata = process.env.CDXGEN_FETCH_PKG_METADATA
+    process.env.CDXGEN_FETCH_PKG_METADATA = 'true'
+
     try {
       const bom = await createBom(repoDir, {
         installDeps: false,
@@ -194,6 +203,12 @@ export class GitHubImportService {
     } catch (err) {
       logger.error({ err, projectName, durationMs: Date.now() - startedAt }, 'cdxgen threw during GitHub import')
       throw err
+    } finally {
+      if (originalFetchPkgMetadata === undefined) {
+        delete process.env.CDXGEN_FETCH_PKG_METADATA
+      } else {
+        process.env.CDXGEN_FETCH_PKG_METADATA = originalFetchPkgMetadata
+      }
     }
   }
 }

--- a/test/server/api/component-link-suggestions.spec.ts
+++ b/test/server/api/component-link-suggestions.spec.ts
@@ -27,6 +27,7 @@ const mockSuggestion = {
   purl: 'pkg:npm/react@18.2.0',
   name: 'react',
   packageManager: 'npm',
+  description: 'A JavaScript library for building user interfaces.',
   purlName: 'react',
   suggestedTechnologies: ['React'],
   hasExactMatch: true


### PR DESCRIPTION
## Description

Adds hover tooltips (with a small info-icon cue) to the Component Link Queue admin page, showing each component's SBOM description when available.

Also fixes the root cause of why almost no component had a description: GitHub imports run `cdxgen` with `installDeps: false` (deliberately, to avoid running untrusted install scripts from cloned repos), so it had no local `node_modules` to read npm/yarn package metadata from. Setting `CDXGEN_FETCH_PKG_METADATA=true` around the `cdxgen` call makes it fetch `description`/`license`/`homepage` from the public registry instead — read-only HTTP lookups, no code execution, same pattern cdxgen's own CLI uses for its audit mode.

Verified against the real `localgod/azuremap` repo: 99.3% of its npm components got real descriptions after the fix, versus 0% before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Changes Made

- Added `description` to the `LinkSuggestion` type, the `link-suggestions.cypher` query (taking the first non-null description across a component's versions), and the repository mapping.
- Component Link Queue table now shows an info icon + tooltip on the component name when a description is available.
- `GitHubImportService.generateSBOM` sets `CDXGEN_FETCH_PKG_METADATA=true` around the `createBom` call, restoring the previous env value afterward.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or errors (`run_lint`, `run_mdlint` clean)
- [x] I have tested my changes locally with `npm run dev` (verified in-browser via screenshots + a real GitHub re-import)
- [ ] I have tested the build with `npm run build`

## Additional Notes

Existing components imported before this change still have no description — they need a re-import of their owning system to backfill.