### PR TITLE
Add Background Jobs admin page (cancel/delete for import + health-refresh jobs)

### DIFF
--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -340,6 +340,16 @@ const mainMenuItems = computed<NavigationMenuItem[][]>(() => {
       to: '/admin/component-links'
     })
     items.push({
+      label: 'Dismissed Components',
+      icon: 'i-lucide-undo-2',
+      to: '/admin/dismissed-links'
+    })
+    items.push({
+      label: 'Background Jobs',
+      icon: 'i-lucide-download',
+      to: '/admin/import-jobs'
+    })
+    items.push({
       label: 'Impersonate User',
       icon: 'i-lucide-eye',
       onSelect: () => openImpersonateModal()

--- a/app/pages/admin/component-links.vue
+++ b/app/pages/admin/component-links.vue
@@ -161,6 +161,7 @@ interface LinkSuggestion {
   name: string
   packageManager: string | null
   description: string | null
+  purl: string
   purlName: string
   suggestedTechnologies: string[]
   hasExactMatch: boolean
@@ -221,13 +222,17 @@ const columns: TableColumn<LinkSuggestion>[] = [
     accessorKey: 'name',
     header: 'Component',
     cell: ({ row }) => {
-      const description = row.original.description
-      if (!description) return h('span', { class: 'font-medium' }, row.original.name)
-      const content = h('span', { class: 'inline-flex items-center gap-1.5 font-medium' }, [
-        row.original.name,
-        h(UIcon, { name: 'i-lucide-info', class: 'size-3.5 text-(--ui-text-muted)' })
+      const { name, description, purl } = row.original
+      const nameEl = description
+        ? h(UTooltip, { text: description }, () => h('span', { class: 'inline-flex items-center gap-1.5 font-medium' }, [
+            name,
+            h(UIcon, { name: 'i-lucide-info', class: 'size-3.5 text-(--ui-text-muted)' })
+          ]))
+        : h('span', { class: 'font-medium' }, name)
+      return h('div', {}, [
+        nameEl,
+        h('div', { class: 'text-xs text-(--ui-text-muted) font-mono truncate' }, purl)
       ])
-      return h(UTooltip, { text: description }, () => content)
     }
   },
   {

--- a/app/pages/admin/dismissed-links.vue
+++ b/app/pages/admin/dismissed-links.vue
@@ -1,0 +1,144 @@
+<template>
+  <div class="space-y-6">
+    <UPageHeader
+      title="Dismissed Components"
+      :description="`${total} component${total === 1 ? '' : 's'} dismissed from the link queue`"
+    />
+
+    <UAlert
+      color="info"
+      variant="subtle"
+      icon="i-lucide-info"
+      description="These components were intentionally excluded from the Component Link Queue. Restoring one puts it back in the queue so it can be linked to (or used to create) a Technology."
+    />
+
+    <UAlert
+      v-if="fetchError"
+      color="error"
+      :title="fetchError.message || 'Failed to load dismissed components'"
+      icon="i-lucide-circle-x"
+    />
+
+    <UAlert
+      v-if="restoreError"
+      color="error"
+      title="Failed to restore component"
+      :description="restoreError"
+      icon="i-lucide-circle-x"
+      close
+      @close="restoreError = ''"
+    />
+
+    <PaginatedTable
+      v-else
+      v-model:page="page"
+      :data="dismissed"
+      :columns="columns"
+      :loading="pending"
+      :total="total"
+      :page-size="pageSize"
+    >
+      <template #header>
+        <TableSearchHeader v-model="searchInput" />
+      </template>
+      <template #empty>
+        <div class="text-center text-(--ui-text-muted) py-12">
+          No dismissed components.
+        </div>
+      </template>
+    </PaginatedTable>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
+
+interface DismissedComponent {
+  name: string
+  packageManager: string | null
+  description: string | null
+  purl: string | null
+  dismissedAt: string
+}
+
+const UButton = resolveComponent('UButton')
+const UTooltip = resolveComponent('UTooltip')
+const UIcon = resolveComponent('UIcon')
+
+const { searchInput, debouncedSearch } = useTableSearch()
+
+const { page, pageSize, offset } = usePaginatedSorting({ pageSize: 50, resetOn: [debouncedSearch] })
+
+const { data, pending, error: fetchError, refresh } = await useFetch<ApiResponse<DismissedComponent>>(
+  '/api/components/dismissed-links',
+  { query: { skip: offset, limit: pageSize, search: debouncedSearch } }
+)
+
+const dismissed = useApiData(data)
+const total = useApiCount(data)
+
+const columns: TableColumn<DismissedComponent>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Component',
+    cell: ({ row }) => {
+      const { name, description, purl } = row.original
+      const nameEl = description
+        ? h(UTooltip, { text: description }, () => h('span', { class: 'inline-flex items-center gap-1.5 font-medium' }, [
+            name,
+            h(UIcon, { name: 'i-lucide-info', class: 'size-3.5 text-(--ui-text-muted)' })
+          ]))
+        : h('span', { class: 'font-medium' }, name)
+      return h('div', {}, [
+        nameEl,
+        purl ? h('div', { class: 'text-xs text-(--ui-text-muted) font-mono truncate' }, purl) : null
+      ])
+    }
+  },
+  {
+    accessorKey: 'packageManager',
+    header: 'Ecosystem',
+    cell: ({ row }) => row.getValue('packageManager') ?? '—'
+  },
+  {
+    accessorKey: 'dismissedAt',
+    header: 'Dismissed',
+    cell: ({ row }) => new Date(row.original.dismissedAt).toLocaleString()
+  },
+  {
+    id: 'actions',
+    header: 'Actions',
+    enableSorting: false,
+    cell: ({ row }) => h(UTooltip, { text: 'Restore to link queue' }, () =>
+      h(UButton, {
+        size: 'xs',
+        icon: 'i-lucide-undo-2',
+        label: 'Restore',
+        color: 'neutral',
+        variant: 'outline',
+        onClick: () => restoreItem(row.original)
+      })
+    )
+  }
+]
+
+const restoreError = ref('')
+
+async function restoreItem(item: DismissedComponent) {
+  restoreError.value = ''
+  try {
+    await $fetch('/api/components/undismiss-link', {
+      method: 'POST',
+      body: { componentName: item.name }
+    })
+    await refresh()
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Unknown error'
+    restoreError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
+  }
+}
+
+useHead({ title: 'Dismissed Components - Polaris' })
+</script>

--- a/app/pages/admin/import-jobs.vue
+++ b/app/pages/admin/import-jobs.vue
@@ -1,0 +1,822 @@
+<template>
+  <div class="space-y-6">
+    <UPageHeader
+      title="Background Jobs"
+      description="GitHub owner imports and health-refresh jobs, live and historical"
+    />
+
+    <UTabs :items="tabItems">
+      <template #github>
+        <div class="space-y-6 mt-4">
+          <UAlert
+            color="info"
+            variant="subtle"
+            icon="i-lucide-info"
+            description="Jobs run in the same process that started them. If that process crashed or restarted mid-import, a job can be stuck showing 'running' forever — cancel it here to clear it from view, then delete it once finished."
+          />
+
+          <UAlert
+            v-if="githubFetchError"
+            color="error"
+            :title="githubFetchError.message || 'Failed to load import jobs'"
+            icon="i-lucide-circle-x"
+          />
+
+          <UAlert
+            v-if="cancelError"
+            color="error"
+            title="Failed to cancel job"
+            :description="cancelError"
+            icon="i-lucide-circle-x"
+            close
+            @close="cancelError = ''"
+          />
+
+          <PaginatedTable
+            v-else
+            v-model:page="githubPage"
+            :data="githubJobs"
+            :columns="githubColumns"
+            :loading="githubPending"
+            :total="githubTotal"
+            :page-size="githubPageSize"
+          >
+            <template #header>
+              <TableSearchHeader v-model="githubSearchInput">
+                <template #filters>
+                  <USelect v-model="githubStatusFilter" :items="statusItems" class="w-40" />
+                  <UButton
+                    label="Refresh"
+                    icon="i-lucide-refresh-cw"
+                    size="sm"
+                    color="neutral"
+                    variant="outline"
+                    :loading="githubPending"
+                    @click="githubRefresh()"
+                  />
+                </template>
+              </TableSearchHeader>
+            </template>
+            <template #empty>
+              <div class="text-center text-(--ui-text-muted) py-12">
+                No import jobs match these filters.
+              </div>
+            </template>
+          </PaginatedTable>
+        </div>
+      </template>
+
+      <template #health>
+        <div class="space-y-6 mt-4">
+          <UAlert
+            color="info"
+            variant="subtle"
+            icon="i-lucide-info"
+            description="Health-refresh jobs run automatically via a scheduled background task that reconciles component EOL, vulnerability, and maintenance data. If that task crashed or restarted mid-run, a job can be stuck showing 'running' forever — cancel it here to clear it from view, then delete it once finished."
+          />
+
+          <UAlert
+            v-if="healthFetchError"
+            color="error"
+            :title="healthFetchError.message || 'Failed to load health-refresh jobs'"
+            icon="i-lucide-circle-x"
+          />
+
+          <UAlert
+            v-if="healthCancelError"
+            color="error"
+            title="Failed to cancel job"
+            :description="healthCancelError"
+            icon="i-lucide-circle-x"
+            close
+            @close="healthCancelError = ''"
+          />
+
+          <PaginatedTable
+            v-else
+            v-model:page="healthPage"
+            :data="healthJobs"
+            :columns="healthColumns"
+            :loading="healthPending"
+            :total="healthTotal"
+            :page-size="healthPageSize"
+          >
+            <template #header>
+              <TableSearchHeader v-model="healthSearchInput">
+                <template #filters>
+                  <USelect v-model="healthStatusFilter" :items="statusItems" class="w-40" />
+                  <UButton
+                    label="Refresh"
+                    icon="i-lucide-refresh-cw"
+                    size="sm"
+                    color="neutral"
+                    variant="outline"
+                    :loading="healthPending"
+                    @click="healthRefresh()"
+                  />
+                </template>
+              </TableSearchHeader>
+            </template>
+            <template #empty>
+              <div class="text-center text-(--ui-text-muted) py-12">
+                No health-refresh jobs match these filters.
+              </div>
+            </template>
+          </PaginatedTable>
+        </div>
+      </template>
+    </UTabs>
+
+    <!-- GitHub import job detail modal -->
+    <UModal v-model:open="detailModalOpen" :ui="{ footer: 'justify-end' }">
+      <template #header>
+        <h3 class="text-lg font-semibold">{{ detailJob?.organization || 'Import Job' }}</h3>
+      </template>
+      <template #body>
+        <USkeleton v-if="detailLoading" class="h-64 w-full" />
+        <UAlert
+          v-else-if="detailError"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-alert-circle"
+          :description="detailError"
+        />
+        <div v-else-if="detailJob" class="space-y-4">
+          <div class="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <span class="text-(--ui-text-muted)">Status</span>
+              <div><UBadge :color="jobStatusColor(detailJob.status)" variant="subtle">{{ detailJob.status }}</UBadge></div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Progress</span>
+              <div>{{ detailJob.completed }}/{{ detailJob.total }} · {{ detailJob.failed }} failed · {{ detailJob.skipped }} skipped</div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Created</span>
+              <div>{{ new Date(detailJob.createdAt).toLocaleString() }}</div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Started</span>
+              <div>{{ detailJob.startedAt ? new Date(detailJob.startedAt).toLocaleString() : '—' }}</div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Finished</span>
+              <div>{{ detailJob.finishedAt ? new Date(detailJob.finishedAt).toLocaleString() : '—' }}</div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Requested by</span>
+              <div class="font-mono text-xs truncate">{{ detailJob.requestedBy }}</div>
+            </div>
+          </div>
+
+          <UAlert
+            v-if="detailJob.error"
+            color="error"
+            variant="subtle"
+            icon="i-lucide-alert-circle"
+            :title="detailJob.error"
+          />
+
+          <div class="max-h-72 overflow-auto divide-y divide-(--ui-border) rounded-md border border-(--ui-border)">
+            <div v-if="detailJob.items.length === 0" class="p-3 text-sm text-(--ui-text-muted)">
+              No repositories recorded for this job.
+            </div>
+            <div
+              v-for="item in detailJob.items"
+              :key="item.id"
+              class="flex items-center justify-between gap-3 px-3 py-2"
+            >
+              <div class="min-w-0">
+                <div class="truncate text-sm font-medium">{{ item.repositoryFullName }}</div>
+                <div v-if="item.message" class="truncate text-xs text-(--ui-text-muted)">{{ item.message }}</div>
+              </div>
+              <UBadge :color="itemStatusColor(item.status)" variant="subtle">{{ item.status }}</UBadge>
+            </div>
+          </div>
+        </div>
+      </template>
+      <template #footer>
+        <UButton
+          v-if="detailJob && (detailJob.status === 'queued' || detailJob.status === 'running')"
+          label="Cancel Job"
+          color="error"
+          variant="outline"
+          :loading="cancellingId === detailJob.id"
+          @click="cancelJob(detailJob.id)"
+        />
+        <UButton
+          v-if="detailJob && detailJob.status !== 'queued' && detailJob.status !== 'running'"
+          label="Delete"
+          color="error"
+          variant="outline"
+          @click="openDeleteModal(detailJob)"
+        />
+        <UButton label="Close" color="neutral" variant="outline" @click="detailModalOpen = false" />
+      </template>
+    </UModal>
+
+    <!-- Health-refresh job detail modal -->
+    <UModal v-model:open="healthDetailModalOpen" :ui="{ footer: 'justify-end' }">
+      <template #header>
+        <h3 class="text-lg font-semibold">{{ healthDetailJob?.systemName || 'Scheduled Health Refresh' }}</h3>
+      </template>
+      <template #body>
+        <USkeleton v-if="healthDetailLoading" class="h-64 w-full" />
+        <UAlert
+          v-else-if="healthDetailError"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-alert-circle"
+          :description="healthDetailError"
+        />
+        <div v-else-if="healthDetailJob" class="space-y-4">
+          <div class="grid grid-cols-2 gap-3 text-sm">
+            <div>
+              <span class="text-(--ui-text-muted)">Status</span>
+              <div><UBadge :color="jobStatusColor(healthDetailJob.status)" variant="subtle">{{ healthDetailJob.status }}</UBadge></div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Trigger</span>
+              <div>{{ healthDetailJob.trigger }}</div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Progress</span>
+              <div>{{ healthDetailJob.completedItems }}/{{ healthDetailJob.totalItems }} · {{ healthDetailJob.failedItems }} failed</div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Created</span>
+              <div>{{ new Date(healthDetailJob.createdAt).toLocaleString() }}</div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Started</span>
+              <div>{{ healthDetailJob.startedAt ? new Date(healthDetailJob.startedAt).toLocaleString() : '—' }}</div>
+            </div>
+            <div>
+              <span class="text-(--ui-text-muted)">Finished</span>
+              <div>{{ healthDetailJob.finishedAt ? new Date(healthDetailJob.finishedAt).toLocaleString() : '—' }}</div>
+            </div>
+          </div>
+
+          <UAlert
+            v-if="healthDetailJob.error"
+            color="error"
+            variant="subtle"
+            icon="i-lucide-alert-circle"
+            :title="healthDetailJob.error"
+          />
+
+          <div class="max-h-72 overflow-auto divide-y divide-(--ui-border) rounded-md border border-(--ui-border)">
+            <div v-if="healthDetailJob.items.length === 0" class="p-3 text-sm text-(--ui-text-muted)">
+              No components recorded for this job.
+            </div>
+            <div
+              v-for="item in healthDetailJob.items"
+              :key="item.id"
+              class="flex items-center justify-between gap-3 px-3 py-2"
+            >
+              <div class="min-w-0">
+                <div class="truncate text-sm font-medium">{{ item.componentName }}@{{ item.componentVersion }}</div>
+                <div v-if="item.errorSummary" class="truncate text-xs text-(--ui-text-muted)">{{ item.errorSummary }}</div>
+              </div>
+              <UBadge :color="healthItemStatusColor(item.status)" variant="subtle">{{ item.status }}</UBadge>
+            </div>
+          </div>
+        </div>
+      </template>
+      <template #footer>
+        <UButton
+          v-if="healthDetailJob && (healthDetailJob.status === 'queued' || healthDetailJob.status === 'running')"
+          label="Cancel Job"
+          color="error"
+          variant="outline"
+          :loading="healthCancellingId === healthDetailJob.id"
+          @click="cancelHealthJob(healthDetailJob.id)"
+        />
+        <UButton
+          v-if="healthDetailJob && healthDetailJob.status !== 'queued' && healthDetailJob.status !== 'running'"
+          label="Delete"
+          color="error"
+          variant="outline"
+          @click="openHealthDeleteModal(healthDetailJob)"
+        />
+        <UButton label="Close" color="neutral" variant="outline" @click="healthDetailModalOpen = false" />
+      </template>
+    </UModal>
+
+    <!-- Health-refresh delete confirmation modal -->
+    <UModal v-model:open="healthDeleteModalOpen" :ui="{ footer: 'justify-end' }">
+      <template #header>
+        <h3 class="text-lg font-semibold">Delete Health-Refresh Job</h3>
+      </template>
+      <template #body>
+        <p class="text-sm">
+          Are you sure you want to delete this health-refresh job for
+          <strong>{{ healthDeleteTarget?.systemName || 'all systems' }}</strong>?
+        </p>
+        <p class="text-sm text-(--ui-text-muted) mt-2">
+          This permanently removes the job's run history and its per-component check results.
+          Component health data itself is not affected. This cannot be undone.
+        </p>
+        <UAlert
+          v-if="healthDeleteError"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-alert-circle"
+          :description="healthDeleteError"
+          class="mt-4"
+        />
+      </template>
+      <template #footer>
+        <UButton label="Cancel" color="neutral" variant="outline" @click="healthDeleteModalOpen = false" />
+        <UButton label="Delete" color="error" :loading="healthDeleteLoading" @click="confirmHealthDelete" />
+      </template>
+    </UModal>
+
+    <!-- Delete confirmation modal -->
+    <UModal v-model:open="deleteModalOpen" :ui="{ footer: 'justify-end' }">
+      <template #header>
+        <h3 class="text-lg font-semibold">Delete Import Job</h3>
+      </template>
+      <template #body>
+        <p class="text-sm">
+          Are you sure you want to delete the import job for <strong>{{ deleteTarget?.organization }}</strong>?
+        </p>
+        <p class="text-sm text-(--ui-text-muted) mt-2">
+          This permanently removes the job's run history and its per-repository results.
+          Any systems or components already imported are not affected. This cannot be undone.
+        </p>
+        <UAlert
+          v-if="deleteError"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-alert-circle"
+          :description="deleteError"
+          class="mt-4"
+        />
+      </template>
+      <template #footer>
+        <UButton label="Cancel" color="neutral" variant="outline" @click="deleteModalOpen = false" />
+        <UButton label="Delete" color="error" :loading="deleteLoading" @click="confirmDelete" />
+      </template>
+    </UModal>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { h } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+import type { ApiResponse } from '~~/types/api'
+
+type ImportJobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+type ImportJobItemStatus = 'pending' | 'running' | 'imported' | 'skipped' | 'failed'
+type HealthRefreshJobStatus = 'queued' | 'running' | 'completed' | 'failed' | 'cancelled'
+type HealthRefreshJobItemStatus = 'pending' | 'running' | 'refreshed' | 'failed' | 'skipped'
+
+interface ImportJobSummary {
+  id: string
+  status: ImportJobStatus
+  organization: string
+  requestedBy: string
+  total: number
+  completed: number
+  failed: number
+  skipped: number
+  createdAt: string
+  startedAt: string | null
+  finishedAt: string | null
+  error: string | null
+}
+
+interface ImportJobItemDetail {
+  id: string
+  repositoryFullName: string
+  repositoryUrl: string
+  status: ImportJobItemStatus
+  message: string | null
+}
+
+interface ImportJobDetail extends ImportJobSummary {
+  items: ImportJobItemDetail[]
+}
+
+interface HealthRefreshJobSummary {
+  id: string
+  status: HealthRefreshJobStatus
+  trigger: 'sbom_import' | 'scheduled' | 'manual'
+  systemName: string | null
+  totalItems: number
+  completedItems: number
+  failedItems: number
+  createdAt: string
+  startedAt: string | null
+  finishedAt: string | null
+  error: string | null
+}
+
+interface HealthRefreshJobItemDetail {
+  id: string
+  componentName: string
+  componentVersion: string
+  status: HealthRefreshJobItemStatus
+  errorSummary: string | null
+}
+
+interface HealthRefreshJobDetail extends HealthRefreshJobSummary {
+  items: HealthRefreshJobItemDetail[]
+}
+
+const UBadge = resolveComponent('UBadge')
+const UButton = resolveComponent('UButton')
+
+const statusItems = [
+  { label: 'All statuses', value: 'all' },
+  { label: 'Running', value: 'running' },
+  { label: 'Queued', value: 'queued' },
+  { label: 'Failed', value: 'failed' },
+  { label: 'Completed', value: 'completed' },
+  { label: 'Cancelled', value: 'cancelled' }
+]
+
+function jobStatusColor(status: ImportJobStatus | HealthRefreshJobStatus): 'success' | 'error' | 'warning' | 'info' | 'neutral' {
+  if (status === 'completed') return 'success'
+  if (status === 'failed' || status === 'cancelled') return 'error'
+  if (status === 'running') return 'info'
+  return 'neutral'
+}
+
+function ageLabel(dateString: string | null): string {
+  if (!dateString) return '—'
+  const ms = Date.now() - new Date(dateString).getTime()
+  const minutes = Math.floor(ms / 60000)
+  if (minutes < 1) return 'just now'
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ${minutes % 60}m ago`
+  return `${Math.floor(hours / 24)}d ago`
+}
+
+// --- GitHub import jobs ---
+
+const { searchInput: githubSearchInput, debouncedSearch: githubDebouncedSearch } = useTableSearch()
+const githubStatusFilter = ref('all')
+const githubStatusQueryParam = computed(() => githubStatusFilter.value === 'all' ? '' : githubStatusFilter.value)
+
+const { page: githubPage, pageSize: githubPageSize, offset: githubOffset } = usePaginatedSorting({
+  pageSize: 25,
+  resetOn: [githubDebouncedSearch, githubStatusFilter]
+})
+
+const { data: githubData, pending: githubPending, error: githubFetchError, refresh: githubRefresh } = await useFetch<ApiResponse<ImportJobSummary>>(
+  '/api/admin/import/jobs',
+  { query: { skip: githubOffset, limit: githubPageSize, search: githubDebouncedSearch, status: githubStatusQueryParam } }
+)
+
+const githubJobs = useApiData(githubData)
+const githubTotal = useApiCount(githubData)
+
+function itemStatusColor(status: ImportJobItemStatus): 'success' | 'error' | 'warning' | 'info' | 'neutral' {
+  if (status === 'imported') return 'success'
+  if (status === 'failed') return 'error'
+  if (status === 'skipped') return 'warning'
+  if (status === 'running') return 'info'
+  return 'neutral'
+}
+
+const cancelError = ref('')
+const cancellingId = ref('')
+
+async function cancelJob(id: string) {
+  cancelError.value = ''
+  cancellingId.value = id
+  try {
+    const res = await $fetch<{ success: boolean; data: ImportJobDetail }>(
+      `/api/admin/import/jobs/${encodeURIComponent(id)}/cancel`,
+      { method: 'POST' }
+    )
+    if (detailJob.value?.id === id) {
+      detailJob.value = res.data
+    }
+    await githubRefresh()
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Failed to cancel job'
+    cancelError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
+  } finally {
+    cancellingId.value = ''
+  }
+}
+
+const detailModalOpen = ref(false)
+const detailJob = ref<ImportJobDetail | null>(null)
+const detailLoading = ref(false)
+const detailError = ref('')
+
+async function openDetail(id: string) {
+  detailModalOpen.value = true
+  detailLoading.value = true
+  detailError.value = ''
+  detailJob.value = null
+  try {
+    const res = await $fetch<{ success: boolean; data: ImportJobDetail }>(`/api/admin/import/jobs/${encodeURIComponent(id)}`)
+    detailJob.value = res.data
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Failed to load job details'
+    detailError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
+  } finally {
+    detailLoading.value = false
+  }
+}
+
+const deleteModalOpen = ref(false)
+const deleteTarget = ref<ImportJobSummary | null>(null)
+const deleteLoading = ref(false)
+const deleteError = ref('')
+
+function openDeleteModal(job: ImportJobSummary) {
+  deleteTarget.value = job
+  deleteError.value = ''
+  deleteModalOpen.value = true
+}
+
+async function confirmDelete() {
+  if (!deleteTarget.value) return
+  deleteLoading.value = true
+  deleteError.value = ''
+  try {
+    await $fetch(`/api/admin/import/jobs/${encodeURIComponent(deleteTarget.value.id)}`, { method: 'DELETE' })
+    deleteModalOpen.value = false
+    if (detailJob.value?.id === deleteTarget.value.id) {
+      detailModalOpen.value = false
+    }
+    await githubRefresh()
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Failed to delete job'
+    deleteError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
+  } finally {
+    deleteLoading.value = false
+  }
+}
+
+const githubColumns: TableColumn<ImportJobSummary>[] = [
+  {
+    accessorKey: 'organization',
+    header: 'Organization',
+    cell: ({ row }) => h('span', { class: 'font-medium' }, row.original.organization)
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => h(UBadge, { color: jobStatusColor(row.original.status), variant: 'subtle' }, () => row.original.status)
+  },
+  {
+    id: 'progress',
+    header: 'Progress',
+    cell: ({ row }) => {
+      const job = row.original
+      const parts = [`${job.completed}/${job.total}`]
+      if (job.failed > 0) parts.push(`${job.failed} failed`)
+      if (job.skipped > 0) parts.push(`${job.skipped} skipped`)
+      return h('span', { class: 'text-sm' }, parts.join(' · '))
+    }
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => h('div', {}, [
+      h('div', { class: 'text-sm' }, new Date(row.original.createdAt).toLocaleString()),
+      h('div', { class: 'text-xs text-(--ui-text-muted)' }, ageLabel(row.original.createdAt))
+    ])
+  },
+  {
+    id: 'actions',
+    header: 'Actions',
+    enableSorting: false,
+    cell: ({ row }) => {
+      const job = row.original
+      const canCancel = job.status === 'queued' || job.status === 'running'
+      return h('div', { class: 'flex gap-2' }, [
+        h(UButton, {
+          size: 'xs',
+          color: 'neutral',
+          variant: 'outline',
+          icon: 'i-lucide-eye',
+          label: 'View',
+          onClick: () => openDetail(job.id)
+        }),
+        canCancel
+          ? h(UButton, {
+              size: 'xs',
+              color: 'error',
+              variant: 'outline',
+              icon: 'i-lucide-x',
+              label: cancellingId.value === job.id ? 'Cancelling…' : 'Cancel',
+              loading: cancellingId.value === job.id,
+              onClick: () => cancelJob(job.id)
+            })
+          : h(UButton, {
+              size: 'xs',
+              color: 'error',
+              variant: 'ghost',
+              icon: 'i-lucide-trash-2',
+              label: 'Delete',
+              onClick: () => openDeleteModal(job)
+            })
+      ])
+    }
+  }
+]
+
+// --- Health-refresh jobs ---
+
+const { searchInput: healthSearchInput, debouncedSearch: healthDebouncedSearch } = useTableSearch()
+const healthStatusFilter = ref('all')
+const healthStatusQueryParam = computed(() => healthStatusFilter.value === 'all' ? '' : healthStatusFilter.value)
+
+const { page: healthPage, pageSize: healthPageSize, offset: healthOffset } = usePaginatedSorting({
+  pageSize: 25,
+  resetOn: [healthDebouncedSearch, healthStatusFilter]
+})
+
+const { data: healthData, pending: healthPending, error: healthFetchError, refresh: healthRefresh } = await useFetch<ApiResponse<HealthRefreshJobSummary>>(
+  '/api/admin/health-refresh/jobs',
+  { query: { skip: healthOffset, limit: healthPageSize, search: healthDebouncedSearch, status: healthStatusQueryParam } }
+)
+
+const healthJobs = useApiData(healthData)
+const healthTotal = useApiCount(healthData)
+
+function healthItemStatusColor(status: HealthRefreshJobItemStatus): 'success' | 'error' | 'warning' | 'info' | 'neutral' {
+  if (status === 'refreshed') return 'success'
+  if (status === 'failed') return 'error'
+  if (status === 'skipped') return 'warning'
+  if (status === 'running') return 'info'
+  return 'neutral'
+}
+
+const healthDetailModalOpen = ref(false)
+const healthDetailJob = ref<HealthRefreshJobDetail | null>(null)
+const healthDetailLoading = ref(false)
+const healthDetailError = ref('')
+
+async function openHealthDetail(id: string) {
+  healthDetailModalOpen.value = true
+  healthDetailLoading.value = true
+  healthDetailError.value = ''
+  healthDetailJob.value = null
+  try {
+    const res = await $fetch<{ success: boolean; data: HealthRefreshJobDetail }>(`/api/admin/health-refresh/jobs/${encodeURIComponent(id)}`)
+    healthDetailJob.value = res.data
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Failed to load job details'
+    healthDetailError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
+  } finally {
+    healthDetailLoading.value = false
+  }
+}
+
+const healthCancelError = ref('')
+const healthCancellingId = ref('')
+
+async function cancelHealthJob(id: string) {
+  healthCancelError.value = ''
+  healthCancellingId.value = id
+  try {
+    const res = await $fetch<{ success: boolean; data: HealthRefreshJobDetail }>(
+      `/api/admin/health-refresh/jobs/${encodeURIComponent(id)}/cancel`,
+      { method: 'POST' }
+    )
+    if (healthDetailJob.value?.id === id) {
+      healthDetailJob.value = res.data
+    }
+    await healthRefresh()
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Failed to cancel job'
+    healthCancelError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
+  } finally {
+    healthCancellingId.value = ''
+  }
+}
+
+const healthDeleteModalOpen = ref(false)
+const healthDeleteTarget = ref<HealthRefreshJobSummary | null>(null)
+const healthDeleteLoading = ref(false)
+const healthDeleteError = ref('')
+
+function openHealthDeleteModal(job: HealthRefreshJobSummary) {
+  healthDeleteTarget.value = job
+  healthDeleteError.value = ''
+  healthDeleteModalOpen.value = true
+}
+
+async function confirmHealthDelete() {
+  if (!healthDeleteTarget.value) return
+  healthDeleteLoading.value = true
+  healthDeleteError.value = ''
+  try {
+    await $fetch(`/api/admin/health-refresh/jobs/${encodeURIComponent(healthDeleteTarget.value.id)}`, { method: 'DELETE' })
+    healthDeleteModalOpen.value = false
+    if (healthDetailJob.value?.id === healthDeleteTarget.value.id) {
+      healthDetailModalOpen.value = false
+    }
+    await healthRefresh()
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'Failed to delete job'
+    healthDeleteError.value = (err as { data?: { message?: string } })?.data?.message ?? msg
+  } finally {
+    healthDeleteLoading.value = false
+  }
+}
+
+const healthColumns: TableColumn<HealthRefreshJobSummary>[] = [
+  {
+    accessorKey: 'systemName',
+    header: 'System',
+    cell: ({ row }) => h('span', { class: 'font-medium' }, row.original.systemName || 'All systems')
+  },
+  {
+    accessorKey: 'trigger',
+    header: 'Trigger',
+    cell: ({ row }) => h(UBadge, { color: 'neutral', variant: 'subtle' }, () => row.original.trigger)
+  },
+  {
+    accessorKey: 'status',
+    header: 'Status',
+    cell: ({ row }) => h(UBadge, { color: jobStatusColor(row.original.status), variant: 'subtle' }, () => row.original.status)
+  },
+  {
+    id: 'progress',
+    header: 'Progress',
+    cell: ({ row }) => {
+      const job = row.original
+      const parts = [`${job.completedItems}/${job.totalItems}`]
+      if (job.failedItems > 0) parts.push(`${job.failedItems} failed`)
+      return h('span', { class: 'text-sm' }, parts.join(' · '))
+    }
+  },
+  {
+    accessorKey: 'createdAt',
+    header: 'Created',
+    cell: ({ row }) => h('div', {}, [
+      h('div', { class: 'text-sm' }, new Date(row.original.createdAt).toLocaleString()),
+      h('div', { class: 'text-xs text-(--ui-text-muted)' }, ageLabel(row.original.createdAt))
+    ])
+  },
+  {
+    id: 'actions',
+    header: 'Actions',
+    enableSorting: false,
+    cell: ({ row }) => {
+      const job = row.original
+      const canCancel = job.status === 'queued' || job.status === 'running'
+      return h('div', { class: 'flex gap-2' }, [
+        h(UButton, {
+          size: 'xs',
+          color: 'neutral',
+          variant: 'outline',
+          icon: 'i-lucide-eye',
+          label: 'View',
+          onClick: () => openHealthDetail(job.id)
+        }),
+        canCancel
+          ? h(UButton, {
+              size: 'xs',
+              color: 'error',
+              variant: 'outline',
+              icon: 'i-lucide-x',
+              label: healthCancellingId.value === job.id ? 'Cancelling…' : 'Cancel',
+              loading: healthCancellingId.value === job.id,
+              onClick: () => cancelHealthJob(job.id)
+            })
+          : h(UButton, {
+              size: 'xs',
+              color: 'error',
+              variant: 'ghost',
+              icon: 'i-lucide-trash-2',
+              label: 'Delete',
+              onClick: () => openHealthDeleteModal(job)
+            })
+      ])
+    }
+  }
+]
+
+const tabItems = computed(() => [
+  { label: `GitHub Imports (${githubTotal.value})`, slot: 'github' as const },
+  { label: `Health Refresh (${healthTotal.value})`, slot: 'health' as const }
+])
+
+// Light polling while this monitoring page is open so status/progress stays fresh.
+let pollTimer: ReturnType<typeof setTimeout> | null = null
+function schedulePoll() {
+  pollTimer = setTimeout(async () => {
+    await Promise.all([githubRefresh(), healthRefresh()])
+    schedulePoll()
+  }, 8000)
+}
+
+onMounted(schedulePoll)
+onUnmounted(() => {
+  if (pollTimer) clearTimeout(pollTimer)
+})
+
+useHead({ title: 'Background Jobs - Polaris' })
+</script>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -215,29 +215,6 @@
           </div>
           <p class="text-xs text-(--ui-text-muted) mt-3">{{ attention.refreshCoverage.refreshedComponents }} of {{ attention.refreshCoverage.totalComponents }} direct components checked.</p>
         </UCard>
-
-        <UCard>
-          <template #header>
-            <div class="flex items-center justify-between gap-3">
-              <h3 class="font-semibold">Import Job Health</h3>
-              <UIcon name="i-lucide-download" class="size-5 text-(--ui-color-primary-500)" />
-            </div>
-          </template>
-          <div v-if="attention.importJobHealth.jobs.length > 0" class="space-y-3">
-            <div
-              v-for="job in attention.importJobHealth.jobs"
-              :key="job.id"
-              class="flex items-center justify-between gap-3"
-            >
-              <span class="truncate">{{ job.organization }}</span>
-              <UBadge :color="job.status === 'failed' ? 'error' : 'info'" variant="subtle">
-                {{ job.status }}
-              </UBadge>
-            </div>
-          </div>
-          <p v-else class="text-sm text-(--ui-text-muted)">No running or recently failed import jobs.</p>
-          <NuxtLink to="/systems" class="text-sm text-(--ui-color-primary-500) mt-3 block">View imports →</NuxtLink>
-        </UCard>
       </div>
     </div>
 
@@ -358,8 +335,7 @@ const emptyAttention: DashboardAttentionSummary = {
     sampleTechnologies: [],
     samplePlatforms: [],
     sampleSystems: []
-  },
-  importJobHealth: { total: 0, jobs: [] }
+  }
 }
 
 const attention = computed(() => attentionData.value?.data || emptyAttention)

--- a/app/pages/systems/index.vue
+++ b/app/pages/systems/index.vue
@@ -119,7 +119,12 @@
             <template v-else>
               <div class="flex flex-wrap items-center justify-between gap-3">
                 <div>
-                  <p class="font-medium">{{ ownerRepositories.length }} repositories found</p>
+                  <p class="font-medium">
+                    {{ visibleOwnerRepositories.length }} repositories found
+                    <span v-if="visibleOwnerRepositories.length !== ownerRepositories.length" class="text-(--ui-text-muted) font-normal">
+                      ({{ ownerRepositories.length - visibleOwnerRepositories.length }} hidden)
+                    </span>
+                  </p>
                   <p class="text-sm text-(--ui-text-muted)">{{ selectedRepositoryFullNames.length }} selected</p>
                 </div>
                 <div class="flex gap-2">
@@ -127,9 +132,13 @@
                   <UButton label="Clear" size="xs" color="neutral" variant="ghost" @click="clearSelectedOwnerRepositories" />
                 </div>
               </div>
+              <div class="flex flex-wrap items-center gap-4">
+                <USwitch v-model="hidePrivateRepos" label="Hide private" size="sm" />
+                <USwitch v-model="hideArchivedRepos" label="Hide archived" size="sm" />
+              </div>
               <div class="max-h-80 overflow-auto divide-y divide-(--ui-border) rounded-md border border-(--ui-border)">
                 <label
-                  v-for="repo in ownerRepositories"
+                  v-for="repo in visibleOwnerRepositories"
                   :key="repo.fullName"
                   class="flex cursor-pointer items-start gap-3 px-3 py-2"
                 >
@@ -202,6 +211,13 @@
 
           <!-- Step 3: Progress -->
           <div v-else-if="importStep === 3" class="space-y-4">
+            <UAlert
+              v-if="isJobRunning"
+              color="info"
+              variant="subtle"
+              icon="i-lucide-info"
+              description="This import continues running in the background even if you close this dialog. Visit Import Jobs (admin) anytime to check progress or cancel it."
+            />
             <USkeleton v-if="!activeImportJob" class="h-32 w-full" />
             <div v-else class="space-y-3">
               <div class="flex items-center justify-between gap-3">
@@ -274,10 +290,17 @@
         </template>
         <template v-else-if="importStep === 3">
           <UButton
+            v-if="isJobRunning"
+            label="View in Background Jobs"
+            icon="i-lucide-external-link"
+            color="neutral"
+            variant="outline"
+            to="/admin/import-jobs"
+          />
+          <UButton
             label="Close"
             color="neutral"
             variant="outline"
-            :disabled="isJobRunning"
             @click="closeImportModal"
           />
         </template>
@@ -570,8 +593,21 @@ const ownerRepositories = ref<OwnerRepository[]>([])
 const selectedRepositoryFullNames = ref<string[]>([])
 const repoConfigs = ref<RepoConfig[]>([])
 const defaultTeam = ref('')
+const hidePrivateRepos = ref(false)
+const hideArchivedRepos = ref(false)
 let importPollTimer: ReturnType<typeof setInterval> | null = null
 let importPollInFlight = false
+
+const visibleOwnerRepositories = computed(() =>
+  ownerRepositories.value.filter(repo =>
+    (!hidePrivateRepos.value || !repo.private) && (!hideArchivedRepos.value || !repo.archived)
+  )
+)
+
+watch([hidePrivateRepos, hideArchivedRepos], () => {
+  const visibleFullNames = new Set(visibleOwnerRepositories.value.map(repo => repo.fullName))
+  selectedRepositoryFullNames.value = selectedRepositoryFullNames.value.filter(name => visibleFullNames.has(name))
+})
 
 const importProgressPercent = computed(() => {
   if (!activeImportJob.value?.total) return 0
@@ -623,10 +659,12 @@ function stopImportPolling() {
 function resetOwnerRepositorySelection() {
   ownerRepositories.value = []
   selectedRepositoryFullNames.value = []
+  hidePrivateRepos.value = false
+  hideArchivedRepos.value = false
 }
 
 function selectAllOwnerRepositories() {
-  selectedRepositoryFullNames.value = ownerRepositories.value.map(repo => repo.fullName)
+  selectedRepositoryFullNames.value = visibleOwnerRepositories.value.map(repo => repo.fullName)
 }
 
 function clearSelectedOwnerRepositories() {
@@ -640,7 +678,7 @@ function toggleOwnerRepository(fullName: string, selected: boolean) {
   } else {
     current.delete(fullName)
   }
-  selectedRepositoryFullNames.value = ownerRepositories.value
+  selectedRepositoryFullNames.value = visibleOwnerRepositories.value
     .map(repo => repo.fullName)
     .filter(name => current.has(name))
 }

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -5360,10 +5360,54 @@
           "Dashboard"
         ],
         "summary": "Get prioritized, actionable dashboard items",
-        "description": "Aggregates the portfolio's actionable signals — compliance violations,\nversion constraint violations, EOL exposure, vulnerability exposure,\nthe unlinked-component queue, stewardship/ownership gaps, and GitHub\nimport job health — into a single \"needs attention\" summary.\n",
+        "description": "Aggregates the portfolio's actionable signals — compliance violations,\nversion constraint violations, EOL exposure, vulnerability exposure,\nthe unlinked-component queue, and stewardship/ownership gaps — into a\nsingle \"needs attention\" summary.\n",
         "responses": {
           "200": {
             "description": "Attention summary retrieved successfully"
+          }
+        }
+      }
+    },
+    "/components/undismiss-link": {
+      "post": {
+        "tags": [
+          "Components"
+        ],
+        "summary": "Restore a dismissed component to the link suggestions queue",
+        "description": "Clears the dismissal (all versions), so the component can reappear in /components/link-suggestions. Superuser only.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "componentName"
+                ],
+                "properties": {
+                  "componentName": {
+                    "type": "string",
+                    "description": "The component name to restore (all versions)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Component restored to queue"
+          },
+          "400": {
+            "description": "Missing componentName"
+          },
+          "403": {
+            "description": "Superuser access required"
           }
         }
       }
@@ -5678,6 +5722,55 @@
           },
           "400": {
             "description": "Missing component name or version"
+          }
+        }
+      }
+    },
+    "/components/dismissed-links": {
+      "get": {
+        "tags": [
+          "Components"
+        ],
+        "summary": "Get components dismissed from the link-suggestions queue",
+        "description": "Returns components previously dismissed via /components/dismiss-link, so they can be restored to the queue. Superuser only.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "skip",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 200
+            }
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive substring match on component name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dismissed components returned"
+          },
+          "403": {
+            "description": "Superuser access required"
           }
         }
       }
@@ -7151,6 +7244,63 @@
         }
       }
     },
+    "/admin/import/jobs": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List GitHub import jobs",
+        "description": "Paginated, filterable listing of all import jobs for the admin monitoring view. Superuser only.",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "skip",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 100
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated list of statuses to include (queued, running, completed, failed, cancelled)"
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive substring match on organization"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Import jobs retrieved successfully"
+          },
+          "403": {
+            "description": "Superuser access required"
+          }
+        }
+      }
+    },
     "/admin/import/jobs/{jobId}": {
       "get": {
         "tags": [
@@ -7181,6 +7331,80 @@
           },
           "404": {
             "description": "Import job not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Delete a GitHub import job",
+        "description": "Permanently removes a finished import job and its repository items.\nQueued/running jobs must be cancelled first. Superuser only.\n",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Import job deleted"
+          },
+          "403": {
+            "description": "Superuser access required"
+          },
+          "404": {
+            "description": "Import job not found"
+          },
+          "409": {
+            "description": "Job is still queued/running and must be cancelled first"
+          }
+        }
+      }
+    },
+    "/admin/import/jobs/{jobId}/cancel": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Cancel a GitHub import job",
+        "description": "Cancels a queued or running import job. Any not-yet-finished repositories\nare marked skipped. Superuser only.\n",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Import job cancelled"
+          },
+          "403": {
+            "description": "Superuser access required"
+          },
+          "404": {
+            "description": "Import job not found"
+          },
+          "409": {
+            "description": "Job is already finished and cannot be cancelled"
           }
         }
       }
@@ -7248,6 +7472,171 @@
           },
           "422": {
             "description": "GitHub owner not accessible"
+          }
+        }
+      }
+    },
+    "/admin/health-refresh/jobs": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List health-refresh jobs",
+        "description": "Paginated, filterable listing of all health-refresh jobs for the admin monitoring view. Superuser only.",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "skip",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 100
+            }
+          },
+          {
+            "in": "query",
+            "name": "status",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated list of statuses to include (queued, running, completed, failed, cancelled)"
+          },
+          {
+            "in": "query",
+            "name": "search",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case-insensitive substring match on system name"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Health-refresh jobs retrieved successfully"
+          },
+          "403": {
+            "description": "Superuser access required"
+          }
+        }
+      }
+    },
+    "/admin/health-refresh/jobs/{jobId}": {
+      "get": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get health-refresh job status",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Health-refresh job status"
+          },
+          "403": {
+            "description": "Superuser access required"
+          },
+          "404": {
+            "description": "Health-refresh job not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Delete a health-refresh job",
+        "description": "Permanently removes a finished health-refresh job and its items.\nQueued/running jobs must be cancelled first. Superuser only.\n",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Health-refresh job deleted"
+          },
+          "403": {
+            "description": "Superuser access required"
+          },
+          "404": {
+            "description": "Health-refresh job not found"
+          },
+          "409": {
+            "description": "Job is still queued/running and must be cancelled first"
+          }
+        }
+      }
+    },
+    "/admin/health-refresh/jobs/{jobId}/cancel": {
+      "post": {
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Cancel a health-refresh job",
+        "description": "Cancels a queued or running health-refresh job. Any not-yet-finished\nitems are marked skipped. Superuser only.\n",
+        "security": [
+          {
+            "sessionAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "path",
+            "name": "jobId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Health-refresh job cancelled"
+          },
+          "403": {
+            "description": "Superuser access required"
+          },
+          "404": {
+            "description": "Health-refresh job not found"
+          },
+          "409": {
+            "description": "Job is already finished and cannot be cancelled"
           }
         }
       }

--- a/server/api/admin/health-refresh/jobs/[jobId].get.ts
+++ b/server/api/admin/health-refresh/jobs/[jobId].get.ts
@@ -1,0 +1,43 @@
+import { healthRefreshService } from '../../../../services/singletons'
+
+/**
+ * @openapi
+ * /admin/health-refresh/jobs/{jobId}:
+ *   get:
+ *     tags:
+ *       - Admin
+ *     summary: Get health-refresh job status
+ *     security:
+ *       - sessionAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: jobId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Health-refresh job status
+ *       403:
+ *         description: Superuser access required
+ *       404:
+ *         description: Health-refresh job not found
+ */
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+
+  const jobId = getRouterParam(event, 'jobId') || ''
+  if (!jobId) {
+    throw createError({ statusCode: 400, message: 'jobId is required' })
+  }
+
+  const job = await healthRefreshService.findById(jobId)
+  if (!job) {
+    throw createError({ statusCode: 404, message: 'Health-refresh job not found' })
+  }
+
+  return {
+    success: true,
+    data: job
+  }
+})

--- a/server/api/admin/health-refresh/jobs/[jobId]/cancel.post.ts
+++ b/server/api/admin/health-refresh/jobs/[jobId]/cancel.post.ts
@@ -1,0 +1,55 @@
+import { healthRefreshService } from '../../../../../services/singletons'
+import { auditFailedOperation } from '../../../../../utils/audit'
+
+/**
+ * @openapi
+ * /admin/health-refresh/jobs/{jobId}/cancel:
+ *   post:
+ *     tags:
+ *       - Admin
+ *     summary: Cancel a health-refresh job
+ *     description: |
+ *       Cancels a queued or running health-refresh job. Any not-yet-finished
+ *       items are marked skipped. Superuser only.
+ *     security:
+ *       - sessionAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: jobId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Health-refresh job cancelled
+ *       403:
+ *         description: Superuser access required
+ *       404:
+ *         description: Health-refresh job not found
+ *       409:
+ *         description: Job is already finished and cannot be cancelled
+ */
+export default defineEventHandler(async (event) => {
+  const user = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
+
+  const jobId = getRouterParam(event, 'jobId') || ''
+  if (!jobId) {
+    throw createError({ statusCode: 400, message: 'jobId is required' })
+  }
+
+  try {
+    const job = await healthRefreshService.cancel(jobId, { userId: user.id, realUserId })
+    return { success: true, data: job }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'CANCEL_HEALTH_REFRESH_JOB',
+      entityType: 'HealthRefreshJob',
+      entityId: jobId,
+      reason: error instanceof Error ? error.message : 'Failed to cancel health-refresh job',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
+})

--- a/server/api/admin/health-refresh/jobs/[jobId]/index.delete.ts
+++ b/server/api/admin/health-refresh/jobs/[jobId]/index.delete.ts
@@ -1,0 +1,55 @@
+import { healthRefreshService } from '../../../../../services/singletons'
+import { auditFailedOperation } from '../../../../../utils/audit'
+
+/**
+ * @openapi
+ * /admin/health-refresh/jobs/{jobId}:
+ *   delete:
+ *     tags:
+ *       - Admin
+ *     summary: Delete a health-refresh job
+ *     description: |
+ *       Permanently removes a finished health-refresh job and its items.
+ *       Queued/running jobs must be cancelled first. Superuser only.
+ *     security:
+ *       - sessionAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: jobId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Health-refresh job deleted
+ *       403:
+ *         description: Superuser access required
+ *       404:
+ *         description: Health-refresh job not found
+ *       409:
+ *         description: Job is still queued/running and must be cancelled first
+ */
+export default defineEventHandler(async (event) => {
+  const user = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
+
+  const jobId = getRouterParam(event, 'jobId') || ''
+  if (!jobId) {
+    throw createError({ statusCode: 400, message: 'jobId is required' })
+  }
+
+  try {
+    await healthRefreshService.remove(jobId, { userId: user.id, realUserId })
+    return { success: true, message: 'Health-refresh job deleted' }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE_HEALTH_REFRESH_JOB',
+      entityType: 'HealthRefreshJob',
+      entityId: jobId,
+      reason: error instanceof Error ? error.message : 'Failed to delete health-refresh job',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
+})

--- a/server/api/admin/health-refresh/jobs/index.get.ts
+++ b/server/api/admin/health-refresh/jobs/index.get.ts
@@ -1,0 +1,70 @@
+import { healthRefreshService } from '../../../../services/singletons'
+import { parseSearchParam } from '../../../../utils/query-params'
+import type { HealthRefreshJobStatus } from '../../../../repositories/health-refresh.repository'
+
+const VALID_STATUSES: HealthRefreshJobStatus[] = ['queued', 'running', 'completed', 'failed', 'cancelled']
+
+/**
+ * @openapi
+ * /admin/health-refresh/jobs:
+ *   get:
+ *     tags:
+ *       - Admin
+ *     summary: List health-refresh jobs
+ *     description: Paginated, filterable listing of all health-refresh jobs for the admin monitoring view. Superuser only.
+ *     security:
+ *       - sessionAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: skip
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *           maximum: 100
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *         description: Comma-separated list of statuses to include (queued, running, completed, failed, cancelled)
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Case-insensitive substring match on system name
+ *     responses:
+ *       200:
+ *         description: Health-refresh jobs retrieved successfully
+ *       403:
+ *         description: Superuser access required
+ */
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+
+  const query = getQuery(event)
+  const skip = Math.max(0, Math.floor(Number(query.skip ?? '0')) || 0)
+  const limit = Math.min(100, Math.max(1, Math.floor(Number(query.limit ?? '20')) || 20))
+  const statusParam = typeof query.status === 'string' ? query.status : ''
+  const statuses = statusParam
+    .split(',')
+    .map(s => s.trim())
+    .filter((s): s is HealthRefreshJobStatus => VALID_STATUSES.includes(s as HealthRefreshJobStatus))
+
+  const result = await healthRefreshService.findAll({
+    skip,
+    limit,
+    statuses: statuses.length > 0 ? statuses : undefined,
+    search: parseSearchParam(query.search)
+  })
+
+  return {
+    success: true,
+    data: result.jobs,
+    count: result.jobs.length,
+    total: result.total
+  }
+})

--- a/server/api/admin/import/jobs/[jobId]/cancel.post.ts
+++ b/server/api/admin/import/jobs/[jobId]/cancel.post.ts
@@ -1,0 +1,55 @@
+import { gitHubOrgImportService } from '../../../../../services/singletons'
+import { auditFailedOperation } from '../../../../../utils/audit'
+
+/**
+ * @openapi
+ * /admin/import/jobs/{jobId}/cancel:
+ *   post:
+ *     tags:
+ *       - Admin
+ *     summary: Cancel a GitHub import job
+ *     description: |
+ *       Cancels a queued or running import job. Any not-yet-finished repositories
+ *       are marked skipped. Superuser only.
+ *     security:
+ *       - sessionAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: jobId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Import job cancelled
+ *       403:
+ *         description: Superuser access required
+ *       404:
+ *         description: Import job not found
+ *       409:
+ *         description: Job is already finished and cannot be cancelled
+ */
+export default defineEventHandler(async (event) => {
+  const user = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
+
+  const jobId = getRouterParam(event, 'jobId') || ''
+  if (!jobId) {
+    throw createError({ statusCode: 400, message: 'jobId is required' })
+  }
+
+  try {
+    const job = await gitHubOrgImportService.cancel(jobId, { userId: user.id, realUserId })
+    return { success: true, data: job }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'CANCEL_IMPORT_JOB',
+      entityType: 'ImportJob',
+      entityId: jobId,
+      reason: error instanceof Error ? error.message : 'Failed to cancel import job',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
+})

--- a/server/api/admin/import/jobs/[jobId]/index.delete.ts
+++ b/server/api/admin/import/jobs/[jobId]/index.delete.ts
@@ -1,0 +1,55 @@
+import { gitHubOrgImportService } from '../../../../../services/singletons'
+import { auditFailedOperation } from '../../../../../utils/audit'
+
+/**
+ * @openapi
+ * /admin/import/jobs/{jobId}:
+ *   delete:
+ *     tags:
+ *       - Admin
+ *     summary: Delete a GitHub import job
+ *     description: |
+ *       Permanently removes a finished import job and its repository items.
+ *       Queued/running jobs must be cancelled first. Superuser only.
+ *     security:
+ *       - sessionAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: jobId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Import job deleted
+ *       403:
+ *         description: Superuser access required
+ *       404:
+ *         description: Import job not found
+ *       409:
+ *         description: Job is still queued/running and must be cancelled first
+ */
+export default defineEventHandler(async (event) => {
+  const user = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
+
+  const jobId = getRouterParam(event, 'jobId') || ''
+  if (!jobId) {
+    throw createError({ statusCode: 400, message: 'jobId is required' })
+  }
+
+  try {
+    await gitHubOrgImportService.remove(jobId, { userId: user.id, realUserId })
+    return { success: true, message: 'Import job deleted' }
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'DELETE_IMPORT_JOB',
+      entityType: 'ImportJob',
+      entityId: jobId,
+      reason: error instanceof Error ? error.message : 'Failed to delete import job',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
+})

--- a/server/api/admin/import/jobs/index.get.ts
+++ b/server/api/admin/import/jobs/index.get.ts
@@ -1,0 +1,70 @@
+import { gitHubOrgImportService } from '../../../../services/singletons'
+import { parseSearchParam } from '../../../../utils/query-params'
+import type { ImportJobStatus } from '../../../../repositories/import-job.repository'
+
+const VALID_STATUSES: ImportJobStatus[] = ['queued', 'running', 'completed', 'failed', 'cancelled']
+
+/**
+ * @openapi
+ * /admin/import/jobs:
+ *   get:
+ *     tags:
+ *       - Admin
+ *     summary: List GitHub import jobs
+ *     description: Paginated, filterable listing of all import jobs for the admin monitoring view. Superuser only.
+ *     security:
+ *       - sessionAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: skip
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 20
+ *           maximum: 100
+ *       - in: query
+ *         name: status
+ *         schema:
+ *           type: string
+ *         description: Comma-separated list of statuses to include (queued, running, completed, failed, cancelled)
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Case-insensitive substring match on organization
+ *     responses:
+ *       200:
+ *         description: Import jobs retrieved successfully
+ *       403:
+ *         description: Superuser access required
+ */
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+
+  const query = getQuery(event)
+  const skip = Math.max(0, Math.floor(Number(query.skip ?? '0')) || 0)
+  const limit = Math.min(100, Math.max(1, Math.floor(Number(query.limit ?? '20')) || 20))
+  const statusParam = typeof query.status === 'string' ? query.status : ''
+  const statuses = statusParam
+    .split(',')
+    .map(s => s.trim())
+    .filter((s): s is ImportJobStatus => VALID_STATUSES.includes(s as ImportJobStatus))
+
+  const result = await gitHubOrgImportService.findAll({
+    skip,
+    limit,
+    statuses: statuses.length > 0 ? statuses : undefined,
+    search: parseSearchParam(query.search)
+  })
+
+  return {
+    success: true,
+    data: result.jobs,
+    count: result.jobs.length,
+    total: result.total
+  }
+})

--- a/server/api/components/dismissed-links.get.ts
+++ b/server/api/components/dismissed-links.get.ts
@@ -1,0 +1,52 @@
+import { componentService } from '../../services/singletons'
+import { parseSearchParam } from '../../utils/query-params'
+
+/**
+ * @openapi
+ * /components/dismissed-links:
+ *   get:
+ *     tags:
+ *       - Components
+ *     summary: Get components dismissed from the link-suggestions queue
+ *     description: Returns components previously dismissed via /components/dismiss-link, so they can be restored to the queue. Superuser only.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: skip
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *           maximum: 200
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *         description: Case-insensitive substring match on component name
+ *     responses:
+ *       200:
+ *         description: Dismissed components returned
+ *       403:
+ *         description: Superuser access required
+ */
+export default defineEventHandler(async (event) => {
+  await requireSuperuser(event)
+
+  const query = getQuery(event)
+  const skip = Math.max(0, Math.floor(Number(query.skip ?? '0')) || 0)
+  const limit = Math.min(200, Math.max(1, Math.floor(Number(query.limit ?? '50')) || 50))
+
+  const result = await componentService.getDismissedLinks(skip, limit, parseSearchParam(query.search))
+
+  return {
+    success: true,
+    data: result.data,
+    count: result.count,
+    total: result.total
+  }
+})

--- a/server/api/components/undismiss-link.post.ts
+++ b/server/api/components/undismiss-link.post.ts
@@ -1,0 +1,58 @@
+import { componentService } from '../../services/singletons'
+import { auditFailedOperation } from '../../utils/audit'
+
+/**
+ * @openapi
+ * /components/undismiss-link:
+ *   post:
+ *     tags:
+ *       - Components
+ *     summary: Restore a dismissed component to the link suggestions queue
+ *     description: Clears the dismissal (all versions), so the component can reappear in /components/link-suggestions. Superuser only.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - componentName
+ *             properties:
+ *               componentName:
+ *                 type: string
+ *                 description: The component name to restore (all versions)
+ *     responses:
+ *       204:
+ *         description: Component restored to queue
+ *       400:
+ *         description: Missing componentName
+ *       403:
+ *         description: Superuser access required
+ */
+export default defineEventHandler(async (event) => {
+  const user = await requireSuperuser(event)
+  const realUserId = await getImpersonatorId(event)
+
+  const body = await readBody(event)
+  if (!body?.componentName) {
+    throw createError({ statusCode: 400, message: 'componentName is required' })
+  }
+
+  try {
+    await componentService.undismissLink(body.componentName)
+    setResponseStatus(event, 204)
+    return null
+  } catch (error) {
+    await auditFailedOperation(event, {
+      operation: 'UNDISMISS_LINK',
+      entityType: 'Component',
+      entityId: body.componentName,
+      reason: error instanceof Error ? error.message : 'Failed to restore component link',
+      userId: user.id,
+      realUserId
+    })
+    throw error
+  }
+})

--- a/server/api/dashboard/attention.get.ts
+++ b/server/api/dashboard/attention.get.ts
@@ -4,7 +4,6 @@ import {
   complianceService,
   healthRefreshService,
   componentService,
-  gitHubOrgImportService,
   teamService
 } from '../../services/singletons'
 import { cachedFetch } from '../../utils/cache'
@@ -20,8 +19,8 @@ import type { DashboardAttentionSummary } from '~~/types/api'
  *     description: |
  *       Aggregates the portfolio's actionable signals — compliance violations,
  *       version constraint violations, EOL exposure, vulnerability exposure,
- *       the unlinked-component queue, stewardship/ownership gaps, and GitHub
- *       import job health — into a single "needs attention" summary.
+ *       the unlinked-component queue, and stewardship/ownership gaps — into a
+ *       single "needs attention" summary.
  *     responses:
  *       200:
  *         description: Attention summary retrieved successfully
@@ -42,14 +41,12 @@ async function buildAttentionSummary(currentUser: Awaited<ReturnType<typeof getC
     compliance,
     healthSummary,
     stewardshipGaps,
-    importJobHealth,
     linkQueue
   ] = await Promise.all([
     versionConstraintService.getViolations({}),
     complianceService.findViolations(),
     healthRefreshService.getDashboardSummary(),
     teamService.getStewardshipGaps(),
-    gitHubOrgImportService.findRecentActive(),
     currentUser?.role === 'superuser'
       ? componentService.getLinkSuggestions(0, 5)
       : Promise.resolve(null)
@@ -77,16 +74,7 @@ async function buildAttentionSummary(currentUser: Awaited<ReturnType<typeof getC
       warning: versionViolations.summary.warning
     },
     componentLinkQueue: linkQueue ? { total: linkQueue.total } : null,
-    stewardshipGaps,
-    importJobHealth: {
-      total: importJobHealth.total,
-      jobs: importJobHealth.jobs.map(job => ({
-        id: job.id,
-        organization: job.organization,
-        status: job.status,
-        createdAt: job.createdAt
-      }))
-    }
+    stewardshipGaps
   }
 
   return { success: true, data }

--- a/server/database/queries/components/dismissed-links-count.cypher
+++ b/server/database/queries/components/dismissed-links-count.cypher
@@ -1,0 +1,4 @@
+MATCH (c:Component)
+WHERE c.linkDismissedAt IS NOT NULL
+  AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
+RETURN count(DISTINCT c.name) AS total

--- a/server/database/queries/components/dismissed-links.cypher
+++ b/server/database/queries/components/dismissed-links.cypher
@@ -1,0 +1,20 @@
+// Returns components previously dismissed from the link-suggestions queue.
+// Deduplicates by component name (ignoring version), since dismissal applies to
+// all versions of a component at once — see components/dismiss-link.cypher.
+// Ordered most-recently-dismissed first.
+MATCH (c:Component)
+WHERE c.linkDismissedAt IS NOT NULL
+  AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
+WITH c.name AS componentName, c.packageManager AS packageManager, c.description AS description, c.purl AS purl, c.linkDismissedAt AS linkDismissedAt
+WITH componentName, packageManager,
+     [d IN collect(description) WHERE d IS NOT NULL][0] AS description,
+     [p IN collect(purl) WHERE p IS NOT NULL][0] AS purl,
+     max(linkDismissedAt) AS dismissedAt
+ORDER BY dismissedAt DESC, componentName ASC
+SKIP toInteger($skip) LIMIT toInteger($limit)
+RETURN
+  componentName AS name,
+  packageManager,
+  description,
+  purl,
+  toString(dismissedAt) AS dismissedAt

--- a/server/database/queries/components/link-suggestions.cypher
+++ b/server/database/queries/components/link-suggestions.cypher
@@ -18,20 +18,21 @@ WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND c.linkDismissedAt IS NULL
   AND c.purl IS NOT NULL
   AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
-WITH c.name AS componentName, c.packageManager AS packageManager, c.description AS description,
+WITH c.name AS componentName, c.packageManager AS packageManager, c.description AS description, c.purl AS purl,
      toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
 WHERE size(purlName) > 0
-// Different versions of the same component may carry different (or missing) descriptions — take the first non-null one
+// Different versions of the same component may carry different (or missing) description/purl — take the first non-null one
 WITH componentName, packageManager, purlName,
-     [d IN collect(description) WHERE d IS NOT NULL][0] AS description
+     [d IN collect(description) WHERE d IS NOT NULL][0] AS description,
+     [p IN collect(purl) WHERE p IS NOT NULL][0] AS purl
 OPTIONAL MATCH (t:Technology)
   WHERE toLower(t.name) = purlName AND t IS NOT NULL
-WITH componentName, packageManager, purlName, description, [x IN collect(t.name) WHERE x IS NOT NULL] AS exactMatches
+WITH componentName, packageManager, purlName, description, purl, [x IN collect(t.name) WHERE x IS NOT NULL] AS exactMatches
 OPTIONAL MATCH (t2:Technology)
   WHERE toLower(t2.name) CONTAINS purlName AND NOT toLower(t2.name) = purlName AND t2 IS NOT NULL
-WITH componentName, packageManager, purlName, description, exactMatches,
+WITH componentName, packageManager, purlName, description, purl, exactMatches,
      [x IN collect(t2.name) WHERE x IS NOT NULL][0..4] AS partialMatches
-WITH componentName, packageManager, purlName, description,
+WITH componentName, packageManager, purlName, description, purl,
      exactMatches + partialMatches AS suggestedTechnologies,
      size(exactMatches) > 0 AS hasExactMatch
 ORDER BY hasExactMatch DESC, componentName ASC
@@ -39,9 +40,8 @@ SKIP toInteger($skip) LIMIT toInteger($limit)
 RETURN
   componentName AS name,
   packageManager,
-  componentName AS purl,
+  purl,
   purlName,
   description,
   suggestedTechnologies,
   hasExactMatch
-

--- a/server/database/queries/components/undismiss-link.cypher
+++ b/server/database/queries/components/undismiss-link.cypher
@@ -1,0 +1,3 @@
+MATCH (c:Component {name: $componentName})
+REMOVE c.linkDismissedAt
+RETURN count(c) AS restored

--- a/server/database/queries/health-refresh/cancel-pending-items.cypher
+++ b/server/database/queries/health-refresh/cancel-pending-items.cypher
@@ -1,0 +1,4 @@
+MATCH (:HealthRefreshJob {id: $jobId})-[:HAS_ITEM]->(item:HealthRefreshJobItem)
+WHERE item.status IN ['pending', 'running']
+SET item.status = 'skipped',
+    item.finishedAt = coalesce(item.finishedAt, datetime())

--- a/server/database/queries/health-refresh/delete-job.cypher
+++ b/server/database/queries/health-refresh/delete-job.cypher
@@ -1,0 +1,3 @@
+MATCH (job:HealthRefreshJob {id: $id})
+OPTIONAL MATCH (job)-[:HAS_ITEM]->(item:HealthRefreshJobItem)
+DETACH DELETE job, item

--- a/server/database/queries/health-refresh/find-all.cypher
+++ b/server/database/queries/health-refresh/find-all.cypher
@@ -1,0 +1,7 @@
+MATCH (job:HealthRefreshJob)
+WHERE ($statuses IS NULL OR job.status IN $statuses)
+  AND ($search IS NULL OR toLower(coalesce(job.systemName, '')) CONTAINS toLower($search))
+WITH job
+ORDER BY job.createdAt DESC
+WITH collect(job) AS jobs
+RETURN size(jobs) AS total, jobs[$skip..$skip + $limit] AS jobs

--- a/server/database/queries/health-refresh/get-status.cypher
+++ b/server/database/queries/health-refresh/get-status.cypher
@@ -1,0 +1,2 @@
+MATCH (job:HealthRefreshJob {id: $id})
+RETURN job.status AS status

--- a/server/database/queries/health-refresh/mark-cancelled.cypher
+++ b/server/database/queries/health-refresh/mark-cancelled.cypher
@@ -1,0 +1,5 @@
+MATCH (job:HealthRefreshJob {id: $id})
+WHERE job.status IN ['queued', 'running']
+SET job.status = 'cancelled',
+    job.finishedAt = datetime(),
+    job.error = 'Cancelled by admin'

--- a/server/database/queries/import-jobs/cancel-pending-items.cypher
+++ b/server/database/queries/import-jobs/cancel-pending-items.cypher
@@ -1,0 +1,9 @@
+MATCH (job:ImportJob {id: $jobId})-[:HAS_ITEM]->(item:ImportJobItem)
+WHERE item.status IN ['pending', 'running']
+WITH job, collect(item) AS pendingItems
+FOREACH (item IN pendingItems |
+  SET item.status = 'skipped',
+      item.message = 'Cancelled',
+      item.finishedAt = coalesce(item.finishedAt, datetime())
+)
+SET job.skipped = job.skipped + size(pendingItems)

--- a/server/database/queries/import-jobs/delete-job.cypher
+++ b/server/database/queries/import-jobs/delete-job.cypher
@@ -1,0 +1,3 @@
+MATCH (job:ImportJob {id: $id})
+OPTIONAL MATCH (job)-[:HAS_ITEM]->(item:ImportJobItem)
+DETACH DELETE job, item

--- a/server/database/queries/import-jobs/find-all.cypher
+++ b/server/database/queries/import-jobs/find-all.cypher
@@ -1,0 +1,7 @@
+MATCH (job:ImportJob)
+WHERE ($statuses IS NULL OR job.status IN $statuses)
+  AND ($search IS NULL OR toLower(job.organization) CONTAINS toLower($search))
+WITH job
+ORDER BY job.createdAt DESC
+WITH collect(job) AS jobs
+RETURN size(jobs) AS total, jobs[$skip..$skip + $limit] AS jobs

--- a/server/database/queries/import-jobs/find-recent-active.cypher
+++ b/server/database/queries/import-jobs/find-recent-active.cypher
@@ -1,6 +1,0 @@
-MATCH (job:ImportJob)
-WHERE job.status IN ['running', 'queued']
-   OR (job.status = 'failed' AND job.createdAt >= datetime() - duration({hours: $sinceHours}))
-WITH job
-ORDER BY job.createdAt DESC
-RETURN count(job) AS total, collect(job)[0..$limit] AS jobs

--- a/server/database/queries/import-jobs/get-status.cypher
+++ b/server/database/queries/import-jobs/get-status.cypher
@@ -1,0 +1,2 @@
+MATCH (job:ImportJob {id: $id})
+RETURN job.status AS status

--- a/server/database/queries/import-jobs/mark-cancelled.cypher
+++ b/server/database/queries/import-jobs/mark-cancelled.cypher
@@ -1,0 +1,5 @@
+MATCH (job:ImportJob {id: $id})
+WHERE job.status IN ['queued', 'running']
+SET job.status = 'cancelled',
+    job.finishedAt = datetime(),
+    job.error = 'Cancelled by admin'

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -53,6 +53,14 @@ export interface LinkSuggestion {
   hasExactMatch: boolean
 }
 
+export interface DismissedComponent {
+  name: string
+  packageManager: string | null
+  description: string | null
+  purl: string | null
+  dismissedAt: string
+}
+
 export interface ComponentEOLCandidate {
   name: string
   version: string
@@ -415,6 +423,31 @@ export class ComponentRepository extends BaseRepository {
   async dismissLink(componentName: string): Promise<void> {
     const query = await loadQuery('components/dismiss-link.cypher')
     await this.executeQuery(query, { componentName })
+  }
+
+  async undismissLink(componentName: string): Promise<void> {
+    const query = await loadQuery('components/undismiss-link.cypher')
+    await this.executeQuery(query, { componentName })
+  }
+
+  async getDismissedLinks(skip: number, limit: number, search?: string): Promise<{ data: DismissedComponent[]; total: number }> {
+    const countQuery = await loadQuery('components/dismissed-links-count.cypher')
+    const dataQuery = await loadQuery('components/dismissed-links.cypher')
+
+    const { records: countRecords } = await this.executeQuery(countQuery, { search: search || null })
+    const total = countRecords.length > 0 ? countRecords[0]!.get('total').toNumber() : 0
+
+    const { records } = await this.executeQuery(dataQuery, { skip, limit, search: search || null })
+    return {
+      data: records.map(record => ({
+        name: record.get('name') as string,
+        packageManager: record.get('packageManager') as string | null,
+        description: record.get('description') as string | null,
+        purl: record.get('purl') as string | null,
+        dismissedAt: record.get('dismissedAt') as string
+      })),
+      total
+    }
   }
 
   async findEOLCandidates(): Promise<ComponentEOLCandidate[]> {

--- a/server/repositories/health-refresh.repository.ts
+++ b/server/repositories/health-refresh.repository.ts
@@ -1,5 +1,6 @@
 import { BaseRepository } from './base.repository'
 import type { Record as Neo4jRecord } from 'neo4j-driver'
+import neo4j from 'neo4j-driver'
 import type { HealthDashboardSummary } from '~~/types/api'
 import { loadQuery, injectPlaceholder } from '../utils/query-loader'
 
@@ -54,6 +55,27 @@ export interface HealthSnapshotUpdate {
   componentName: string
   values: Record<string, unknown>
   advisories?: AdvisorySnapshot[]
+}
+
+export interface HealthRefreshJobSummary {
+  id: string
+  status: HealthRefreshJobStatus
+  trigger: HealthRefreshTrigger
+  systemName: string | null
+  totalItems: number
+  completedItems: number
+  failedItems: number
+  createdAt: string
+  startedAt: string | null
+  finishedAt: string | null
+  error: string | null
+}
+
+export interface FindAllHealthRefreshJobsParams {
+  skip?: number
+  limit?: number
+  statuses?: HealthRefreshJobStatus[]
+  search?: string
 }
 
 function intValue(value: unknown): number {
@@ -128,6 +150,33 @@ export class HealthRefreshRepository extends BaseRepository {
     return this.mapJob(records[0]!)
   }
 
+  async getStatus(id: string): Promise<HealthRefreshJobStatus | null> {
+    const { records } = await this.executeQuery(await loadQuery('health-refresh/get-status.cypher'), { id })
+
+    if (records.length === 0) return null
+    return records[0]!.get('status') as HealthRefreshJobStatus
+  }
+
+  /** Paginated, filterable job listing for the admin monitoring view. */
+  async findAll(params: FindAllHealthRefreshJobsParams = {}): Promise<{ total: number; jobs: HealthRefreshJobSummary[] }> {
+    const { records } = await this.executeQuery(await loadQuery('health-refresh/find-all.cypher'), {
+      statuses: params.statuses && params.statuses.length > 0 ? params.statuses : null,
+      search: params.search?.trim() || null,
+      skip: neo4j.int(params.skip ?? 0),
+      limit: neo4j.int(params.limit ?? 20)
+    })
+
+    if (records.length === 0) return { total: 0, jobs: [] }
+
+    const record = records[0]!
+    const rawJobs = (record.get('jobs') || []) as Array<{ properties: Record<string, unknown> }>
+
+    return {
+      total: intValue(record.get('total')),
+      jobs: rawJobs.map(job => this.mapJobSummary(job.properties))
+    }
+  }
+
   async getPendingItems(jobId: string, limit = 25): Promise<HealthRefreshJobItem[]> {
     const { records } = await this.executeQuery(await loadQuery('health-refresh/get-pending-items.cypher'), { jobId, limit })
 
@@ -164,6 +213,20 @@ export class HealthRefreshRepository extends BaseRepository {
 
   async markJobFailed(jobId: string, error: string): Promise<void> {
     await this.executeQuery(await loadQuery('health-refresh/mark-job-failed.cypher'), { jobId, error })
+  }
+
+  /** Only transitions jobs still in `queued`/`running` — a no-op on already-finished jobs. */
+  async markCancelled(id: string): Promise<void> {
+    await this.executeQuery(await loadQuery('health-refresh/mark-cancelled.cypher'), { id })
+  }
+
+  /** Marks any not-yet-finished items as skipped once their job is cancelled. */
+  async cancelPendingItems(jobId: string): Promise<void> {
+    await this.executeQuery(await loadQuery('health-refresh/cancel-pending-items.cypher'), { jobId })
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.executeQuery(await loadQuery('health-refresh/delete-job.cypher'), { id })
   }
 
   async upsertHealthSnapshot(update: HealthSnapshotUpdate): Promise<void> {
@@ -208,6 +271,22 @@ export class HealthRefreshRepository extends BaseRepository {
       error: job.properties.error || null,
       correlationId: job.properties.correlationId || null,
       items
+    }
+  }
+
+  private mapJobSummary(job: Record<string, unknown>): HealthRefreshJobSummary {
+    return {
+      id: job.id as string,
+      status: job.status as HealthRefreshJobStatus,
+      trigger: job.trigger as HealthRefreshTrigger,
+      systemName: (job.systemName as string | null | undefined) ?? null,
+      totalItems: intValue(job.totalItems),
+      completedItems: intValue(job.completedItems),
+      failedItems: intValue(job.failedItems),
+      createdAt: job.createdAt?.toString() || '',
+      startedAt: job.startedAt?.toString() || null,
+      finishedAt: job.finishedAt?.toString() || null,
+      error: (job.error as string | null | undefined) ?? null
     }
   }
 

--- a/server/repositories/import-job.repository.ts
+++ b/server/repositories/import-job.repository.ts
@@ -59,11 +59,22 @@ export interface ImportJobSummary {
   id: string
   status: ImportJobStatus
   organization: string
+  requestedBy: string
   total: number
   completed: number
   failed: number
+  skipped: number
   createdAt: string
+  startedAt: string | null
+  finishedAt: string | null
   error: string | null
+}
+
+export interface FindAllImportJobsParams {
+  skip?: number
+  limit?: number
+  statuses?: ImportJobStatus[]
+  search?: string
 }
 
 export interface CreateImportJobItemParams {
@@ -108,12 +119,23 @@ export class ImportJobRepository extends BaseRepository {
     return this.mapJob(records[0]!)
   }
 
+  async getStatus(id: string): Promise<ImportJobStatus | null> {
+    const { records } = await this.executeQuery(await loadQuery('import-jobs/get-status.cypher'), { id })
+
+    if (records.length === 0) return null
+    return records[0]!.get('status') as ImportJobStatus
+  }
+
   /**
-   * Currently active jobs (running/queued) plus jobs that failed within the
-   * last `sinceHours` — the set worth surfacing on a "needs attention" view.
+   * Paginated, filterable job listing for the admin monitoring view.
    */
-  async findRecentActive(sinceHours = 24, limit = 5): Promise<{ total: number; jobs: ImportJobSummary[] }> {
-    const { records } = await this.executeQuery(await loadQuery('import-jobs/find-recent-active.cypher'), { sinceHours, limit: neo4j.int(limit) })
+  async findAll(params: FindAllImportJobsParams = {}): Promise<{ total: number; jobs: ImportJobSummary[] }> {
+    const { records } = await this.executeQuery(await loadQuery('import-jobs/find-all.cypher'), {
+      statuses: params.statuses && params.statuses.length > 0 ? params.statuses : null,
+      search: params.search?.trim() || null,
+      skip: neo4j.int(params.skip ?? 0),
+      limit: neo4j.int(params.limit ?? 20)
+    })
 
     if (records.length === 0) return { total: 0, jobs: [] }
 
@@ -136,6 +158,20 @@ export class ImportJobRepository extends BaseRepository {
 
   async markFailed(id: string, error: string): Promise<void> {
     await this.executeQuery(await loadQuery('import-jobs/mark-failed.cypher'), { id, error })
+  }
+
+  /** Only transitions jobs still in `queued`/`running` — a no-op on already-finished jobs. */
+  async markCancelled(id: string): Promise<void> {
+    await this.executeQuery(await loadQuery('import-jobs/mark-cancelled.cypher'), { id })
+  }
+
+  /** Marks any not-yet-finished items as skipped once their job is cancelled, keeping progress counters consistent. */
+  async cancelPendingItems(jobId: string): Promise<void> {
+    await this.executeQuery(await loadQuery('import-jobs/cancel-pending-items.cypher'), { jobId })
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.executeQuery(await loadQuery('import-jobs/delete-job.cypher'), { id })
   }
 
   async createItems(jobId: string, items: CreateImportJobItemParams[]): Promise<void> {
@@ -208,10 +244,14 @@ export class ImportJobRepository extends BaseRepository {
       id: job.id as string,
       status: job.status as ImportJobStatus,
       organization: job.organization as string,
+      requestedBy: job.requestedBy as string,
       total: intValue(job.total),
       completed: intValue(job.completed),
       failed: intValue(job.failed),
+      skipped: intValue(job.skipped),
       createdAt: job.createdAt?.toString() || '',
+      startedAt: job.startedAt?.toString() || null,
+      finishedAt: job.finishedAt?.toString() || null,
       error: (job.error as string | null | undefined) ?? null
     }
   }

--- a/server/services/component.service.ts
+++ b/server/services/component.service.ts
@@ -1,9 +1,9 @@
 import { ComponentRepository } from '../repositories/component.repository'
-import type { ComponentDependencyFilters, ComponentDependencyTree, ComponentFilters, LinkSuggestion } from '../repositories/component.repository'
+import type { ComponentDependencyFilters, ComponentDependencyTree, ComponentFilters, DismissedComponent, LinkSuggestion } from '../repositories/component.repository'
 import type { Component, ComponentDetail, GroupedComponent } from '~~/types/api'
 import type { ComponentIdentity } from '~~/utils/component-identity'
 
-export type { ComponentFilters, LinkSuggestion }
+export type { ComponentFilters, DismissedComponent, LinkSuggestion }
 
 /**
  * Service for component-related business logic
@@ -84,6 +84,15 @@ export class ComponentService {
 
   async dismissLink(componentName: string): Promise<void> {
     await this.componentRepo.dismissLink(componentName)
+  }
+
+  async undismissLink(componentName: string): Promise<void> {
+    await this.componentRepo.undismissLink(componentName)
+  }
+
+  async getDismissedLinks(skip: number, limit: number, search?: string): Promise<{ data: DismissedComponent[]; count: number; total: number }> {
+    const { data, total } = await this.componentRepo.getDismissedLinks(skip, limit, search)
+    return { data, count: data.length, total }
   }
 
 }

--- a/server/services/github-import.service.ts
+++ b/server/services/github-import.service.ts
@@ -1,7 +1,8 @@
-import { rmSync, existsSync } from 'fs'
+import { rmSync, existsSync, readFileSync } from 'fs'
 import { join } from 'path'
 import { randomBytes } from 'crypto'
-import { createBom } from '@cyclonedx/cdxgen'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { logger } from '../utils/logger'
 import {
   parseGitHubRepo,
@@ -41,6 +42,49 @@ export interface GitHubImportResult {
   componentsAdded: number
   componentsUpdated: number
   relationshipsCreated: number
+}
+
+const execFileAsync = promisify(execFile)
+
+// cdxgen is run as its own subprocess (not imported in-process) so a memory-hungry or
+// runaway scan can only take down that child, never the Nitro server itself. Previously,
+// an in-process, unrestricted-project-type scan of a large repo OOM-killed the whole dev
+// server — see the incident where self-importing this repo took down `nuxt dev`.
+const CDXGEN_BIN = join(process.cwd(), 'node_modules', '@cyclonedx', 'cdxgen', 'bin', 'cdxgen.js')
+const CDXGEN_TIMEOUT_MS = 5 * 60 * 1000
+const CDXGEN_MAX_OLD_SPACE_MB = 2048
+
+// Best-effort narrowing of cdxgen's scan to the ecosystem GitHub already detected as the
+// repo's primary language — dramatically cuts scan cost vs. cdxgen's default "universal"
+// mode, which walks every manifest type it knows about (Maven, Gradle, pip, Cargo, ...).
+// Falls back to an unrestricted (but still subprocess-isolated) scan when unmapped.
+const GITHUB_LANGUAGE_TO_CDXGEN_TYPE: Record<string, string> = {
+  javascript: 'javascript',
+  typescript: 'typescript',
+  vue: 'typescript',
+  python: 'python',
+  java: 'java',
+  kotlin: 'java',
+  scala: 'scala',
+  go: 'go',
+  rust: 'rust',
+  php: 'php',
+  csharp: 'csharp',
+  'c#': 'csharp',
+  ruby: 'ruby',
+  swift: 'swift',
+  'objective-c': 'objective-c',
+  dart: 'dart',
+  c: 'c',
+  'c++': 'cpp',
+  clojure: 'clojure',
+  haskell: 'haskell',
+  elixir: 'elixir'
+}
+
+function resolveCdxgenProjectType(githubLanguage: string | null): string | null {
+  if (!githubLanguage) return null
+  return GITHUB_LANGUAGE_TO_CDXGEN_TYPE[githubLanguage.toLowerCase()] ?? null
 }
 
 export class GitHubImportService {
@@ -83,7 +127,7 @@ export class GitHubImportService {
       await this.createSystemWithRepo(metadata, input)
 
       // 4. Generate and submit SBOM
-      const sbom = await this.generateSBOM(tempDir, metadata.name)
+      const sbom = await this.generateSBOM(tempDir, metadata.name, metadata.language)
 
       if (sbom) {
         sbomResult = await this.sbomService.processSBOM({
@@ -163,51 +207,62 @@ export class GitHubImportService {
 
   /**
    * Run cdxgen on a cloned repository directory to generate an SBOM.
+   *
+   * Runs cdxgen as a subprocess rather than importing it in-process, capped with
+   * --max-old-space-size and a hard timeout, so a memory-hungry or hanging scan
+   * only kills that child process instead of the whole Nitro server.
    */
-  private async generateSBOM(repoDir: string, projectName: string): Promise<object | null> {
+  private async generateSBOM(repoDir: string, projectName: string, githubLanguage: string | null): Promise<object | null> {
     logger.info({ projectName, repoDir }, 'Running cdxgen for GitHub import')
     const startedAt = Date.now()
 
-    // With installDeps: false, cdxgen has no local node_modules to read
-    // per-package description/license/homepage from — so npm/yarn components
-    // normally come back with none of that metadata. CDXGEN_FETCH_PKG_METADATA
-    // makes cdxgen fetch the same fields from the public registry (e.g.
-    // registry.npmjs.org) instead — read-only HTTP lookups, no install
-    // scripts run — matching the pattern cdxgen's own CLI uses.
-    const originalFetchPkgMetadata = process.env.CDXGEN_FETCH_PKG_METADATA
-    process.env.CDXGEN_FETCH_PKG_METADATA = 'true'
+    const outputFile = join(repoDir, `.cdxgen-bom-${randomBytes(4).toString('hex')}.json`)
+    const projectType = resolveCdxgenProjectType(githubLanguage)
+
+    const args = [
+      `--max-old-space-size=${CDXGEN_MAX_OLD_SPACE_MB}`,
+      CDXGEN_BIN,
+      repoDir,
+      '-o', outputFile,
+      '--no-install-deps'
+    ]
+    if (projectType) {
+      args.push('-t', projectType)
+    }
 
     try {
-      const bom = await createBom(repoDir, {
-        installDeps: false,
-        projectName,
-        projectVersion: '1.0.0',
-        multiProject: true,
+      // With --no-install-deps, cdxgen has no local node_modules to read
+      // per-package description/license/homepage from — so npm/yarn components
+      // normally come back with none of that metadata. CDXGEN_FETCH_PKG_METADATA
+      // makes cdxgen fetch the same fields from the public registry (e.g.
+      // registry.npmjs.org) instead — read-only HTTP lookups, no install
+      // scripts run — matching the pattern cdxgen's own CLI uses.
+      await execFileAsync('node', args, {
+        timeout: CDXGEN_TIMEOUT_MS,
+        killSignal: 'SIGKILL',
+        maxBuffer: 20 * 1024 * 1024,
+        env: { ...process.env, CDXGEN_FETCH_PKG_METADATA: 'true' }
       })
+
       const durationMs = Date.now() - startedAt
 
-      if (!bom) {
-        logger.warn({ projectName, durationMs }, 'cdxgen returned no BOM')
+      if (!existsSync(outputFile)) {
+        logger.warn({ projectName, durationMs }, 'cdxgen produced no BOM file')
         return null
       }
 
-      logger.info({ projectName, durationMs }, 'cdxgen completed')
-
-      if (typeof bom === 'string') {
-        return JSON.parse(bom)
-      } else if (bom && typeof bom === 'object' && 'bomJson' in bom) {
-        return (bom as Record<string, unknown>).bomJson as object
-      }
-
-      return bom as object
+      logger.info({ projectName, durationMs, projectType }, 'cdxgen completed')
+      return JSON.parse(readFileSync(outputFile, 'utf8'))
     } catch (err) {
-      logger.error({ err, projectName, durationMs: Date.now() - startedAt }, 'cdxgen threw during GitHub import')
-      throw err
+      const durationMs = Date.now() - startedAt
+      const timedOut = (err as { killed?: boolean })?.killed === true
+      logger.error({ err, projectName, durationMs, timedOut }, 'cdxgen failed during GitHub import')
+      throw timedOut
+        ? new Error(`cdxgen timed out after ${CDXGEN_TIMEOUT_MS}ms while scanning ${projectName}`)
+        : err
     } finally {
-      if (originalFetchPkgMetadata === undefined) {
-        delete process.env.CDXGEN_FETCH_PKG_METADATA
-      } else {
-        process.env.CDXGEN_FETCH_PKG_METADATA = originalFetchPkgMetadata
+      if (existsSync(outputFile)) {
+        rmSync(outputFile, { force: true })
       }
     }
   }

--- a/server/services/github-org-import.service.ts
+++ b/server/services/github-org-import.service.ts
@@ -4,7 +4,8 @@ import {
   type ImportJob,
   type ImportJobFilters,
   type ImportJobItem,
-  type CreateImportJobItemParams
+  type CreateImportJobItemParams,
+  type FindAllImportJobsParams
 } from '../repositories/import-job.repository'
 import { GitHubImportService } from './github-import.service'
 import { listGitHubOwnerRepositories, parseGitHubOwner, runWithConcurrency, type GitHubOrgRepository } from '../utils/github'
@@ -82,8 +83,68 @@ export class GitHubOrgImportService {
     return await this.jobRepo.findById(id)
   }
 
-  async findRecentActive(sinceHours = 24, limit = 5) {
-    return await this.jobRepo.findRecentActive(sinceHours, limit)
+  async findAll(params: FindAllImportJobsParams = {}) {
+    return await this.jobRepo.findAll(params)
+  }
+
+  /**
+   * Cancels a queued/running job. Already-finished jobs are rejected (409) rather
+   * than silently no-op'd, since the caller likely expects a state change to happen.
+   * A job orphaned by a dead/restarted process (no live `process()` loop anywhere)
+   * is cancelled purely at the DB level; a job still executing in *this* process
+   * is stopped between repositories via the status check in `importRepository`.
+   */
+  async cancel(jobId: string, actor: { userId: string; realUserId?: string | null }): Promise<ImportJob> {
+    const job = await this.jobRepo.findById(jobId)
+    if (!job) {
+      throw createError({ statusCode: 404, message: 'Import job not found' })
+    }
+    if (job.status !== 'queued' && job.status !== 'running') {
+      throw createError({ statusCode: 409, message: `Cannot cancel a job with status '${job.status}'` })
+    }
+
+    await this.jobRepo.markCancelled(jobId)
+    await this.jobRepo.cancelPendingItems(jobId)
+
+    await this.auditRepo.create({
+      operation: 'CANCEL',
+      entityType: 'ImportJob',
+      entityId: jobId,
+      entityLabel: `GitHub owner ${job.organization} import job`,
+      changedFields: ['status'],
+      source: 'Import Job Admin',
+      userId: actor.userId,
+      realUserId: actor.realUserId ?? null
+    })
+
+    return (await this.jobRepo.findById(jobId))!
+  }
+
+  /**
+   * Deletes a finished job. Active jobs must be cancelled first — deleting out from
+   * under a still-running `process()` loop would let it keep writing to a node that
+   * no longer exists (silently, since the mark-* queries just no-op on a missing match).
+   */
+  async remove(jobId: string, actor: { userId: string; realUserId?: string | null }): Promise<void> {
+    const job = await this.jobRepo.findById(jobId)
+    if (!job) {
+      throw createError({ statusCode: 404, message: 'Import job not found' })
+    }
+    if (job.status === 'queued' || job.status === 'running') {
+      throw createError({ statusCode: 409, message: 'Cancel the job before deleting it' })
+    }
+
+    await this.jobRepo.delete(jobId)
+
+    await this.auditRepo.create({
+      operation: 'DELETE',
+      entityType: 'ImportJob',
+      entityId: jobId,
+      entityLabel: `GitHub owner ${job.organization} import job`,
+      source: 'Import Job Admin',
+      userId: actor.userId,
+      realUserId: actor.realUserId ?? null
+    })
   }
 
   private runInBackground(jobId: string, input: GitHubOrgImportInput): void {
@@ -128,6 +189,8 @@ export class GitHubOrgImportService {
       const tasks = items.map(item => () => this.importRepository(jobId, item, input))
       await runWithConcurrency(tasks, 5)
 
+      if ((await this.jobRepo.getStatus(jobId)) === 'cancelled') return
+
       await this.jobRepo.markCompleted(jobId)
       await this.createAuditLog(jobId, input)
       logger.info({
@@ -156,6 +219,10 @@ export class GitHubOrgImportService {
     item: Pick<ImportJobItem, 'repositoryFullName' | 'repositoryUrl'> & { ownerTeam?: string | null; systemName?: string | null },
     input: GitHubOrgImportInput
   ): Promise<void> {
+    // An admin may have cancelled the job between task scheduling and this task
+    // starting — `cancelPendingItems` already marked this item skipped in that case.
+    if ((await this.jobRepo.getStatus(jobId)) === 'cancelled') return
+
     await this.jobRepo.markItemRunning(jobId, item.repositoryFullName)
     const startedAt = Date.now()
 

--- a/server/services/health-refresh.service.ts
+++ b/server/services/health-refresh.service.ts
@@ -13,7 +13,9 @@ import { ComponentRepository } from '../repositories/component.repository'
 import {
   HealthRefreshRepository,
   type AdvisorySnapshot,
-  type HealthRefreshJobItem
+  type HealthRefreshJob,
+  type HealthRefreshJobItem,
+  type FindAllHealthRefreshJobsParams
 } from '../repositories/health-refresh.repository'
 import { calculateMaintenanceHealth } from '../utils/component-health'
 import { logger } from '../utils/logger'
@@ -82,6 +84,73 @@ export class HealthRefreshService {
     return await this.healthRepo.getDashboardSummary()
   }
 
+  async findAll(params: FindAllHealthRefreshJobsParams = {}) {
+    return await this.healthRepo.findAll(params)
+  }
+
+  async findById(id: string): Promise<HealthRefreshJob | null> {
+    return await this.healthRepo.findById(id)
+  }
+
+  /**
+   * Cancels a queued/running job. A job orphaned by a dead/restarted process (no
+   * live `processJob()` loop anywhere) is cancelled purely at the DB level; a job
+   * still executing in *this* process is stopped between batches via the status
+   * check in `processJob`.
+   */
+  async cancel(jobId: string, actor: { userId: string; realUserId?: string | null }): Promise<HealthRefreshJob> {
+    const job = await this.healthRepo.findById(jobId)
+    if (!job) {
+      throw createError({ statusCode: 404, message: 'Health-refresh job not found' })
+    }
+    if (job.status !== 'queued' && job.status !== 'running') {
+      throw createError({ statusCode: 409, message: `Cannot cancel a job with status '${job.status}'` })
+    }
+
+    await this.healthRepo.markCancelled(jobId)
+    await this.healthRepo.cancelPendingItems(jobId)
+
+    await this.auditRepo.create({
+      operation: 'CANCEL',
+      entityType: 'HealthRefreshJob',
+      entityId: jobId,
+      entityLabel: job.systemName ? `Health refresh for ${job.systemName}` : 'Scheduled health refresh',
+      changedFields: ['status'],
+      source: 'Background Jobs Admin',
+      userId: actor.userId,
+      realUserId: actor.realUserId ?? null
+    })
+
+    return (await this.healthRepo.findById(jobId))!
+  }
+
+  /**
+   * Deletes a finished job. Active jobs must be cancelled first — deleting out from
+   * under a still-running `processJob()` loop would let it keep writing to a node
+   * that no longer exists (silently, since the mark-* queries just no-op).
+   */
+  async remove(jobId: string, actor: { userId: string; realUserId?: string | null }): Promise<void> {
+    const job = await this.healthRepo.findById(jobId)
+    if (!job) {
+      throw createError({ statusCode: 404, message: 'Health-refresh job not found' })
+    }
+    if (job.status === 'queued' || job.status === 'running') {
+      throw createError({ statusCode: 409, message: 'Cancel the job before deleting it' })
+    }
+
+    await this.healthRepo.delete(jobId)
+
+    await this.auditRepo.create({
+      operation: 'DELETE',
+      entityType: 'HealthRefreshJob',
+      entityId: jobId,
+      entityLabel: job.systemName ? `Health refresh for ${job.systemName}` : 'Scheduled health refresh',
+      source: 'Background Jobs Admin',
+      userId: actor.userId,
+      realUserId: actor.realUserId ?? null
+    })
+  }
+
   async processNextQueuedJob(options: { batchSize?: number } = {}): Promise<string | null> {
     const jobId = await this.healthRepo.claimNextQueuedJob()
     if (!jobId) return null
@@ -107,6 +176,8 @@ export class HealthRefreshService {
     const correlationId = job?.correlationId ?? null
 
     while (true) {
+      if ((await this.healthRepo.getStatus(jobId)) === 'cancelled') break
+
       const items = await this.healthRepo.getPendingItems(jobId, batchSize)
       if (items.length === 0) break
 
@@ -123,7 +194,9 @@ export class HealthRefreshService {
       }
     }
 
-    await this.healthRepo.markJobCompletedIfDone(jobId)
+    if ((await this.healthRepo.getStatus(jobId)) !== 'cancelled') {
+      await this.healthRepo.markJobCompletedIfDone(jobId)
+    }
     logger.info({
       jobId,
       correlationId,

--- a/test/server/api/admin-health-refresh-jobs.spec.ts
+++ b/test/server/api/admin-health-refresh-jobs.spec.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import listHandler from '../../../server/api/admin/health-refresh/jobs/index.get'
+import detailHandler from '../../../server/api/admin/health-refresh/jobs/[jobId].get'
+import cancelHandler from '../../../server/api/admin/health-refresh/jobs/[jobId]/cancel.post'
+import deleteHandler from '../../../server/api/admin/health-refresh/jobs/[jobId]/index.delete'
+import { healthRefreshService } from '../../../server/services/singletons'
+
+vi.mock('../../../server/services/singletons', () => ({
+  healthRefreshService: {
+    findAll: vi.fn(),
+    findById: vi.fn(),
+    cancel: vi.fn(),
+    remove: vi.fn()
+  }
+}))
+
+const { mockRequireSuperuser, mockGetImpersonatorId } = vi.hoisted(() => ({
+  mockRequireSuperuser: vi.fn(),
+  mockGetImpersonatorId: vi.fn().mockResolvedValue(null)
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('requireSuperuser', mockRequireSuperuser)
+  vi.stubGlobal('getImpersonatorId', mockGetImpersonatorId)
+})
+
+const superuser = { id: 'admin-1', email: 'admin@example.com', role: 'superuser' as const, teams: [] }
+
+const mockJob = {
+  id: 'job-1',
+  status: 'running' as const,
+  trigger: 'scheduled' as const,
+  systemName: null,
+  totalItems: 3,
+  completedItems: 1,
+  failedItems: 0,
+  createdAt: '2026-07-24T10:00:00Z',
+  startedAt: '2026-07-24T10:00:01Z',
+  finishedAt: null,
+  error: null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRequireSuperuser.mockResolvedValue(superuser)
+})
+
+describe('[contract] GET /api/admin/health-refresh/jobs', () => {
+  it('should return jobs with count and total', async () => {
+    vi.mocked(healthRefreshService.findAll).mockResolvedValue({ total: 1, jobs: [mockJob] })
+
+    const result = await listHandler(mockEvent())
+
+    expect(result.success).toBe(true)
+    expect(result.data).toHaveLength(1)
+    expect(result.total).toBe(1)
+  })
+
+  it('should pass skip/limit/search to the service', async () => {
+    vi.mocked(healthRefreshService.findAll).mockResolvedValue({ total: 0, jobs: [] })
+
+    await listHandler(mockEvent({ query: { skip: '20', limit: '10', search: 'acme' } }))
+
+    expect(healthRefreshService.findAll).toHaveBeenCalledWith({
+      skip: 20,
+      limit: 10,
+      statuses: undefined,
+      search: 'acme'
+    })
+  })
+
+  it('should filter out invalid status values', async () => {
+    vi.mocked(healthRefreshService.findAll).mockResolvedValue({ total: 0, jobs: [] })
+
+    await listHandler(mockEvent({ query: { status: 'running,bogus,failed' } }))
+
+    expect(healthRefreshService.findAll).toHaveBeenCalledWith(expect.objectContaining({
+      statuses: ['running', 'failed']
+    }))
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(listHandler(mockEvent())).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+describe('[contract] GET /api/admin/health-refresh/jobs/[jobId]', () => {
+  it('should return the job', async () => {
+    vi.mocked(healthRefreshService.findById).mockResolvedValue({ ...mockJob, items: [] } as never)
+
+    const result = await detailHandler(mockEvent({ params: { jobId: 'job-1' } }))
+
+    expect(result.success).toBe(true)
+    expect(result.data.id).toBe('job-1')
+  })
+
+  it('should return 400 when jobId is missing', async () => {
+    await expect(
+      detailHandler(mockEvent({ params: {} }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should return 404 when the job does not exist', async () => {
+    vi.mocked(healthRefreshService.findById).mockResolvedValue(null)
+
+    await expect(
+      detailHandler(mockEvent({ params: { jobId: 'missing-job' } }))
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(
+      detailHandler(mockEvent({ params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+describe('[contract] POST /api/admin/health-refresh/jobs/[jobId]/cancel', () => {
+  it('should cancel the job and return it', async () => {
+    vi.mocked(healthRefreshService.cancel).mockResolvedValue({ ...mockJob, status: 'cancelled' } as never)
+
+    const result = await cancelHandler(mockEvent({ method: 'POST', params: { jobId: 'job-1' } }))
+
+    expect(result.success).toBe(true)
+    expect(result.data.status).toBe('cancelled')
+    expect(healthRefreshService.cancel).toHaveBeenCalledWith('job-1', { userId: 'admin-1', realUserId: null })
+  })
+
+  it('should return 400 when jobId is missing', async () => {
+    await expect(
+      cancelHandler(mockEvent({ method: 'POST', params: {} }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should propagate a 404 when the job does not exist', async () => {
+    vi.mocked(healthRefreshService.cancel).mockRejectedValue(
+      Object.assign(new Error('Health-refresh job not found'), { statusCode: 404 })
+    )
+
+    await expect(
+      cancelHandler(mockEvent({ method: 'POST', params: { jobId: 'missing-job' } }))
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('should propagate a 409 when the job is already finished', async () => {
+    vi.mocked(healthRefreshService.cancel).mockRejectedValue(
+      Object.assign(new Error("Cannot cancel a job with status 'completed'"), { statusCode: 409 })
+    )
+
+    await expect(
+      cancelHandler(mockEvent({ method: 'POST', params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 409 })
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(
+      cancelHandler(mockEvent({ method: 'POST', params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+describe('[contract] DELETE /api/admin/health-refresh/jobs/[jobId]', () => {
+  it('should delete the job', async () => {
+    vi.mocked(healthRefreshService.remove).mockResolvedValue(undefined)
+
+    const result = await deleteHandler(mockEvent({ method: 'DELETE', params: { jobId: 'job-1' } }))
+
+    expect(result.success).toBe(true)
+    expect(healthRefreshService.remove).toHaveBeenCalledWith('job-1', { userId: 'admin-1', realUserId: null })
+  })
+
+  it('should return 400 when jobId is missing', async () => {
+    await expect(
+      deleteHandler(mockEvent({ method: 'DELETE', params: {} }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should propagate a 404 when the job does not exist', async () => {
+    vi.mocked(healthRefreshService.remove).mockRejectedValue(
+      Object.assign(new Error('Health-refresh job not found'), { statusCode: 404 })
+    )
+
+    await expect(
+      deleteHandler(mockEvent({ method: 'DELETE', params: { jobId: 'missing-job' } }))
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('should propagate a 409 when the job is still active', async () => {
+    vi.mocked(healthRefreshService.remove).mockRejectedValue(
+      Object.assign(new Error('Cancel the job before deleting it'), { statusCode: 409 })
+    )
+
+    await expect(
+      deleteHandler(mockEvent({ method: 'DELETE', params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 409 })
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(
+      deleteHandler(mockEvent({ method: 'DELETE', params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})

--- a/test/server/api/admin-import-jobs.spec.ts
+++ b/test/server/api/admin-import-jobs.spec.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import listHandler from '../../../server/api/admin/import/jobs/index.get'
+import cancelHandler from '../../../server/api/admin/import/jobs/[jobId]/cancel.post'
+import deleteHandler from '../../../server/api/admin/import/jobs/[jobId]/index.delete'
+import { gitHubOrgImportService } from '../../../server/services/singletons'
+
+vi.mock('../../../server/services/singletons', () => ({
+  gitHubOrgImportService: {
+    findAll: vi.fn(),
+    cancel: vi.fn(),
+    remove: vi.fn()
+  }
+}))
+
+const { mockRequireSuperuser, mockGetImpersonatorId } = vi.hoisted(() => ({
+  mockRequireSuperuser: vi.fn(),
+  mockGetImpersonatorId: vi.fn().mockResolvedValue(null)
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('requireSuperuser', mockRequireSuperuser)
+  vi.stubGlobal('getImpersonatorId', mockGetImpersonatorId)
+})
+
+const superuser = { id: 'admin-1', email: 'admin@example.com', role: 'superuser' as const, teams: [] }
+
+const mockJob = {
+  id: 'job-1',
+  status: 'running' as const,
+  organization: 'acme',
+  requestedBy: 'user-1',
+  total: 3,
+  completed: 1,
+  failed: 0,
+  skipped: 0,
+  createdAt: '2026-07-24T10:00:00Z',
+  startedAt: '2026-07-24T10:00:01Z',
+  finishedAt: null,
+  error: null
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRequireSuperuser.mockResolvedValue(superuser)
+})
+
+describe('[contract] GET /api/admin/import/jobs', () => {
+  it('should return jobs with count and total', async () => {
+    vi.mocked(gitHubOrgImportService.findAll).mockResolvedValue({ total: 1, jobs: [mockJob] })
+
+    const result = await listHandler(mockEvent())
+
+    expect(result.success).toBe(true)
+    expect(result.data).toHaveLength(1)
+    expect(result.total).toBe(1)
+  })
+
+  it('should pass skip/limit/search to the service', async () => {
+    vi.mocked(gitHubOrgImportService.findAll).mockResolvedValue({ total: 0, jobs: [] })
+
+    await listHandler(mockEvent({ query: { skip: '20', limit: '10', search: 'acme' } }))
+
+    expect(gitHubOrgImportService.findAll).toHaveBeenCalledWith({
+      skip: 20,
+      limit: 10,
+      statuses: undefined,
+      search: 'acme'
+    })
+  })
+
+  it('should filter out invalid status values', async () => {
+    vi.mocked(gitHubOrgImportService.findAll).mockResolvedValue({ total: 0, jobs: [] })
+
+    await listHandler(mockEvent({ query: { status: 'running,bogus,failed' } }))
+
+    expect(gitHubOrgImportService.findAll).toHaveBeenCalledWith(expect.objectContaining({
+      statuses: ['running', 'failed']
+    }))
+  })
+
+  it('should clamp limit to 100 maximum', async () => {
+    vi.mocked(gitHubOrgImportService.findAll).mockResolvedValue({ total: 0, jobs: [] })
+
+    await listHandler(mockEvent({ query: { limit: '999' } }))
+
+    expect(gitHubOrgImportService.findAll).toHaveBeenCalledWith(expect.objectContaining({ limit: 100 }))
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(listHandler(mockEvent())).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+describe('[contract] POST /api/admin/import/jobs/[jobId]/cancel', () => {
+  it('should cancel the job and return it', async () => {
+    vi.mocked(gitHubOrgImportService.cancel).mockResolvedValue({ ...mockJob, status: 'cancelled' } as never)
+
+    const result = await cancelHandler(mockEvent({ method: 'POST', params: { jobId: 'job-1' } }))
+
+    expect(result.success).toBe(true)
+    expect(result.data.status).toBe('cancelled')
+    expect(gitHubOrgImportService.cancel).toHaveBeenCalledWith('job-1', { userId: 'admin-1', realUserId: null })
+  })
+
+  it('should return 400 when jobId is missing', async () => {
+    await expect(
+      cancelHandler(mockEvent({ method: 'POST', params: {} }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should propagate a 404 when the job does not exist', async () => {
+    vi.mocked(gitHubOrgImportService.cancel).mockRejectedValue(
+      Object.assign(new Error('Import job not found'), { statusCode: 404 })
+    )
+
+    await expect(
+      cancelHandler(mockEvent({ method: 'POST', params: { jobId: 'missing-job' } }))
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('should propagate a 409 when the job is already finished', async () => {
+    vi.mocked(gitHubOrgImportService.cancel).mockRejectedValue(
+      Object.assign(new Error("Cannot cancel a job with status 'completed'"), { statusCode: 409 })
+    )
+
+    await expect(
+      cancelHandler(mockEvent({ method: 'POST', params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 409 })
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(
+      cancelHandler(mockEvent({ method: 'POST', params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+describe('[contract] DELETE /api/admin/import/jobs/[jobId]', () => {
+  it('should delete the job', async () => {
+    vi.mocked(gitHubOrgImportService.remove).mockResolvedValue(undefined)
+
+    const result = await deleteHandler(mockEvent({ method: 'DELETE', params: { jobId: 'job-1' } }))
+
+    expect(result.success).toBe(true)
+    expect(gitHubOrgImportService.remove).toHaveBeenCalledWith('job-1', { userId: 'admin-1', realUserId: null })
+  })
+
+  it('should return 400 when jobId is missing', async () => {
+    await expect(
+      deleteHandler(mockEvent({ method: 'DELETE', params: {} }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should propagate a 404 when the job does not exist', async () => {
+    vi.mocked(gitHubOrgImportService.remove).mockRejectedValue(
+      Object.assign(new Error('Import job not found'), { statusCode: 404 })
+    )
+
+    await expect(
+      deleteHandler(mockEvent({ method: 'DELETE', params: { jobId: 'missing-job' } }))
+    ).rejects.toMatchObject({ statusCode: 404 })
+  })
+
+  it('should propagate a 409 when the job is still active', async () => {
+    vi.mocked(gitHubOrgImportService.remove).mockRejectedValue(
+      Object.assign(new Error('Cancel the job before deleting it'), { statusCode: 409 })
+    )
+
+    await expect(
+      deleteHandler(mockEvent({ method: 'DELETE', params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 409 })
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(
+      deleteHandler(mockEvent({ method: 'DELETE', params: { jobId: 'job-1' } }))
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})

--- a/test/server/api/component-dismissed-links.spec.ts
+++ b/test/server/api/component-dismissed-links.spec.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest'
+import { mockEvent } from '../../fixtures/h3-event'
+import dismissedLinksHandler from '../../../server/api/components/dismissed-links.get'
+import undismissLinkHandler from '../../../server/api/components/undismiss-link.post'
+import { componentService } from '../../../server/services/singletons'
+
+vi.mock('../../../server/services/singletons', () => ({
+  componentService: {
+    getDismissedLinks: vi.fn(),
+    undismissLink: vi.fn()
+  }
+}))
+
+const { mockRequireSuperuser, mockGetImpersonatorId } = vi.hoisted(() => ({
+  mockRequireSuperuser: vi.fn(),
+  mockGetImpersonatorId: vi.fn().mockResolvedValue(null)
+}))
+
+beforeAll(() => {
+  vi.stubGlobal('requireSuperuser', mockRequireSuperuser)
+  vi.stubGlobal('getImpersonatorId', mockGetImpersonatorId)
+})
+
+const superuser = { id: 'admin-1', email: 'admin@example.com', role: 'superuser' as const, teams: [] }
+
+const mockDismissed = {
+  name: 'left-pad',
+  packageManager: 'npm',
+  description: null,
+  purl: 'pkg:npm/left-pad@1.3.0',
+  dismissedAt: '2026-07-20T12:00:00Z'
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockRequireSuperuser.mockResolvedValue(superuser)
+})
+
+describe('[contract] GET /api/components/dismissed-links', () => {
+  it('should return dismissed components with count and total', async () => {
+    vi.mocked(componentService.getDismissedLinks).mockResolvedValue({
+      data: [mockDismissed], count: 1, total: 1
+    })
+
+    const result = await dismissedLinksHandler(mockEvent())
+
+    expect(result.success).toBe(true)
+    expect(result.data).toHaveLength(1)
+    expect(result.total).toBe(1)
+  })
+
+  it('should pass skip and limit query params to service', async () => {
+    vi.mocked(componentService.getDismissedLinks).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await dismissedLinksHandler(mockEvent({ query: { skip: '50', limit: '25' } }))
+
+    expect(componentService.getDismissedLinks).toHaveBeenCalledWith(50, 25, undefined)
+  })
+
+  it('should clamp limit to 200 maximum', async () => {
+    vi.mocked(componentService.getDismissedLinks).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await dismissedLinksHandler(mockEvent({ query: { limit: '999' } }))
+
+    expect(componentService.getDismissedLinks).toHaveBeenCalledWith(0, 200, undefined)
+  })
+
+  it('should clamp skip to 0 minimum', async () => {
+    vi.mocked(componentService.getDismissedLinks).mockResolvedValue({ data: [], count: 0, total: 0 })
+
+    await dismissedLinksHandler(mockEvent({ query: { skip: '-10' } }))
+
+    expect(componentService.getDismissedLinks).toHaveBeenCalledWith(0, 50, undefined)
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(dismissedLinksHandler(mockEvent())).rejects.toMatchObject({ statusCode: 403 })
+  })
+})
+
+describe('[contract] POST /api/components/undismiss-link', () => {
+  it('should restore a component by componentName and return 204', async () => {
+    vi.mocked(componentService.undismissLink).mockResolvedValue(undefined)
+
+    const result = await undismissLinkHandler(mockEvent({
+      method: 'POST',
+      body: { componentName: 'left-pad' }
+    }))
+
+    expect(result).toBeNull()
+    expect(componentService.undismissLink).toHaveBeenCalledWith('left-pad')
+  })
+
+  it('should return 400 when componentName is missing', async () => {
+    await expect(
+      undismissLinkHandler(mockEvent({ method: 'POST', body: {} }))
+    ).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it('should enforce superuser access', async () => {
+    mockRequireSuperuser.mockRejectedValue(Object.assign(new Error('Forbidden'), { statusCode: 403 }))
+
+    await expect(
+      undismissLinkHandler(mockEvent({ method: 'POST', body: { componentName: 'left-pad' } }))
+    ).rejects.toMatchObject({ statusCode: 403 })
+  })
+})

--- a/test/server/api/dashboard-attention.spec.ts
+++ b/test/server/api/dashboard-attention.spec.ts
@@ -6,7 +6,6 @@ import {
   complianceService,
   healthRefreshService,
   componentService,
-  gitHubOrgImportService,
   teamService
 } from '../../../server/services/singletons'
 
@@ -15,7 +14,6 @@ vi.mock('../../../server/services/singletons', () => ({
   complianceService: { findViolations: vi.fn() },
   healthRefreshService: { getDashboardSummary: vi.fn() },
   componentService: { getLinkSuggestions: vi.fn() },
-  gitHubOrgImportService: { findRecentActive: vi.fn() },
   teamService: { getStewardshipGaps: vi.fn() }
 }))
 
@@ -73,10 +71,6 @@ beforeEach(() => {
   })
   vi.mocked(healthRefreshService.getDashboardSummary).mockResolvedValue(healthSummary as never)
   vi.mocked(teamService.getStewardshipGaps).mockResolvedValue(stewardshipGaps)
-  vi.mocked(gitHubOrgImportService.findRecentActive).mockResolvedValue({
-    total: 1,
-    jobs: [{ id: 'job-1', status: 'failed', organization: 'acme', total: 3, completed: 1, failed: 1, createdAt: '2026-01-01T00:00:00Z', error: 'boom' }]
-  })
   vi.mocked(componentService.getLinkSuggestions).mockResolvedValue({ data: [], count: 0, total: 7 })
 })
 
@@ -98,10 +92,6 @@ describe('[pin] GET /api/dashboard/attention', () => {
       topItems: [{ name: 'OldTech', version: '1.0.0', systemCount: 4 }]
     })
     expect(result.data.stewardshipGaps).toEqual(stewardshipGaps)
-    expect(result.data.importJobHealth.total).toBe(1)
-    expect(result.data.importJobHealth.jobs).toEqual([
-      { id: 'job-1', organization: 'acme', status: 'failed', createdAt: '2026-01-01T00:00:00Z' }
-    ])
   })
 
   it('omits the component link queue for non-superusers', async () => {

--- a/test/server/repositories/health-refresh.repository.spec.ts
+++ b/test/server/repositories/health-refresh.repository.spec.ts
@@ -216,4 +216,126 @@ describe('HealthRefreshRepository', () => {
       expect(result.records[0]?.get('advisoryIds')).toEqual([`${PREFIX}GHSA-current`])
     })
   })
+
+  describe('[pin] findAll()', () => {
+    it('filters by status', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      const queuedId = await repo.enqueueForSystem(`${PREFIX}queued-system`)
+      const failedId = await repo.enqueueForSystem(`${PREFIX}failed-system`)
+      await repo.markJobFailed(failedId, 'boom')
+
+      const result = await repo.findAll({ statuses: ['queued'] })
+      const ids = result.jobs.map(j => j.id)
+
+      expect(ids).toContain(queuedId)
+      expect(ids).not.toContain(failedId)
+    })
+
+    it('filters by system name search substring', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      const matchId = await repo.enqueueForSystem(`${PREFIX}searchable-system`)
+      const otherId = await repo.enqueueForSystem(`${PREFIX}other-system`)
+
+      const result = await repo.findAll({ search: 'searchable' })
+      const ids = result.jobs.map(j => j.id)
+
+      expect(ids).toContain(matchId)
+      expect(ids).not.toContain(otherId)
+    })
+
+    it('paginates with skip/limit and reports total', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      for (let i = 0; i < 3; i++) {
+        await repo.enqueueForSystem(`${PREFIX}limit-system-${i}`)
+      }
+
+      const result = await repo.findAll({ search: `${PREFIX}limit-system`, skip: 0, limit: 2 })
+      expect(result.jobs.length).toBeLessThanOrEqual(2)
+      expect(result.total).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('[pin] markCancelled() and cancelPendingItems()', () => {
+    it('cancels a running job and skips its pending items', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await session.run(`
+        CREATE (s:System {name: $systemName})
+        CREATE (a:Component {name: $componentName, version: '1.0.0', packageManager: 'npm', purl: $componentPurl})
+        CREATE (s)-[:USES]->(a)
+      `, {
+        systemName: `${PREFIX}cancel-system`,
+        componentName: `${PREFIX}cancel-component`,
+        componentPurl: `${PREFIX}pkg:cancel@1.0.0`
+      })
+
+      const jobId = await repo.enqueueForSystem(`${PREFIX}cancel-system`)
+      await session.run('MATCH (j:HealthRefreshJob {id: $id}) SET j.status = "running"', { id: jobId })
+
+      await repo.markCancelled(jobId)
+      await repo.cancelPendingItems(jobId)
+
+      const found = await repo.findById(jobId)
+      expect(found?.status).toBe('cancelled')
+      expect(found?.finishedAt).not.toBeNull()
+      expect(found?.items.every(item => item.status === 'skipped')).toBe(true)
+    })
+
+    it('does not cancel an already-completed job', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      const jobId = await repo.enqueueForSystem(`${PREFIX}already-done-system`)
+      await repo.markJobCompletedIfDone(jobId)
+
+      await repo.markCancelled(jobId)
+
+      const found = await repo.findById(jobId)
+      expect(found?.status).toBe('completed')
+    })
+  })
+
+  describe('[pin] getStatus()', () => {
+    it('returns the current status', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      const jobId = await repo.enqueueForSystem(`${PREFIX}status-system`)
+      await expect(repo.getStatus(jobId)).resolves.toBe('queued')
+    })
+
+    it('returns null for an unknown job', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await expect(repo.getStatus(`${PREFIX}missing`)).resolves.toBeNull()
+    })
+  })
+
+  describe('[pin] delete()', () => {
+    it('removes the job and its items', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await session.run(`
+        CREATE (s:System {name: $systemName})
+        CREATE (a:Component {name: $componentName, version: '1.0.0', packageManager: 'npm', purl: $componentPurl})
+        CREATE (s)-[:USES]->(a)
+      `, {
+        systemName: `${PREFIX}delete-system`,
+        componentName: `${PREFIX}delete-component`,
+        componentPurl: `${PREFIX}pkg:delete@1.0.0`
+      })
+      const jobId = await repo.enqueueForSystem(`${PREFIX}delete-system`)
+
+      await repo.delete(jobId)
+
+      await expect(repo.findById(jobId)).resolves.toBeNull()
+    })
+
+    it('is a no-op for an unknown job id', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await expect(repo.delete(`${PREFIX}missing`)).resolves.toBeUndefined()
+    })
+  })
 })

--- a/test/server/repositories/import-job.repository.spec.ts
+++ b/test/server/repositories/import-job.repository.spec.ts
@@ -140,66 +140,44 @@ describe('[pin] ImportJobRepository', () => {
     expect(found?.finishedAt).not.toBeNull()
   })
 
-  describe('[pin] findRecentActive()', () => {
-    it('includes queued and running jobs regardless of age', async () => {
+  describe('[pin] findAll()', () => {
+    it('filters by status', async () => {
       if (!ctx.neo4jAvailable) return
 
       const queued = await repo.create({
         type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}queued-org`, filters: {}, dryRun: false
       })
-      const running = await repo.create({
-        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}running-org`, filters: {}, dryRun: false
+      const completed = await repo.create({
+        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}completed-org`, filters: {}, dryRun: false
       })
-      await repo.markRunning(running.id)
-      await session.run('MATCH (j:ImportJob {id: $id}) SET j.createdAt = datetime() - duration({days: 30})', { id: running.id })
+      await repo.createItems(completed.id, [])
+      await repo.markCompleted(completed.id)
 
-      const result = await repo.findRecentActive(24, 50)
+      const result = await repo.findAll({ statuses: ['queued'] })
       const ids = result.jobs.map(j => j.id)
 
       expect(ids).toContain(queued.id)
-      expect(ids).toContain(running.id)
+      expect(ids).not.toContain(completed.id)
     })
 
-    it('includes a failed job within the lookback window', async () => {
+    it('filters by organization search substring', async () => {
       if (!ctx.neo4jAvailable) return
 
       const job = await repo.create({
-        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}failed-org`, filters: {}, dryRun: false
+        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}searchable-org`, filters: {}, dryRun: false
       })
-      await repo.markFailed(job.id, 'boom')
+      const other = await repo.create({
+        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}other-org`, filters: {}, dryRun: false
+      })
 
-      const result = await repo.findRecentActive(24, 50)
-      expect(result.jobs.map(j => j.id)).toContain(job.id)
-      expect(result.jobs.find(j => j.id === job.id)).toMatchObject({ status: 'failed', error: 'boom' })
+      const result = await repo.findAll({ search: 'searchable' })
+      const ids = result.jobs.map(j => j.id)
+
+      expect(ids).toContain(job.id)
+      expect(ids).not.toContain(other.id)
     })
 
-    it('excludes a failed job outside the lookback window', async () => {
-      if (!ctx.neo4jAvailable) return
-
-      const job = await repo.create({
-        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}stale-failed-org`, filters: {}, dryRun: false
-      })
-      await repo.markFailed(job.id, 'boom')
-      await session.run('MATCH (j:ImportJob {id: $id}) SET j.createdAt = datetime() - duration({hours: 48})', { id: job.id })
-
-      const result = await repo.findRecentActive(24, 50)
-      expect(result.jobs.map(j => j.id)).not.toContain(job.id)
-    })
-
-    it('excludes completed jobs', async () => {
-      if (!ctx.neo4jAvailable) return
-
-      const job = await repo.create({
-        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}completed-org`, filters: {}, dryRun: false
-      })
-      await repo.createItems(job.id, [])
-      await repo.markCompleted(job.id)
-
-      const result = await repo.findRecentActive(24, 50)
-      expect(result.jobs.map(j => j.id)).not.toContain(job.id)
-    })
-
-    it('respects the limit', async () => {
+    it('paginates with skip/limit and reports total', async () => {
       if (!ctx.neo4jAvailable) return
 
       for (let i = 0; i < 3; i++) {
@@ -208,9 +186,71 @@ describe('[pin] ImportJobRepository', () => {
         })
       }
 
-      const result = await repo.findRecentActive(24, 2)
+      const result = await repo.findAll({ search: `${PREFIX}limit-org`, skip: 0, limit: 2 })
       expect(result.jobs.length).toBeLessThanOrEqual(2)
       expect(result.total).toBeGreaterThanOrEqual(3)
+    })
+  })
+
+  describe('[pin] markCancelled() and cancelPendingItems()', () => {
+    it('cancels a running job and skips its pending/running items', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      const job = await repo.create({
+        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}cancel-org`, filters: {}, dryRun: false
+      })
+      await repo.markRunning(job.id)
+      await repo.createItems(job.id, [
+        { repositoryFullName: `${PREFIX}cancel-org/repo-a`, repositoryUrl: `https://github.com/${PREFIX}cancel-org/repo-a` },
+        { repositoryFullName: `${PREFIX}cancel-org/repo-b`, repositoryUrl: `https://github.com/${PREFIX}cancel-org/repo-b` }
+      ])
+      await repo.markItemRunning(job.id, `${PREFIX}cancel-org/repo-a`)
+
+      await repo.markCancelled(job.id)
+      await repo.cancelPendingItems(job.id)
+
+      const found = await repo.findById(job.id)
+      expect(found).toMatchObject({ status: 'cancelled', skipped: 2 })
+      expect(found?.finishedAt).not.toBeNull()
+      expect(found?.items.every(item => item.status === 'skipped')).toBe(true)
+    })
+
+    it('does not cancel an already-completed job', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      const job = await repo.create({
+        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}already-done-org`, filters: {}, dryRun: false
+      })
+      await repo.createItems(job.id, [])
+      await repo.markCompleted(job.id)
+
+      await repo.markCancelled(job.id)
+
+      const found = await repo.findById(job.id)
+      expect(found?.status).toBe('completed')
+    })
+  })
+
+  describe('[pin] delete()', () => {
+    it('removes the job and its items', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      const job = await repo.create({
+        type: 'github-org', requestedBy: `${PREFIX}user`, organization: `${PREFIX}delete-org`, filters: {}, dryRun: false
+      })
+      await repo.createItems(job.id, [
+        { repositoryFullName: `${PREFIX}delete-org/repo-a`, repositoryUrl: `https://github.com/${PREFIX}delete-org/repo-a` }
+      ])
+
+      await repo.delete(job.id)
+
+      await expect(repo.findById(job.id)).resolves.toBeNull()
+    })
+
+    it('is a no-op for an unknown job id', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      await expect(repo.delete(`${PREFIX}missing`)).resolves.toBeUndefined()
     })
   })
 })

--- a/test/server/services/github-import.service.spec.ts
+++ b/test/server/services/github-import.service.spec.ts
@@ -18,14 +18,15 @@ vi.mock('../../../server/services/sbom.service', () => ({
   SBOMService: vi.fn()
 }))
 
-// cdxgen is invoked inside generateSBOM; stub it out
-vi.mock('@cyclonedx/cdxgen', () => ({
-  createBom: vi.fn().mockResolvedValue(null)
+// cdxgen is run as a subprocess inside generateSBOM; stub execFile so no real process spawns
+vi.mock('child_process', () => ({
+  execFile: vi.fn((_cmd, _args, _options, callback) => callback(null, '', ''))
 }))
 
 // fs cleanup runs in finally; mock to avoid touching the filesystem
 vi.mock('fs', () => ({
   existsSync: vi.fn(() => false),
+  readFileSync: vi.fn(),
   rmSync: vi.fn()
 }))
 

--- a/test/server/services/github-org-import.service.spec.ts
+++ b/test/server/services/github-org-import.service.spec.ts
@@ -43,9 +43,14 @@ function createRepoMocks() {
   return {
     create: vi.fn().mockResolvedValue(baseJob),
     findById: vi.fn().mockResolvedValue({ ...baseJob, status: 'completed' }),
+    findAll: vi.fn().mockResolvedValue({ total: 0, jobs: [] }),
+    getStatus: vi.fn().mockResolvedValue('running'),
     markRunning: vi.fn().mockResolvedValue(undefined),
     markCompleted: vi.fn().mockResolvedValue(undefined),
     markFailed: vi.fn().mockResolvedValue(undefined),
+    markCancelled: vi.fn().mockResolvedValue(undefined),
+    cancelPendingItems: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
     createItems: vi.fn().mockResolvedValue(undefined),
     markItemRunning: vi.fn().mockResolvedValue(undefined),
     markItemFinished: vi.fn().mockResolvedValue(undefined)
@@ -321,5 +326,144 @@ describe('[pin] GitHubOrgImportService', () => {
       componentsAdded: 3
     }))
     expect(repo.markCompleted).toHaveBeenCalledWith('job-1')
+  })
+
+  it('skips marking a cancelled job completed after processing finishes', async () => {
+    const repo = createRepoMocks()
+    repo.getStatus.mockResolvedValue('cancelled')
+    vi.mocked(listGitHubOwnerRepositories).mockResolvedValue([])
+
+    const service = new GitHubOrgImportService(
+      repo as never,
+      { import: vi.fn() } as never,
+      { create: vi.fn() } as never
+    )
+
+    await service.process('job-1', {
+      organization: 'acme',
+      ownerTeam: 'Platform',
+      userId: 'user-1'
+    })
+
+    expect(repo.markCompleted).not.toHaveBeenCalled()
+  })
+
+  it('does not import a repository whose job was cancelled before its task started', async () => {
+    const repo = createRepoMocks()
+    repo.getStatus.mockResolvedValue('cancelled')
+    const importService = { import: vi.fn() }
+    vi.mocked(listGitHubOwnerRepositories).mockResolvedValue([
+      {
+        name: 'repo-a',
+        full_name: 'acme/repo-a',
+        html_url: 'https://github.com/acme/repo-a',
+        description: null,
+        default_branch: 'main',
+        language: 'TypeScript',
+        private: false,
+        fork: false,
+        archived: false,
+        topics: []
+      }
+    ])
+
+    const service = new GitHubOrgImportService(
+      repo as never,
+      importService as never,
+      { create: vi.fn() } as never
+    )
+
+    await service.process('job-1', {
+      organization: 'acme',
+      ownerTeam: 'Platform',
+      userId: 'user-1'
+    })
+
+    expect(importService.import).not.toHaveBeenCalled()
+    expect(repo.markItemRunning).not.toHaveBeenCalled()
+  })
+
+  describe('[pin] cancel()', () => {
+    it('cancels a running job and its pending items', async () => {
+      const repo = createRepoMocks()
+      repo.findById.mockResolvedValue({ ...baseJob, status: 'running' })
+      const service = new GitHubOrgImportService(
+        repo as never,
+        { import: vi.fn() } as never,
+        { create: vi.fn() } as never
+      )
+
+      const result = await service.cancel('job-1', { userId: 'admin-1', realUserId: null })
+
+      expect(repo.markCancelled).toHaveBeenCalledWith('job-1')
+      expect(repo.cancelPendingItems).toHaveBeenCalledWith('job-1')
+      expect(result).toEqual({ ...baseJob, status: 'running' })
+    })
+
+    it('rejects cancelling a job that is not queued/running', async () => {
+      const repo = createRepoMocks()
+      repo.findById.mockResolvedValue({ ...baseJob, status: 'completed' })
+      const service = new GitHubOrgImportService(
+        repo as never,
+        { import: vi.fn() } as never,
+        { create: vi.fn() } as never
+      )
+
+      await expect(service.cancel('job-1', { userId: 'admin-1' })).rejects.toMatchObject({ statusCode: 409 })
+      expect(repo.markCancelled).not.toHaveBeenCalled()
+    })
+
+    it('rejects cancelling an unknown job', async () => {
+      const repo = createRepoMocks()
+      repo.findById.mockResolvedValue(null)
+      const service = new GitHubOrgImportService(
+        repo as never,
+        { import: vi.fn() } as never,
+        { create: vi.fn() } as never
+      )
+
+      await expect(service.cancel('missing-job', { userId: 'admin-1' })).rejects.toMatchObject({ statusCode: 404 })
+    })
+  })
+
+  describe('[pin] remove()', () => {
+    it('deletes a finished job', async () => {
+      const repo = createRepoMocks()
+      repo.findById.mockResolvedValue({ ...baseJob, status: 'completed' })
+      const service = new GitHubOrgImportService(
+        repo as never,
+        { import: vi.fn() } as never,
+        { create: vi.fn() } as never
+      )
+
+      await service.remove('job-1', { userId: 'admin-1', realUserId: null })
+
+      expect(repo.delete).toHaveBeenCalledWith('job-1')
+    })
+
+    it('rejects deleting a queued/running job', async () => {
+      const repo = createRepoMocks()
+      repo.findById.mockResolvedValue({ ...baseJob, status: 'running' })
+      const service = new GitHubOrgImportService(
+        repo as never,
+        { import: vi.fn() } as never,
+        { create: vi.fn() } as never
+      )
+
+      await expect(service.remove('job-1', { userId: 'admin-1' })).rejects.toMatchObject({ statusCode: 409 })
+      expect(repo.delete).not.toHaveBeenCalled()
+    })
+
+    it('rejects deleting an unknown job', async () => {
+      const repo = createRepoMocks()
+      repo.findById.mockResolvedValue(null)
+      const service = new GitHubOrgImportService(
+        repo as never,
+        { import: vi.fn() } as never,
+        { create: vi.fn() } as never
+      )
+
+      await expect(service.remove('missing-job', { userId: 'admin-1' })).rejects.toMatchObject({ statusCode: 404 })
+    })
   })
 })

--- a/test/server/services/health-refresh.service.spec.ts
+++ b/test/server/services/health-refresh.service.spec.ts
@@ -73,7 +73,11 @@ function createHealthRepo(correlationId: string | null = null) {
     markItemRunning: vi.fn(async () => {}),
     upsertHealthSnapshot: vi.fn(async () => {}),
     markItemFinished: vi.fn(async () => {}),
-    markJobCompletedIfDone: vi.fn(async () => {})
+    markJobCompletedIfDone: vi.fn(async () => {}),
+    getStatus: vi.fn(async () => 'running'),
+    markCancelled: vi.fn(async () => {}),
+    cancelPendingItems: vi.fn(async () => {}),
+    delete: vi.fn(async () => {})
   }
 }
 
@@ -248,5 +252,109 @@ describe('[contract] HealthRefreshService', () => {
       operation: 'HEALTH_REFRESH_FAILED',
       correlationId: 'corr-sbom-1'
     }))
+  })
+})
+
+describe('[pin] HealthRefreshService findAll()/findById()', () => {
+  it('delegates findAll to the repository', async () => {
+    const healthRepo = { findAll: vi.fn().mockResolvedValue({ total: 1, jobs: [] }) }
+    const service = new HealthRefreshService(healthRepo as never)
+
+    const result = await service.findAll({ skip: 10, limit: 5 })
+
+    expect(healthRepo.findAll).toHaveBeenCalledWith({ skip: 10, limit: 5 })
+    expect(result).toEqual({ total: 1, jobs: [] })
+  })
+
+  it('delegates findById to the repository', async () => {
+    const job = { id: 'job-1', status: 'completed' }
+    const healthRepo = { findById: vi.fn().mockResolvedValue(job) }
+    const service = new HealthRefreshService(healthRepo as never)
+
+    const result = await service.findById('job-1')
+
+    expect(healthRepo.findById).toHaveBeenCalledWith('job-1')
+    expect(result).toEqual(job)
+  })
+})
+
+describe('[pin] HealthRefreshService processJob() respects cancellation', () => {
+  it('stops before fetching pending items once the job is cancelled', async () => {
+    const healthRepo = {
+      findById: vi.fn().mockResolvedValue({ id: 'job-1', correlationId: null }),
+      getStatus: vi.fn().mockResolvedValue('cancelled'),
+      getPendingItems: vi.fn(),
+      markJobCompletedIfDone: vi.fn()
+    }
+    const service = new HealthRefreshService(healthRepo as never)
+
+    await service.processJob('job-1')
+
+    expect(healthRepo.getPendingItems).not.toHaveBeenCalled()
+    expect(healthRepo.markJobCompletedIfDone).not.toHaveBeenCalled()
+  })
+})
+
+describe('[pin] HealthRefreshService cancel()', () => {
+  it('cancels a running job and its pending items', async () => {
+    const healthRepo = {
+      findById: vi.fn().mockResolvedValue({ id: 'job-1', status: 'running', systemName: 'acme' }),
+      markCancelled: vi.fn().mockResolvedValue(undefined),
+      cancelPendingItems: vi.fn().mockResolvedValue(undefined)
+    }
+    const auditRepo = { create: vi.fn().mockResolvedValue(undefined) }
+    const service = new HealthRefreshService(healthRepo as never, {} as never, auditRepo as never)
+
+    const result = await service.cancel('job-1', { userId: 'admin-1', realUserId: null })
+
+    expect(healthRepo.markCancelled).toHaveBeenCalledWith('job-1')
+    expect(healthRepo.cancelPendingItems).toHaveBeenCalledWith('job-1')
+    expect(auditRepo.create).toHaveBeenCalledWith(expect.objectContaining({ operation: 'CANCEL', entityType: 'HealthRefreshJob' }))
+    expect(result).toEqual({ id: 'job-1', status: 'running', systemName: 'acme' })
+  })
+
+  it('rejects cancelling a job that is not queued/running', async () => {
+    const healthRepo = { findById: vi.fn().mockResolvedValue({ id: 'job-1', status: 'completed' }) }
+    const service = new HealthRefreshService(healthRepo as never)
+
+    await expect(service.cancel('job-1', { userId: 'admin-1' })).rejects.toMatchObject({ statusCode: 409 })
+  })
+
+  it('rejects cancelling an unknown job', async () => {
+    const healthRepo = { findById: vi.fn().mockResolvedValue(null) }
+    const service = new HealthRefreshService(healthRepo as never)
+
+    await expect(service.cancel('missing-job', { userId: 'admin-1' })).rejects.toMatchObject({ statusCode: 404 })
+  })
+})
+
+describe('[pin] HealthRefreshService remove()', () => {
+  it('deletes a finished job', async () => {
+    const healthRepo = {
+      findById: vi.fn().mockResolvedValue({ id: 'job-1', status: 'completed', systemName: 'acme' }),
+      delete: vi.fn().mockResolvedValue(undefined)
+    }
+    const auditRepo = { create: vi.fn().mockResolvedValue(undefined) }
+    const service = new HealthRefreshService(healthRepo as never, {} as never, auditRepo as never)
+
+    await service.remove('job-1', { userId: 'admin-1', realUserId: null })
+
+    expect(healthRepo.delete).toHaveBeenCalledWith('job-1')
+    expect(auditRepo.create).toHaveBeenCalledWith(expect.objectContaining({ operation: 'DELETE', entityType: 'HealthRefreshJob' }))
+  })
+
+  it('rejects deleting a queued/running job', async () => {
+    const healthRepo = { findById: vi.fn().mockResolvedValue({ id: 'job-1', status: 'running' }), delete: vi.fn() }
+    const service = new HealthRefreshService(healthRepo as never)
+
+    await expect(service.remove('job-1', { userId: 'admin-1' })).rejects.toMatchObject({ statusCode: 409 })
+    expect(healthRepo.delete).not.toHaveBeenCalled()
+  })
+
+  it('rejects deleting an unknown job', async () => {
+    const healthRepo = { findById: vi.fn().mockResolvedValue(null) }
+    const service = new HealthRefreshService(healthRepo as never)
+
+    await expect(service.remove('missing-job', { userId: 'admin-1' })).rejects.toMatchObject({ statusCode: 404 })
   })
 })

--- a/types/api.d.ts
+++ b/types/api.d.ts
@@ -289,10 +289,6 @@ export interface DashboardAttentionSummary {
     samplePlatforms: string[]
     sampleSystems: string[]
   }
-  importJobHealth: {
-    total: number
-    jobs: Array<{ id: string; organization: string; status: string; createdAt: string }>
-  }
 }
 
 export type VersionSprawlSeverity = 'high' | 'medium' | 'low'


### PR DESCRIPTION
## Description

The homepage's "Import Job Health" card showed GitHub import jobs stuck in
`running`/`queued` forever with no way to clear them — investigation found
these were orphaned by a dead/restarted Nitro process (imports run as
fire-and-forget in-process promises, with no queue/worker, timeout check, or
reaper). This PR removes that card and replaces it with a proper superuser
admin page for managing background jobs.

## Changes Made

**New "Background Jobs" admin page** (`app/pages/admin/import-jobs.vue`),
with two tabs:

- **GitHub Imports** — paginated/filterable job listing, a detail modal with
  per-repository item status, Cancel (for queued/running jobs) and Delete
  (blocked on active jobs — cancel first) actions.
- **Health Refresh** — the same listing/detail/cancel/delete treatment for
  the separate, structurally similar health-refresh background job type
  driven by the scheduled Nitro task.

For both job types, cancel adds a cancellation checkpoint inside the actual
background processing loop (`GitHubOrgImportService.process()` /
`HealthRefreshService.processJob()`), so a still-live process actually stops
work rather than just flipping a status flag. `markJobCompletedIfDone()` was
also guarded so it can't silently overwrite a cancelled health-refresh job
back to `completed`.

New repository methods (`findAll`, `getStatus`, `markCancelled`,
`cancelPendingItems`, `delete`) and matching `.cypher` files were added to
both `ImportJobRepository` and `HealthRefreshRepository`. The now-dead
`ImportJobRepository.findRecentActive` (only used by the removed homepage
card) and its query were deleted. New API routes under
`server/api/admin/import/jobs/**` and `server/api/admin/health-refresh/jobs/**`.

**Import dialog UX**: the "Import from GitHub" dialog can now be closed
while the import keeps running in the background (previously blocked until
finished), with an info alert and a "View in Background Jobs" link. Also
added "Hide private"/"Hide archived" toggles to the repo-picker step.

**Delete confirmation wording**: tightened to make clear that deleting a job
only removes its run-history/per-item tracking rows — it does not touch the
underlying Component/System data or health snapshots.

**Bundled, unrelated, pre-existing work**: this branch also carries a
component link-suggestions dismiss/undismiss flow that was already
uncommitted in the working tree before this task started — a new admin page
(`app/pages/admin/dismissed-links.vue`) to view/restore dismissed
components, plus showing component descriptions/purl in the existing
link-suggestions queue.

## Test plan

- [x] Repository tests (live Neo4j) for all new methods on both
      `ImportJobRepository` and `HealthRefreshRepository`
- [x] Service tests (mocked) for `cancel`/`remove`/`findAll` and the
      cancellation-checkpoint behavior in both processing loops
- [x] API-handler tests for all new/changed endpoints
- [x] `run_lint` clean across the full changeset
- [x] Full layered test suite (utils, services, repositories, api, app,
      schema, e2e) passing
- [x] Manually verified the new admin page and both tabs render correctly
      in a browser (dev server), including the status-filter dropdown fix
- [ ] `npm run build` not run this session — only `npm run dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)