### PR TITLE
Fix component-linking name collisions across npm scopes/ecosystems

### DIFF
--- a/app/components/ComponentVersionsModal.vue
+++ b/app/components/ComponentVersionsModal.vue
@@ -178,7 +178,14 @@ function versionActions(component: GroupedComponentVersion) {
     groups.push([{
       label: 'Create Technology',
       icon: 'i-lucide-plus',
-      onSelect: () => navigateTo({ path: '/admin/component-links', query: { component: component.name } })
+      onSelect: () => navigateTo({
+        path: '/admin/component-links',
+        query: {
+          component: component.name,
+          group: component.group ?? undefined,
+          packageManager: component.packageManager ?? undefined
+        }
+      })
     }])
   }
 

--- a/app/components/LinkComponentModal.vue
+++ b/app/components/LinkComponentModal.vue
@@ -22,19 +22,19 @@
         <div v-if="searchResults.length > 0" class="max-h-60 overflow-y-auto border border-(--ui-border) rounded-md divide-y divide-(--ui-border)">
           <UButton
             v-for="comp in searchResults"
-            :key="`${comp.name}@${comp.version}`"
+            :key="`${comp.packageManager}:${comp.group}:${comp.name}@${comp.version}`"
             variant="ghost"
             color="neutral"
             class="w-full justify-start px-3 py-2"
-            :class="{ 'bg-(--ui-bg-elevated)': selected?.name === comp.name && selected?.version === comp.version }"
-            @click="selected = { name: comp.name, version: comp.version }"
+            :class="{ 'bg-(--ui-bg-elevated)': isSelected(comp) }"
+            @click="selected = { name: comp.name, version: comp.version, group: comp.group ?? null, packageManager: comp.packageManager ?? null }"
           >
-            <span class="font-medium">{{ comp.name }}</span>
+            <span class="font-medium">{{ displayName(comp) }}</span>
             <code class="ml-2 text-sm">{{ comp.version }}</code>
           </UButton>
         </div>
         <div v-if="selected" class="text-sm">
-          Selected: <strong>{{ selected.name }}</strong> <code>{{ selected.version }}</code>
+          Selected: <strong>{{ displayName(selected) }}</strong> <code>{{ selected.version }}</code>
         </div>
         <UAlert
           v-if="error"
@@ -70,12 +70,33 @@ const emit = defineEmits<{
   linked: []
 }>()
 
+interface ComponentOption {
+  name: string
+  version: string
+  group?: string | null
+  packageManager?: string | null
+  purl?: string
+}
+
 const loading = ref(false)
 const error = ref('')
 const search = ref('')
-const searchResults = ref<{ name: string; version: string; purl?: string }[]>([])
+const searchResults = ref<ComponentOption[]>([])
 const searching = ref(false)
-const selected = ref<{ name: string; version: string } | null>(null)
+const selected = ref<ComponentOption | null>(null)
+
+// Group-qualifies the display name — different scopes/ecosystems can share a bare
+// name (e.g. @nuxt/ui vs @vitest/ui), so the bare name alone can be ambiguous.
+function displayName(comp: ComponentOption): string {
+  return comp.group ? `${comp.group}/${comp.name}` : comp.name
+}
+
+function isSelected(comp: ComponentOption): boolean {
+  return selected.value?.name === comp.name &&
+    selected.value?.version === comp.version &&
+    (selected.value?.group ?? null) === (comp.group ?? null) &&
+    (selected.value?.packageManager ?? null) === (comp.packageManager ?? null)
+}
 
 let searchTimeout: ReturnType<typeof setTimeout> | null = null
 watch(search, (val) => {
@@ -88,7 +109,7 @@ watch(search, (val) => {
   searchTimeout = setTimeout(async () => {
     searching.value = true
     try {
-      const res = await $fetch<{ data: { name: string; version: string; purl?: string; technologyName?: string }[] }>('/api/components', {
+      const res = await $fetch<{ data: { name: string; version: string; group?: string | null; packageManager?: string | null; purl?: string; technologyName?: string }[] }>('/api/components', {
         query: { search: val, limit: 20 }
       })
       // Only show components not already linked to a technology
@@ -111,7 +132,9 @@ async function confirmLink() {
       method: 'POST',
       body: {
         componentName: selected.value.name,
-        componentVersion: selected.value.version
+        componentVersion: selected.value.version,
+        componentGroup: selected.value.group ?? null,
+        componentPackageManager: selected.value.packageManager ?? null
       }
     })
     emit('update:open', false)

--- a/app/pages/admin/component-links.vue
+++ b/app/pages/admin/component-links.vue
@@ -67,7 +67,7 @@
       <template #body>
         <div class="space-y-4">
           <div class="text-sm text-(--ui-text-muted)">
-            Component: <code>{{ confirmItem?.name }}</code>
+            Component: <code>{{ confirmItem?.group ? `${confirmItem.group}/${confirmItem.name}` : confirmItem?.name }}</code>
           </div>
 
           <div>
@@ -159,6 +159,7 @@ import type { ApiResponse } from '~~/types/api'
 
 interface LinkSuggestion {
   name: string
+  group: string | null
   packageManager: string | null
   description: string | null
   purl: string
@@ -199,7 +200,10 @@ const suggestions = useApiData(data)
 const total = useApiCount(data)
 
 // Deep-link support: ComponentVersionsModal's "Create Technology" action
-// links here with ?component=<name> to jump straight into the confirm flow.
+// links here with ?component=<name>&group=<group>&packageManager=<pm> to jump straight
+// into the confirm flow. group/packageManager disambiguate components sharing a bare
+// name across scopes or ecosystems (e.g. @nuxt/ui vs @vitest/ui) — older links without
+// them fall back to matching on name alone.
 // Only attempted once on initial load — not re-triggered by later refreshes.
 const route = useRoute()
 const deepLinkNotFound = ref('')
@@ -209,7 +213,13 @@ watch(suggestions, (items) => {
   const target = route.query.component as string | undefined
   if (!target || deepLinkAttempted || pending.value) return
   deepLinkAttempted = true
-  const match = items.find(item => item.name === target)
+  const targetGroup = route.query.group as string | undefined
+  const targetPackageManager = route.query.packageManager as string | undefined
+  const match = items.find(item =>
+    item.name === target &&
+    (targetGroup === undefined || (item.group ?? '') === targetGroup) &&
+    (targetPackageManager === undefined || (item.packageManager ?? '') === targetPackageManager)
+  )
   if (match) {
     openConfirmModal(match)
   } else {
@@ -222,13 +232,16 @@ const columns: TableColumn<LinkSuggestion>[] = [
     accessorKey: 'name',
     header: 'Component',
     cell: ({ row }) => {
-      const { name, description, purl } = row.original
+      const { name, group, description, purl } = row.original
+      // Group-qualify the display name — different scopes/ecosystems can share a bare
+      // name (e.g. @nuxt/ui vs @vitest/ui), and each now appears as its own row.
+      const displayName = group ? `${group}/${name}` : name
       const nameEl = description
         ? h(UTooltip, { text: description }, () => h('span', { class: 'inline-flex items-center gap-1.5 font-medium' }, [
-            name,
+            displayName,
             h(UIcon, { name: 'i-lucide-info', class: 'size-3.5 text-(--ui-text-muted)' })
           ]))
-        : h('span', { class: 'font-medium' }, name)
+        : h('span', { class: 'font-medium' }, displayName)
       return h('div', {}, [
         nameEl,
         h('div', { class: 'text-xs text-(--ui-text-muted) font-mono truncate' }, purl)
@@ -377,7 +390,11 @@ async function submitConfirmLink() {
   try {
     await $fetch(`/api/technologies/${encodeURIComponent(selectedTech.value)}/components`, {
       method: 'POST',
-      body: { purl: confirmItem.value.name }
+      body: {
+        purl: confirmItem.value.name,
+        componentGroup: confirmItem.value.group,
+        componentPackageManager: confirmItem.value.packageManager
+      }
     })
     confirmModalOpen.value = false
     await refresh()
@@ -405,7 +422,9 @@ async function submitCreateNew() {
         domain: createForm.domain || undefined,
         vendor: createForm.vendor || undefined,
         ownerTeam: createForm.ownerTeam || undefined,
-        componentName: confirmItem.value.name
+        componentName: confirmItem.value.name,
+        componentGroup: confirmItem.value.group,
+        componentPackageManager: confirmItem.value.packageManager
       }
     })
     confirmModalOpen.value = false
@@ -426,7 +445,11 @@ async function dismissItem(item: LinkSuggestion) {
   try {
     await $fetch('/api/components/dismiss-link', {
       method: 'POST',
-      body: { componentName: item.name }
+      body: {
+        componentName: item.name,
+        componentGroup: item.group,
+        componentPackageManager: item.packageManager
+      }
     })
     await refresh()
   } catch (err: unknown) {

--- a/app/pages/admin/dismissed-links.vue
+++ b/app/pages/admin/dismissed-links.vue
@@ -57,6 +57,7 @@ import type { ApiResponse } from '~~/types/api'
 
 interface DismissedComponent {
   name: string
+  group: string | null
   packageManager: string | null
   description: string | null
   purl: string | null
@@ -84,13 +85,14 @@ const columns: TableColumn<DismissedComponent>[] = [
     accessorKey: 'name',
     header: 'Component',
     cell: ({ row }) => {
-      const { name, description, purl } = row.original
+      const { name, group, description, purl } = row.original
+      const displayName = group ? `${group}/${name}` : name
       const nameEl = description
         ? h(UTooltip, { text: description }, () => h('span', { class: 'inline-flex items-center gap-1.5 font-medium' }, [
-            name,
+            displayName,
             h(UIcon, { name: 'i-lucide-info', class: 'size-3.5 text-(--ui-text-muted)' })
           ]))
-        : h('span', { class: 'font-medium' }, name)
+        : h('span', { class: 'font-medium' }, displayName)
       return h('div', {}, [
         nameEl,
         purl ? h('div', { class: 'text-xs text-(--ui-text-muted) font-mono truncate' }, purl) : null
@@ -131,7 +133,11 @@ async function restoreItem(item: DismissedComponent) {
   try {
     await $fetch('/api/components/undismiss-link', {
       method: 'POST',
-      body: { componentName: item.name }
+      body: {
+        componentName: item.name,
+        componentGroup: item.group,
+        componentPackageManager: item.packageManager
+      }
     })
     await refresh()
   } catch (err: unknown) {

--- a/app/pages/technologies/[name]/index.vue
+++ b/app/pages/technologies/[name]/index.vue
@@ -174,9 +174,19 @@
             <UTable v-model:sorting="versionSorting" :data="versionRows" :columns="versionColumns" class="flex-1" />
           </div>
 
-          <div v-if="tech.constraints && tech.constraints.length > 0" class="first:pt-0 last:pb-0 py-6">
-            <h3 class="text-base font-semibold mb-3">Version Constraints ({{ tech.constraints.length }})</h3>
-            <div class="flex flex-wrap gap-2">
+          <div class="first:pt-0 last:pb-0 py-6">
+            <div class="flex justify-between items-center mb-3">
+              <h3 class="text-base font-semibold">Version Constraints ({{ tech.constraints?.length || 0 }})</h3>
+              <UButton
+                v-if="isSuperuser"
+                label="Add Constraint"
+                icon="i-lucide-shield-plus"
+                size="sm"
+                variant="outline"
+                @click="openConstraintModal()"
+              />
+            </div>
+            <div v-if="tech.constraints && tech.constraints.length > 0" class="flex flex-wrap gap-2">
               <UButton
                 v-for="vc in tech.constraints"
                 :key="vc.name"
@@ -193,9 +203,69 @@
                 </template>
               </UButton>
             </div>
+            <p v-else class="text-sm text-(--ui-text-muted)">No version constraints yet.</p>
           </div>
         </div>
       </UCard>
+
+      <!-- Add Version Constraint Modal -->
+      <UModal v-model:open="constraintModalOpen">
+        <template #header>
+          <h3 class="text-lg font-semibold">Add Version Constraint for {{ tech.name }}</h3>
+        </template>
+        <template #body>
+          <form class="space-y-4" @submit.prevent="submitConstraint">
+            <UFormField label="Version Range" required>
+              <UInput v-model="constraintForm.versionRange" placeholder="e.g. >=18.0.0 <20.0.0" class="w-full" autofocus />
+            </UFormField>
+
+            <div class="grid grid-cols-2 gap-4">
+              <UFormField label="Severity" required>
+                <USelect v-model="constraintForm.severity" :items="constraintSeverityOptions" placeholder="Select severity" class="w-full" />
+              </UFormField>
+              <UFormField label="Scope" required>
+                <USelect v-model="constraintForm.scope" :items="constraintScopeOptions" class="w-full" />
+              </UFormField>
+            </div>
+
+            <UFormField v-if="constraintForm.scope === 'team'" label="Subject Team" required>
+              <USelect v-model="constraintForm.subjectTeam" :items="constraintTeamOptions" placeholder="Select team" class="w-full" />
+            </UFormField>
+
+            <UFormField label="Name" required hint="Auto-generated — edit to customize">
+              <UInput
+                v-model="constraintForm.name"
+                placeholder="e.g. typescript-min-version"
+                class="w-full"
+                @update:model-value="constraintNameEdited = true"
+              />
+            </UFormField>
+
+            <UFormField label="Rationale">
+              <UTextarea v-model="constraintForm.description" placeholder="Why does this constraint exist? (e.g. CVE-2024-XXXX, contractual requirement...)" class="w-full" />
+            </UFormField>
+
+            <UAlert
+              v-if="constraintError"
+              color="error"
+              variant="subtle"
+              icon="i-lucide-alert-circle"
+              :description="constraintError"
+            />
+          </form>
+        </template>
+        <template #footer>
+          <div class="flex justify-end gap-2">
+            <UButton label="Cancel" color="neutral" variant="outline" @click="constraintModalOpen = false" />
+            <UButton
+              :label="isCreatingConstraint ? 'Creating...' : 'Create'"
+              :loading="isCreatingConstraint"
+              :disabled="!constraintForm.name || !constraintForm.severity || !constraintForm.versionRange"
+              @click="submitConstraint"
+            />
+          </div>
+        </template>
+      </UModal>
 
       <!-- Systems -->
       <div v-if="tech.systems && tech.systems.length > 0">
@@ -262,6 +332,8 @@ const versionRiskSorting = ref([])
 
 const route = useRoute()
 const { data: session } = useAuth()
+const { isSuperuser } = useEffectiveRole()
+const toast = useToast()
 
 const userTeams = computed(() =>
   (session.value?.user?.teams as { name: string }[] | undefined)?.map(t => t.name) || []
@@ -709,6 +781,83 @@ async function submitApproval() {
     approvalError.value = error.data?.message || error.message || 'Failed to set approval'
   } finally {
     approvalSubmitting.value = false
+  }
+}
+
+// Add Version Constraint modal
+const constraintModalOpen = ref(false)
+const isCreatingConstraint = ref(false)
+const constraintError = ref('')
+const constraintNameEdited = ref(false)
+const constraintSeverityOptions = ['critical', 'error', 'warning', 'info']
+const constraintScopeOptions = ['organization', 'team']
+const constraintForm = ref({
+  name: '',
+  description: '',
+  severity: undefined as string | undefined,
+  scope: 'organization',
+  subjectTeam: undefined as string | undefined,
+  versionRange: ''
+})
+
+interface TeamsResponse { success: boolean; data: { name: string }[] }
+const { data: constraintTeamsData } = useLazyFetch<TeamsResponse>('/api/teams', { key: 'tech-constraint-teams' })
+const constraintTeamOptions = computed(() =>
+  (constraintTeamsData.value?.data || []).map(t => t.name).sort()
+)
+
+watch(
+  () => [constraintForm.value.severity, constraintForm.value.scope, constraintForm.value.subjectTeam, constraintForm.value.versionRange],
+  () => {
+    if (constraintNameEdited.value) return
+    constraintForm.value.name = generateVersionConstraintName({
+      technology: tech.value?.name,
+      scope: constraintForm.value.scope,
+      subjectTeam: constraintForm.value.subjectTeam,
+      severity: constraintForm.value.severity,
+      versionRange: constraintForm.value.versionRange
+    })
+  }
+)
+
+function openConstraintModal() {
+  constraintError.value = ''
+  constraintNameEdited.value = false
+  constraintForm.value = {
+    name: '',
+    description: '',
+    severity: undefined,
+    scope: 'organization',
+    subjectTeam: undefined,
+    versionRange: ''
+  }
+  constraintModalOpen.value = true
+}
+
+async function submitConstraint() {
+  isCreatingConstraint.value = true
+  constraintError.value = ''
+  try {
+    await $fetch('/api/version-constraints', {
+      method: 'POST',
+      body: {
+        name: constraintForm.value.name,
+        description: constraintForm.value.description || undefined,
+        severity: constraintForm.value.severity,
+        scope: constraintForm.value.scope,
+        subjectTeam: constraintForm.value.scope === 'team' ? constraintForm.value.subjectTeam : undefined,
+        versionRange: constraintForm.value.versionRange,
+        governsTechnology: tech.value!.name
+      }
+    })
+    constraintModalOpen.value = false
+    await refresh()
+    toast.add({ title: 'Version constraint created', color: 'success' })
+  } catch (e: unknown) {
+    const err = e as { data?: { message?: string }; message?: string }
+    constraintError.value = err.data?.message || err.message || 'Failed to create version constraint'
+  } finally {
+    isCreatingConstraint.value = false
   }
 }
 

--- a/app/pages/version-constraints/index.vue
+++ b/app/pages/version-constraints/index.vue
@@ -8,7 +8,7 @@
       <UButton
         v-if="isSuperuser"
         label="+ Create"
-        @click="showCreateModal = true"
+        @click="openCreateModal()"
       />
     </div>
 
@@ -50,36 +50,34 @@
       </template>
       <template #body>
         <div class="space-y-4">
-          <div>
-            <label class="block text-sm font-medium mb-1">Name *</label>
-            <UInput v-model="createForm.name" placeholder="e.g. react-min-version" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Description</label>
-            <UTextarea v-model="createForm.description" placeholder="What does this constraint enforce?" />
-          </div>
+          <UFormField label="Version Range" required>
+            <UInput v-model="createForm.versionRange" placeholder="e.g. >=18.0.0 <20.0.0" class="w-full" autofocus />
+          </UFormField>
           <div class="grid grid-cols-2 gap-4">
-            <div>
-              <label class="block text-sm font-medium mb-1">Severity *</label>
-              <USelect v-model="createForm.severity" :items="severityOptions" placeholder="Select severity" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium mb-1">Scope *</label>
-              <USelect v-model="createForm.scope" :items="scopeOptions" />
-            </div>
+            <UFormField label="Severity" required>
+              <USelect v-model="createForm.severity" :items="severityOptions" placeholder="Select severity" class="w-full" />
+            </UFormField>
+            <UFormField label="Scope" required>
+              <USelect v-model="createForm.scope" :items="scopeOptions" class="w-full" />
+            </UFormField>
           </div>
-          <div v-if="createForm.scope === 'team'">
-            <label class="block text-sm font-medium mb-1">Subject Team *</label>
-            <USelect v-model="createForm.subjectTeam" :items="teamOptions" placeholder="Select team" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Version Range *</label>
-            <UInput v-model="createForm.versionRange" placeholder="e.g. >=18.0.0 <20.0.0" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Governs Technology</label>
-            <USelect v-model="createForm.governsTechnology" :items="technologyOptions" placeholder="Select technology" />
-          </div>
+          <UFormField v-if="createForm.scope === 'team'" label="Subject Team" required>
+            <USelect v-model="createForm.subjectTeam" :items="teamOptions" placeholder="Select team" class="w-full" />
+          </UFormField>
+          <UFormField label="Governs Technology">
+            <USelect v-model="createForm.governsTechnology" :items="technologyOptions" placeholder="Select technology" class="w-full" />
+          </UFormField>
+          <UFormField label="Name" required hint="Auto-generated — edit to customize">
+            <UInput
+              v-model="createForm.name"
+              placeholder="e.g. react-min-version"
+              class="w-full"
+              @update:model-value="createNameEdited = true"
+            />
+          </UFormField>
+          <UFormField label="Rationale">
+            <UTextarea v-model="createForm.description" placeholder="Why does this constraint exist? (e.g. CVE-2024-XXXX, contractual requirement...)" class="w-full" />
+          </UFormField>
         </div>
       </template>
       <template #footer>
@@ -101,40 +99,32 @@
       </template>
       <template #body>
         <div class="space-y-4">
-          <div>
-            <label class="block text-sm font-medium mb-1">Name</label>
-            <UInput :model-value="editForm.name" disabled />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Description</label>
-            <UTextarea v-model="editForm.description" placeholder="Description" />
-          </div>
+          <UFormField label="Version Range" required>
+            <UInput v-model="editForm.versionRange" placeholder="e.g. >=18.0.0 <20.0.0" class="w-full" autofocus />
+          </UFormField>
           <div class="grid grid-cols-2 gap-4">
-            <div>
-              <label class="block text-sm font-medium mb-1">Severity *</label>
-              <USelect v-model="editForm.severity" :items="severityOptions" placeholder="Select severity" />
-            </div>
-            <div>
-              <label class="block text-sm font-medium mb-1">Scope *</label>
-              <USelect v-model="editForm.scope" :items="editScopeOptions" />
-            </div>
+            <UFormField label="Severity" required>
+              <USelect v-model="editForm.severity" :items="severityOptions" placeholder="Select severity" class="w-full" />
+            </UFormField>
+            <UFormField label="Scope" required>
+              <USelect v-model="editForm.scope" :items="editScopeOptions" class="w-full" />
+            </UFormField>
           </div>
-          <div v-if="editForm.scope === 'team'">
-            <label class="block text-sm font-medium mb-1">Subject Team *</label>
-            <USelect v-model="editForm.subjectTeam" :items="teamOptions" placeholder="Select team" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Version Range *</label>
-            <UInput v-model="editForm.versionRange" placeholder="e.g. >=18.0.0 <20.0.0" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Governs Technology</label>
-            <USelect v-model="editForm.governsTechnology" :items="technologyOptions" placeholder="Select technology" />
-          </div>
-          <div>
-            <label class="block text-sm font-medium mb-1">Status</label>
-            <USelect v-model="editForm.status" :items="statusOptions" />
-          </div>
+          <UFormField v-if="editForm.scope === 'team'" label="Subject Team" required>
+            <USelect v-model="editForm.subjectTeam" :items="teamOptions" placeholder="Select team" class="w-full" />
+          </UFormField>
+          <UFormField label="Governs Technology">
+            <USelect v-model="editForm.governsTechnology" :items="technologyOptions" placeholder="Select technology" class="w-full" />
+          </UFormField>
+          <UFormField label="Status" required>
+            <USelect v-model="editForm.status" :items="statusOptions" class="w-full" />
+          </UFormField>
+          <UFormField label="Name" hint="Fixed — identifiers can't be renamed">
+            <UInput :model-value="editForm.name" disabled class="w-full" />
+          </UFormField>
+          <UFormField label="Rationale">
+            <UTextarea v-model="editForm.description" placeholder="Why does this constraint exist? (e.g. CVE-2024-XXXX, contractual requirement...)" class="w-full" />
+          </UFormField>
         </div>
       </template>
       <template #footer>
@@ -351,6 +341,28 @@ const { data: techData } = useLazyFetch<TechResponse>('/api/technologies', { key
 const technologyOptions = computed(() =>
   (techData.value?.data || []).map(t => t.name).sort()
 )
+
+const createNameEdited = ref(false)
+
+watch(
+  () => [createForm.value.severity, createForm.value.scope, createForm.value.subjectTeam, createForm.value.versionRange, createForm.value.governsTechnology],
+  () => {
+    if (createNameEdited.value) return
+    createForm.value.name = generateVersionConstraintName({
+      technology: createForm.value.governsTechnology,
+      scope: createForm.value.scope,
+      subjectTeam: createForm.value.subjectTeam,
+      severity: createForm.value.severity,
+      versionRange: createForm.value.versionRange
+    })
+  }
+)
+
+function openCreateModal() {
+  createNameEdited.value = false
+  createForm.value = { name: '', description: '', severity: undefined, scope: 'organization', subjectTeam: undefined, versionRange: '', governsTechnology: undefined }
+  showCreateModal.value = true
+}
 
 async function handleCreate() {
   isCreating.value = true

--- a/app/utils/version-constraint-name.ts
+++ b/app/utils/version-constraint-name.ts
@@ -1,0 +1,42 @@
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9.]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
+// Turns ">=18.0.0 <20.0.0" into "gte18.0.0-lt20.0.0" so it reads as a name segment
+function slugifyVersionRange(range: string): string {
+  return range
+    .trim()
+    .replace(/>=/g, 'gte')
+    .replace(/<=/g, 'lte')
+    .replace(/>/g, 'gt')
+    .replace(/</g, 'lt')
+    .replace(/=/g, 'eq')
+    .split(/\s+/)
+    .filter(Boolean)
+    .join('-')
+}
+
+export interface ConstraintNameInput {
+  technology?: string | null
+  scope: string
+  subjectTeam?: string | null
+  severity?: string | null
+  versionRange?: string | null
+}
+
+export function generateVersionConstraintName(input: ConstraintNameInput): string {
+  const parts: string[] = []
+  if (input.technology) parts.push(slugify(input.technology))
+  parts.push(
+    input.scope === 'team' && input.subjectTeam
+      ? slugify(input.subjectTeam)
+      : 'org'
+  )
+  if (input.severity) parts.push(input.severity)
+  if (input.versionRange) parts.push(slugifyVersionRange(input.versionRange))
+  return parts.filter(Boolean).join('-')
+}

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Polaris API",
-    "version": "0.6.72",
+    "version": "0.6.85",
     "description": "# Polaris Technology Catalog API\n\nThe Polaris API provides programmatic access to the technology catalog, enabling automation, integration, and custom tooling.\n\n## Key Features\n\n- **RESTful Design** - Resource-based URLs with proper HTTP methods\n- **Comprehensive Coverage** - Systems, Teams, Technologies, Components, Policies, and more\n- **Developer-Friendly** - Clear error messages and consistent response structure\n\n## Authentication\n\nMost endpoints require authentication using session-based authentication integrated with the web application.\n\n**Authorization Levels:**\n- **Public** - No authentication required\n- **Authenticated** - Valid user session required  \n- **Team Member** - User must belong to a team\n- **Team Owner** - User must belong to team that owns the resource\n- **Superuser** - User must have superuser role\n\n## Response Format\n\nAll successful responses follow this structure:\n```json\n{\n  \"success\": true,\n  \"data\": [...],\n  \"count\": 10\n}\n```\n\nAll errors follow this structure:\n```json\n{\n  \"statusCode\": 404,\n  \"message\": \"Resource 'example' not found\"\n}\n```\n\n## Richardson Maturity Model\n\nThis API implements **RMM Level 2** with proper use of HTTP methods and status codes.",
     "license": {
       "name": "MIT",
@@ -1381,7 +1381,15 @@
                   },
                   "componentName": {
                     "type": "string",
-                    "description": "Name of an existing, unlinked Component — all currently-unlinked versions sharing this name are linked"
+                    "description": "Name of an existing, unlinked Component — all currently-unlinked versions sharing this identity are linked"
+                  },
+                  "componentGroup": {
+                    "type": "string",
+                    "description": "Npm scope / Maven groupId / etc. — required to disambiguate components sharing a bare name across scopes"
+                  },
+                  "componentPackageManager": {
+                    "type": "string",
+                    "description": "Package manager — required to disambiguate components sharing a bare name across ecosystems"
                   }
                 }
               }
@@ -3584,7 +3592,16 @@
                     ],
                     "properties": {
                       "purl": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "A full PURL to link one specific component, or a bare component name to bulk-link every matching version (disambiguated by componentGroup/componentPackageManager)"
+                      },
+                      "componentGroup": {
+                        "type": "string",
+                        "description": "Npm scope / Maven groupId / etc. — used with the bare-name form to disambiguate components sharing a name across scopes"
+                      },
+                      "componentPackageManager": {
+                        "type": "string",
+                        "description": "Package manager — used with the bare-name form to disambiguate components sharing a name across ecosystems"
                       }
                     }
                   },
@@ -3599,6 +3616,14 @@
                       },
                       "componentVersion": {
                         "type": "string"
+                      },
+                      "componentGroup": {
+                        "type": "string",
+                        "description": "Npm scope / Maven groupId / etc. — disambiguates components sharing a name+version across scopes"
+                      },
+                      "componentPackageManager": {
+                        "type": "string",
+                        "description": "Package manager — disambiguates components sharing a name+version across ecosystems"
                       }
                     }
                   }
@@ -5409,6 +5434,14 @@
                   "componentName": {
                     "type": "string",
                     "description": "The component name to restore (all versions)"
+                  },
+                  "componentGroup": {
+                    "type": "string",
+                    "description": "Npm scope / Maven groupId / etc., to disambiguate components sharing a bare name"
+                  },
+                  "componentPackageManager": {
+                    "type": "string",
+                    "description": "Package manager, to disambiguate components sharing a bare name across ecosystems"
                   }
                 }
               }
@@ -5832,6 +5865,14 @@
                   "componentName": {
                     "type": "string",
                     "description": "The component name to dismiss (all versions)"
+                  },
+                  "componentGroup": {
+                    "type": "string",
+                    "description": "Npm scope / Maven groupId / etc., to disambiguate components sharing a bare name"
+                  },
+                  "componentPackageManager": {
+                    "type": "string",
+                    "description": "Package manager, to disambiguate components sharing a bare name across ecosystems"
                   }
                 }
               }

--- a/server/api/components/dismiss-link.post.ts
+++ b/server/api/components/dismiss-link.post.ts
@@ -23,6 +23,12 @@ import { auditFailedOperation } from '../../utils/audit'
  *               componentName:
  *                 type: string
  *                 description: The component name to dismiss (all versions)
+ *               componentGroup:
+ *                 type: string
+ *                 description: Npm scope / Maven groupId / etc., to disambiguate components sharing a bare name
+ *               componentPackageManager:
+ *                 type: string
+ *                 description: Package manager, to disambiguate components sharing a bare name across ecosystems
  *     responses:
  *       204:
  *         description: Component dismissed from queue
@@ -41,7 +47,11 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    await componentService.dismissLink(body.componentName)
+    await componentService.dismissLink({
+      name: body.componentName,
+      group: body.componentGroup ?? null,
+      packageManager: body.componentPackageManager ?? null
+    })
     setResponseStatus(event, 204)
     return null
   } catch (error) {

--- a/server/api/components/undismiss-link.post.ts
+++ b/server/api/components/undismiss-link.post.ts
@@ -23,6 +23,12 @@ import { auditFailedOperation } from '../../utils/audit'
  *               componentName:
  *                 type: string
  *                 description: The component name to restore (all versions)
+ *               componentGroup:
+ *                 type: string
+ *                 description: Npm scope / Maven groupId / etc., to disambiguate components sharing a bare name
+ *               componentPackageManager:
+ *                 type: string
+ *                 description: Package manager, to disambiguate components sharing a bare name across ecosystems
  *     responses:
  *       204:
  *         description: Component restored to queue
@@ -41,7 +47,11 @@ export default defineEventHandler(async (event) => {
   }
 
   try {
-    await componentService.undismissLink(body.componentName)
+    await componentService.undismissLink({
+      name: body.componentName,
+      group: body.componentGroup ?? null,
+      packageManager: body.componentPackageManager ?? null
+    })
     setResponseStatus(event, 204)
     return null
   } catch (error) {

--- a/server/api/technologies.post.ts
+++ b/server/api/technologies.post.ts
@@ -48,7 +48,13 @@ import { auditFailedOperation } from '../utils/audit'
  *                 type: string
  *               componentName:
  *                 type: string
- *                 description: Name of an existing, unlinked Component — all currently-unlinked versions sharing this name are linked
+ *                 description: Name of an existing, unlinked Component — all currently-unlinked versions sharing this identity are linked
+ *               componentGroup:
+ *                 type: string
+ *                 description: Npm scope / Maven groupId / etc. — required to disambiguate components sharing a bare name across scopes
+ *               componentPackageManager:
+ *                 type: string
+ *                 description: Package manager — required to disambiguate components sharing a bare name across ecosystems
  *     responses:
  *       201:
  *         description: Technology created
@@ -71,6 +77,8 @@ interface CreateTechnologyRequest {
   vendor?: string
   ownerTeam?: string
   componentName: string
+  componentGroup?: string | null
+  componentPackageManager?: string | null
 }
 
 interface CreateTechnologyResponse {

--- a/server/api/technologies/[name]/components.post.ts
+++ b/server/api/technologies/[name]/components.post.ts
@@ -33,12 +33,25 @@ import { auditFailedOperation } from '../../../utils/audit'
  *                 properties:
  *                   purl:
  *                     type: string
+ *                     description: A full PURL to link one specific component, or a bare component name to bulk-link every matching version (disambiguated by componentGroup/componentPackageManager)
+ *                   componentGroup:
+ *                     type: string
+ *                     description: Npm scope / Maven groupId / etc. — used with the bare-name form to disambiguate components sharing a name across scopes
+ *                   componentPackageManager:
+ *                     type: string
+ *                     description: Package manager — used with the bare-name form to disambiguate components sharing a name across ecosystems
  *               - required: [componentName, componentVersion]
  *                 properties:
  *                   componentName:
  *                     type: string
  *                   componentVersion:
  *                     type: string
+ *                   componentGroup:
+ *                     type: string
+ *                     description: Npm scope / Maven groupId / etc. — disambiguates components sharing a name+version across scopes
+ *                   componentPackageManager:
+ *                     type: string
+ *                     description: Package manager — disambiguates components sharing a name+version across ecosystems
  *     responses:
  *       200:
  *         description: Component linked
@@ -83,6 +96,8 @@ export default defineEventHandler(async (event) => {
         const result = await technologyService.linkComponentByName({
           technologyName,
           componentName: body.purl,
+          componentGroup: body.componentGroup ?? null,
+          componentPackageManager: body.componentPackageManager ?? null,
           userId: user.id,
           realUserId
         })
@@ -102,6 +117,8 @@ export default defineEventHandler(async (event) => {
       technologyName,
       componentName: body.componentName,
       componentVersion: body.componentVersion,
+      componentGroup: body.componentGroup ?? null,
+      componentPackageManager: body.componentPackageManager ?? null,
       userId: user.id,
       realUserId
     })

--- a/server/database/queries/components/dismiss-link.cypher
+++ b/server/database/queries/components/dismiss-link.cypher
@@ -1,3 +1,7 @@
+// Matches by full package identity, not just name — see link-suggestions.cypher for why
+// bare name isn't a safe key (e.g. @nuxt/ui vs @vitest/ui share the name "ui").
 MATCH (c:Component {name: $componentName})
+WHERE coalesce(c.`group`, '') = coalesce($componentGroup, '')
+  AND coalesce(c.packageManager, '') = coalesce($componentPackageManager, '')
 SET c.linkDismissedAt = datetime()
 RETURN count(c) AS dismissed

--- a/server/database/queries/components/dismissed-links-count.cypher
+++ b/server/database/queries/components/dismissed-links-count.cypher
@@ -1,4 +1,5 @@
+// Count must use the same dedup key as dismissed-links.cypher: (name, group, packageManager).
 MATCH (c:Component)
 WHERE c.linkDismissedAt IS NOT NULL
   AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
-RETURN count(DISTINCT c.name) AS total
+RETURN count(DISTINCT [c.name, coalesce(c.`group`, ''), coalesce(c.packageManager, '')]) AS total

--- a/server/database/queries/components/dismissed-links.cypher
+++ b/server/database/queries/components/dismissed-links.cypher
@@ -1,19 +1,20 @@
 // Returns components previously dismissed from the link-suggestions queue.
-// Deduplicates by component name (ignoring version), since dismissal applies to
-// all versions of a component at once — see components/dismiss-link.cypher.
+// Deduplicates by (name, group, packageManager) — ignoring version, since dismissal
+// applies to all versions of a package at once — see components/dismiss-link.cypher.
 // Ordered most-recently-dismissed first.
 MATCH (c:Component)
 WHERE c.linkDismissedAt IS NOT NULL
   AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
-WITH c.name AS componentName, c.packageManager AS packageManager, c.description AS description, c.purl AS purl, c.linkDismissedAt AS linkDismissedAt
-WITH componentName, packageManager,
+WITH c.name AS componentName, c.`group` AS componentGroup, c.packageManager AS packageManager, c.description AS description, c.purl AS purl, c.linkDismissedAt AS linkDismissedAt
+WITH componentName, componentGroup, packageManager,
      [d IN collect(description) WHERE d IS NOT NULL][0] AS description,
      [p IN collect(purl) WHERE p IS NOT NULL][0] AS purl,
      max(linkDismissedAt) AS dismissedAt
-ORDER BY dismissedAt DESC, componentName ASC
+ORDER BY dismissedAt DESC, componentName ASC, componentGroup ASC
 SKIP toInteger($skip) LIMIT toInteger($limit)
 RETURN
   componentName AS name,
+  componentGroup AS `group`,
   packageManager,
   description,
   purl,

--- a/server/database/queries/components/link-suggestions-count.cypher
+++ b/server/database/queries/components/link-suggestions-count.cypher
@@ -1,3 +1,4 @@
+// Count must use the same dedup key as link-suggestions.cypher: (name, group, packageManager).
 MATCH (c:Component)<-[uses:USES {isDirect: true}]-(:System)
 WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND c.linkDismissedAt IS NULL
@@ -5,4 +6,4 @@ WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
 WITH c, toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
 WHERE size(purlName) > 0
-RETURN count(DISTINCT c.name) AS total
+RETURN count(DISTINCT [c.name, coalesce(c.`group`, ''), coalesce(c.packageManager, '')]) AS total

--- a/server/database/queries/components/link-suggestions.cypher
+++ b/server/database/queries/components/link-suggestions.cypher
@@ -1,5 +1,7 @@
 // Returns unlinked, non-dismissed, direct-dependency components with fuzzy Technology name suggestions.
-// Deduplicates by component name (ignoring version).
+// Deduplicates by (name, group, packageManager) — bare name alone is not a safe dedup key,
+// since unrelated packages routinely share a name across npm scopes or ecosystems
+// (e.g. @nuxt/ui vs @vitest/ui, or a DefinitelyTyped @types/* package vs the real package).
 //
 // PURL name extraction: last path segment before the first '@'
 //   pkg:npm/react@18.2.0           → react
@@ -10,7 +12,7 @@
 //   exactMatches   — Technology names whose toLower equals the extracted purlName
 //   partialMatches — Technology names that contain the purlName (up to 4)
 //
-// Results ordered: exact matches first, then alphabetically by component name.
+// Results ordered: exact matches first, then alphabetically by component name and group.
 // Total count is fetched separately via link-suggestions-count.cypher to avoid
 // collecting all matching nodes into memory before paginating.
 MATCH (c:Component)<-[uses:USES {isDirect: true}]-(:System)
@@ -18,27 +20,28 @@ WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
   AND c.linkDismissedAt IS NULL
   AND c.purl IS NOT NULL
   AND ($search IS NULL OR toLower(c.name) CONTAINS toLower($search))
-WITH c.name AS componentName, c.packageManager AS packageManager, c.description AS description, c.purl AS purl,
+WITH c.name AS componentName, c.`group` AS componentGroup, c.packageManager AS packageManager, c.description AS description, c.purl AS purl,
      toLower(split(last(split(c.purl, '/')), '@')[0]) AS purlName
 WHERE size(purlName) > 0
 // Different versions of the same component may carry different (or missing) description/purl — take the first non-null one
-WITH componentName, packageManager, purlName,
+WITH componentName, componentGroup, packageManager, purlName,
      [d IN collect(description) WHERE d IS NOT NULL][0] AS description,
      [p IN collect(purl) WHERE p IS NOT NULL][0] AS purl
 OPTIONAL MATCH (t:Technology)
   WHERE toLower(t.name) = purlName AND t IS NOT NULL
-WITH componentName, packageManager, purlName, description, purl, [x IN collect(t.name) WHERE x IS NOT NULL] AS exactMatches
+WITH componentName, componentGroup, packageManager, purlName, description, purl, [x IN collect(t.name) WHERE x IS NOT NULL] AS exactMatches
 OPTIONAL MATCH (t2:Technology)
   WHERE toLower(t2.name) CONTAINS purlName AND NOT toLower(t2.name) = purlName AND t2 IS NOT NULL
-WITH componentName, packageManager, purlName, description, purl, exactMatches,
+WITH componentName, componentGroup, packageManager, purlName, description, purl, exactMatches,
      [x IN collect(t2.name) WHERE x IS NOT NULL][0..4] AS partialMatches
-WITH componentName, packageManager, purlName, description, purl,
+WITH componentName, componentGroup, packageManager, purlName, description, purl,
      exactMatches + partialMatches AS suggestedTechnologies,
      size(exactMatches) > 0 AS hasExactMatch
-ORDER BY hasExactMatch DESC, componentName ASC
+ORDER BY hasExactMatch DESC, componentName ASC, componentGroup ASC
 SKIP toInteger($skip) LIMIT toInteger($limit)
 RETURN
   componentName AS name,
+  componentGroup AS `group`,
   packageManager,
   purl,
   purlName,

--- a/server/database/queries/components/undismiss-link.cypher
+++ b/server/database/queries/components/undismiss-link.cypher
@@ -1,3 +1,7 @@
+// Matches by full package identity, not just name — see link-suggestions.cypher for why
+// bare name isn't a safe key (e.g. @nuxt/ui vs @vitest/ui share the name "ui").
 MATCH (c:Component {name: $componentName})
+WHERE coalesce(c.`group`, '') = coalesce($componentGroup, '')
+  AND coalesce(c.packageManager, '') = coalesce($componentPackageManager, '')
 REMOVE c.linkDismissedAt
 RETURN count(c) AS restored

--- a/server/database/queries/technologies/create-from-component.cypher
+++ b/server/database/queries/technologies/create-from-component.cypher
@@ -1,12 +1,20 @@
-// Creates a Technology and links every currently-unlinked Component sharing
-// $componentName to it, atomically — Technology can never exist without at
-// least one linked Component (see docs/architecture/decisions/
-// 0004-technology-requires-component.md). If zero components match (none
-// exist with this name, or all are already linked elsewhere), nothing is
-// created and zero rows are returned so the caller can reject the request.
+// Creates a Technology and links every currently-unlinked Component sharing the same
+// package identity — (name, group, packageManager) — to it, atomically. Technology can
+// never exist without at least one linked Component (see docs/architecture/decisions/
+// 0004-technology-requires-component.md).
+//
+// Matching includes group/packageManager, not just name: unrelated packages routinely
+// share a bare name across npm scopes or ecosystems (e.g. @nuxt/ui vs @vitest/ui, or npm
+// "requests" vs PyPI "requests"), and matching on name alone would silently merge them
+// into one Technology.
+//
+// If zero components match (none exist with this identity, or all are already linked
+// elsewhere), nothing is created and zero rows are returned so the caller can reject the request.
 //
 MATCH (c:Component {name: $componentName})
 WHERE NOT (c)-[:IS_VERSION_OF]->(:Technology)
+  AND coalesce(c.`group`, '') = coalesce($componentGroup, '')
+  AND coalesce(c.packageManager, '') = coalesce($componentPackageManager, '')
 WITH collect(c) AS components
 WHERE size(components) > 0
 CREATE (t:Technology {

--- a/server/database/queries/technologies/link-component.cypher
+++ b/server/database/queries/technologies/link-component.cypher
@@ -1,5 +1,10 @@
+// Matches by full package identity, not just name+version — see create-from-component.cypher
+// for why bare name isn't a safe key (unrelated packages can share a name and, coincidentally,
+// a version string, across npm scopes or ecosystems).
 MATCH (t:Technology {name: $technologyName})
 MATCH (c:Component {name: $componentName, version: $componentVersion})
+WHERE coalesce(c.`group`, '') = coalesce($componentGroup, '')
+  AND coalesce(c.packageManager, '') = coalesce($componentPackageManager, '')
 MERGE (c)-[:IS_VERSION_OF]->(t)
 WITH t, c
 CREATE (al:AuditLog {

--- a/server/database/queries/technologies/link-components-by-name.cypher
+++ b/server/database/queries/technologies/link-components-by-name.cypher
@@ -1,17 +1,22 @@
-// Link all components with a given name to a technology.
+// Link all components matching the same package identity — (name, group, packageManager) —
+// to a technology. Matching includes group/packageManager, not just name: unrelated packages
+// routinely share a bare name across npm scopes or ecosystems (e.g. @nuxt/ui vs @vitest/ui),
+// and matching on name alone would silently cross-link them into the same Technology.
 // Returns the technology name, component name, count of linked components, and affected systems.
 
 MATCH (t:Technology {name: $technologyName})
 MATCH (c:Component {name: $componentName})
 WHERE NOT (c)-[:IS_VERSION_OF]->(t)
-
-// Create the IS_VERSION_OF relationship
+  AND coalesce(c.`group`, '') = coalesce($componentGroup, '')
+  AND coalesce(c.packageManager, '') = coalesce($componentPackageManager, '')
+WITH t, collect(c) AS components
+UNWIND components AS c
 CREATE (c)-[:IS_VERSION_OF]->(t)
-
-// Find all systems affected by this linking
-WITH t, c, $componentName AS componentName, count(c) AS linkedCount
-MATCH (s:System)-[uses:USES]->(c)
-WITH t, componentName, linkedCount, collect(DISTINCT s.name) AS affectedSystems
+WITH t, components
+UNWIND components AS c2
+OPTIONAL MATCH (s:System)-[:USES]->(c2)
+WITH t, components, collect(DISTINCT s.name) AS affectedSystemsRaw
+WITH t, components, [x IN affectedSystemsRaw WHERE x IS NOT NULL] AS affectedSystems
 
 CREATE (al:AuditLog {
   id: randomUUID(),
@@ -19,7 +24,7 @@ CREATE (al:AuditLog {
   operation: 'LINK',
   entityType: 'TechnologyComponent',
   entityId: t.name,
-  entityLabel: componentName + ' -> ' + t.name,
+  entityLabel: $componentName + ' -> ' + t.name,
   source: 'API',
   userId: $userId,
   realUserId: $realUserId
@@ -28,7 +33,7 @@ CREATE (al)-[:AUDITS]->(t)
 
 RETURN
   t.name AS technologyName,
-  componentName AS name,
-  linkedCount AS count,
+  $componentName AS name,
+  size(components) AS count,
   affectedSystems
 LIMIT 1

--- a/server/repositories/component.repository.ts
+++ b/server/repositories/component.repository.ts
@@ -49,7 +49,7 @@ export interface ComponentDependencyTree {
 export interface LinkSuggestion {
   purl: string
   name: string
-  version: string
+  group: string | null
   packageManager: string | null
   description: string | null
   purlName: string
@@ -59,10 +59,17 @@ export interface LinkSuggestion {
 
 export interface DismissedComponent {
   name: string
+  group: string | null
   packageManager: string | null
   description: string | null
   purl: string | null
   dismissedAt: string
+}
+
+export interface ComponentIdentityKey {
+  name: string
+  group?: string | null
+  packageManager?: string | null
 }
 
 export interface ComponentEOLCandidate {
@@ -423,6 +430,7 @@ export class ComponentRepository extends BaseRepository {
       data: records.map(record => ({
         purl: record.get('purl') as string,
         name: record.get('name') as string,
+        group: record.get('group') as string | null,
         packageManager: record.get('packageManager') as string | null,
         description: record.get('description') as string | null,
         purlName: record.get('purlName') as string,
@@ -433,14 +441,22 @@ export class ComponentRepository extends BaseRepository {
     }
   }
 
-  async dismissLink(componentName: string): Promise<void> {
+  async dismissLink(component: ComponentIdentityKey): Promise<void> {
     const query = await loadQuery('components/dismiss-link.cypher')
-    await this.executeQuery(query, { componentName })
+    await this.executeQuery(query, {
+      componentName: component.name,
+      componentGroup: component.group ?? null,
+      componentPackageManager: component.packageManager ?? null
+    })
   }
 
-  async undismissLink(componentName: string): Promise<void> {
+  async undismissLink(component: ComponentIdentityKey): Promise<void> {
     const query = await loadQuery('components/undismiss-link.cypher')
-    await this.executeQuery(query, { componentName })
+    await this.executeQuery(query, {
+      componentName: component.name,
+      componentGroup: component.group ?? null,
+      componentPackageManager: component.packageManager ?? null
+    })
   }
 
   async getDismissedLinks(skip: number, limit: number, search?: string): Promise<{ data: DismissedComponent[]; total: number }> {
@@ -454,6 +470,7 @@ export class ComponentRepository extends BaseRepository {
     return {
       data: records.map(record => ({
         name: record.get('name') as string,
+        group: record.get('group') as string | null,
         packageManager: record.get('packageManager') as string | null,
         description: record.get('description') as string | null,
         purl: record.get('purl') as string | null,

--- a/server/repositories/technology.repository.ts
+++ b/server/repositories/technology.repository.ts
@@ -44,6 +44,8 @@ export interface CreateTechnologyFromComponentParams {
   vendor: string | null
   ownerTeam: string | null
   componentName: string
+  componentGroup?: string | null
+  componentPackageManager?: string | null
   userId: string
   realUserId?: string | null
 }
@@ -210,13 +212,15 @@ export class TechnologyRepository extends BaseRepository {
       vendor: params.vendor || null,
       ownerTeam: params.ownerTeam || null,
       componentName: params.componentName,
+      componentGroup: params.componentGroup ?? null,
+      componentPackageManager: params.componentPackageManager ?? null,
       userId: params.userId,
       realUserId: params.realUserId ?? null,
       changes,
     })
 
     if (records.length === 0) {
-      throw createError({ statusCode: 404, message: `No unlinked component named '${params.componentName}' found` })
+      throw createError({ statusCode: 404, message: `No unlinked component matching '${params.componentName}' (with the given group/package manager) was found` })
     }
 
     return records[0]!.get('name')
@@ -297,9 +301,14 @@ export class TechnologyRepository extends BaseRepository {
   /**
    * Link a component to a technology via IS_VERSION_OF
    */
-  async linkComponent(params: { technologyName: string; componentName: string; componentVersion: string; userId: string; realUserId?: string | null }): Promise<{ technologyName: string; componentName: string; componentVersion: string }> {
+  async linkComponent(params: { technologyName: string; componentName: string; componentVersion: string; componentGroup?: string | null; componentPackageManager?: string | null; userId: string; realUserId?: string | null }): Promise<{ technologyName: string; componentName: string; componentVersion: string }> {
     const query = await loadQuery('technologies/link-component.cypher')
-    const { records } = await this.executeQuery(query, { ...params, realUserId: params.realUserId ?? null })
+    const { records } = await this.executeQuery(query, {
+      ...params,
+      componentGroup: params.componentGroup ?? null,
+      componentPackageManager: params.componentPackageManager ?? null,
+      realUserId: params.realUserId ?? null
+    })
 
     if (records.length === 0) {
       throw new Error('Failed to link component — technology or component not found')
@@ -333,12 +342,17 @@ export class TechnologyRepository extends BaseRepository {
     }
   }
 
-  async linkComponentsByName(params: { technologyName: string; componentName: string; userId: string; realUserId?: string | null }): Promise<{ technologyName: string; name: string; count: number; affectedSystems: string[] }> {
+  async linkComponentsByName(params: { technologyName: string; componentName: string; componentGroup?: string | null; componentPackageManager?: string | null; userId: string; realUserId?: string | null }): Promise<{ technologyName: string; name: string; count: number; affectedSystems: string[] }> {
     const query = await loadQuery('technologies/link-components-by-name.cypher')
-    const { records } = await this.executeQuery(query, { ...params, realUserId: params.realUserId ?? null })
+    const { records } = await this.executeQuery(query, {
+      ...params,
+      componentGroup: params.componentGroup ?? null,
+      componentPackageManager: params.componentPackageManager ?? null,
+      realUserId: params.realUserId ?? null
+    })
 
     if (records.length === 0) {
-      throw createError({ statusCode: 404, message: `No components with name '${params.componentName}' found` })
+      throw createError({ statusCode: 404, message: `No components matching '${params.componentName}' (with the given group/package manager) found that aren't already linked to '${params.technologyName}'` })
     }
 
     return {

--- a/server/services/component.service.ts
+++ b/server/services/component.service.ts
@@ -1,9 +1,9 @@
 import { ComponentRepository } from '../repositories/component.repository'
-import type { ComponentDependencyFilters, ComponentDependencyTree, ComponentFilters, DismissedComponent, LinkSuggestion } from '../repositories/component.repository'
+import type { ComponentDependencyFilters, ComponentDependencyTree, ComponentFilters, ComponentIdentityKey, DismissedComponent, LinkSuggestion } from '../repositories/component.repository'
 import type { Component, ComponentDetail, GroupedComponent } from '~~/types/api'
 import type { ComponentIdentity } from '~~/utils/component-identity'
 
-export type { ComponentFilters, DismissedComponent, LinkSuggestion }
+export type { ComponentFilters, ComponentIdentityKey, DismissedComponent, LinkSuggestion }
 
 /**
  * Service for component-related business logic
@@ -82,12 +82,12 @@ export class ComponentService {
     return { data, count: data.length, total }
   }
 
-  async dismissLink(componentName: string): Promise<void> {
-    await this.componentRepo.dismissLink(componentName)
+  async dismissLink(component: ComponentIdentityKey): Promise<void> {
+    await this.componentRepo.dismissLink(component)
   }
 
-  async undismissLink(componentName: string): Promise<void> {
-    await this.componentRepo.undismissLink(componentName)
+  async undismissLink(component: ComponentIdentityKey): Promise<void> {
+    await this.componentRepo.undismissLink(component)
   }
 
   async getDismissedLinks(skip: number, limit: number, search?: string): Promise<{ data: DismissedComponent[]; count: number; total: number }> {

--- a/server/services/technology.service.ts
+++ b/server/services/technology.service.ts
@@ -40,6 +40,8 @@ export interface CreateTechnologyFromComponentInput {
   vendor?: string
   ownerTeam?: string
   componentName: string
+  componentGroup?: string | null
+  componentPackageManager?: string | null
   userId: string
   realUserId?: string | null
 }
@@ -209,6 +211,8 @@ export class TechnologyService {
       vendor: input.vendor?.trim() || null,
       ownerTeam: input.ownerTeam?.trim() || null,
       componentName: input.componentName.trim(),
+      componentGroup: input.componentGroup ?? null,
+      componentPackageManager: input.componentPackageManager ?? null,
       userId: input.userId,
       realUserId: input.realUserId ?? null
     }
@@ -341,7 +345,7 @@ export class TechnologyService {
   /**
    * Link a component to a technology via IS_VERSION_OF
    */
-  async linkComponent(input: { technologyName: string; componentName: string; componentVersion: string; userId: string; realUserId?: string | null }) {
+  async linkComponent(input: { technologyName: string; componentName: string; componentVersion: string; componentGroup?: string | null; componentPackageManager?: string | null; userId: string; realUserId?: string | null }) {
     const exists = await this.techRepo.exists(input.technologyName)
     if (!exists) {
       throw createError({ statusCode: 404, message: `Technology '${input.technologyName}' not found` })
@@ -384,7 +388,7 @@ export class TechnologyService {
    * that uses the components so that compliance and version-constraint queries
    * reflect the new relationship immediately.
    */
-  async linkComponentByName(input: { technologyName: string; componentName: string; userId: string; realUserId?: string | null }): Promise<{ technologyName: string; name: string; count: number }> {
+  async linkComponentByName(input: { technologyName: string; componentName: string; componentGroup?: string | null; componentPackageManager?: string | null; userId: string; realUserId?: string | null }): Promise<{ technologyName: string; name: string; count: number }> {
     const exists = await this.techRepo.exists(input.technologyName)
     if (!exists) {
       throw createError({ statusCode: 404, message: `Technology '${input.technologyName}' not found` })

--- a/test/server/api/component-dismissed-links.spec.ts
+++ b/test/server/api/component-dismissed-links.spec.ts
@@ -25,6 +25,7 @@ const superuser = { id: 'admin-1', email: 'admin@example.com', role: 'superuser'
 
 const mockDismissed = {
   name: 'left-pad',
+  group: null,
   packageManager: 'npm',
   description: null,
   purl: 'pkg:npm/left-pad@1.3.0',
@@ -90,7 +91,18 @@ describe('[contract] POST /api/components/undismiss-link', () => {
     }))
 
     expect(result).toBeNull()
-    expect(componentService.undismissLink).toHaveBeenCalledWith('left-pad')
+    expect(componentService.undismissLink).toHaveBeenCalledWith({ name: 'left-pad', group: null, packageManager: null })
+  })
+
+  it('should pass componentGroup and componentPackageManager through to disambiguate components sharing a bare name', async () => {
+    vi.mocked(componentService.undismissLink).mockResolvedValue(undefined)
+
+    await undismissLinkHandler(mockEvent({
+      method: 'POST',
+      body: { componentName: 'ui', componentGroup: '@nuxt', componentPackageManager: 'npm' }
+    }))
+
+    expect(componentService.undismissLink).toHaveBeenCalledWith({ name: 'ui', group: '@nuxt', packageManager: 'npm' })
   })
 
   it('should return 400 when componentName is missing', async () => {

--- a/test/server/api/component-link-suggestions.spec.ts
+++ b/test/server/api/component-link-suggestions.spec.ts
@@ -26,6 +26,7 @@ const superuser = { id: 'admin-1', email: 'admin@example.com', role: 'superuser'
 const mockSuggestion = {
   purl: 'pkg:npm/react@18.2.0',
   name: 'react',
+  group: null,
   packageManager: 'npm',
   description: 'A JavaScript library for building user interfaces.',
   purlName: 'react',
@@ -92,7 +93,18 @@ describe('[contract] POST /api/components/dismiss-link', () => {
     }))
 
     expect(result).toBeNull()
-    expect(componentService.dismissLink).toHaveBeenCalledWith('react')
+    expect(componentService.dismissLink).toHaveBeenCalledWith({ name: 'react', group: null, packageManager: null })
+  })
+
+  it('should pass componentGroup and componentPackageManager through to disambiguate components sharing a bare name', async () => {
+    vi.mocked(componentService.dismissLink).mockResolvedValue(undefined)
+
+    await dismissLinkHandler(mockEvent({
+      method: 'POST',
+      body: { componentName: 'ui', componentGroup: '@nuxt', componentPackageManager: 'npm' }
+    }))
+
+    expect(componentService.dismissLink).toHaveBeenCalledWith({ name: 'ui', group: '@nuxt', packageManager: 'npm' })
   })
 
   it('should return 400 when componentName is missing', async () => {

--- a/test/server/repositories/component.repository.spec.ts
+++ b/test/server/repositories/component.repository.spec.ts
@@ -980,4 +980,69 @@ describe('ComponentRepository', () => {
     })
   })
 
+  describe('[contract] getLinkSuggestions() / dismissLink() / undismissLink()', () => {
+    // Regression coverage for the bare-name collision bug: unrelated packages that
+    // happen to share a name across npm scopes (e.g. @nuxt/ui vs @vitest/ui) must
+    // surface as distinct suggestions and be dismissible/linkable independently.
+    async function seedScopedNameCollision() {
+      const componentName = `${PREFIX}ui`
+      await seed(ctx.driver, `
+        CREATE (c1:Component { name: $componentName, version: '4.10.0', packageManager: 'npm', group: '@nuxt', purl: $purl1 })
+        CREATE (c2:Component { name: $componentName, version: '4.1.10', packageManager: 'npm', group: '@vitest', purl: $purl2 })
+        CREATE (s1:System { name: $sys1 })-[:USES { isDirect: true }]->(c1)
+        CREATE (s2:System { name: $sys2 })-[:USES { isDirect: true }]->(c2)
+      `, {
+        componentName,
+        purl1: `pkg:npm/%40nuxt/${componentName}@4.10.0`,
+        purl2: `pkg:npm/%40vitest/${componentName}@4.1.10`,
+        sys1: `${PREFIX}sys-1`,
+        sys2: `${PREFIX}sys-2`
+      })
+      return componentName
+    }
+
+    it('getLinkSuggestions should list components sharing a bare name but differing group as separate suggestions', async () => {
+      if (!ctx.neo4jAvailable) return
+      const componentName = await seedScopedNameCollision()
+
+      const { data } = await repo.getLinkSuggestions(0, 50, componentName)
+      const matches = data.filter(s => s.name === componentName)
+
+      expect(matches).toHaveLength(2)
+      expect(matches.map(m => m.group).sort()).toEqual(['@nuxt', '@vitest'])
+    })
+
+    it('dismissLink should only dismiss the component matching the given group, not others sharing its bare name', async () => {
+      if (!ctx.neo4jAvailable) return
+      const componentName = await seedScopedNameCollision()
+
+      await repo.dismissLink({ name: componentName, group: '@nuxt', packageManager: 'npm' })
+
+      const { records } = await session.run(
+        `MATCH (c:Component {name: $componentName}) RETURN c.group AS group, c.linkDismissedAt AS dismissedAt`,
+        { componentName }
+      )
+      const byGroup = new Map(records.map(r => [r.get('group'), r.get('dismissedAt')]))
+      expect(byGroup.get('@nuxt')).not.toBeNull()
+      expect(byGroup.get('@vitest')).toBeNull()
+    })
+
+    it('undismissLink should only restore the component matching the given group, not others sharing its bare name', async () => {
+      if (!ctx.neo4jAvailable) return
+      const componentName = await seedScopedNameCollision()
+
+      await repo.dismissLink({ name: componentName, group: '@nuxt', packageManager: 'npm' })
+      await repo.dismissLink({ name: componentName, group: '@vitest', packageManager: 'npm' })
+      await repo.undismissLink({ name: componentName, group: '@nuxt', packageManager: 'npm' })
+
+      const { records } = await session.run(
+        `MATCH (c:Component {name: $componentName}) RETURN c.group AS group, c.linkDismissedAt AS dismissedAt`,
+        { componentName }
+      )
+      const byGroup = new Map(records.map(r => [r.get('group'), r.get('dismissedAt')]))
+      expect(byGroup.get('@nuxt')).toBeNull()
+      expect(byGroup.get('@vitest')).not.toBeNull()
+    })
+  })
+
 })

--- a/test/server/repositories/technology.repository.spec.ts
+++ b/test/server/repositories/technology.repository.spec.ts
@@ -76,6 +76,7 @@ describe('TechnologyRepository', () => {
         vendor: 'Meta',
         ownerTeam: null,
         componentName,
+        componentPackageManager: 'npm',
         userId: 'test-user'
       })
 
@@ -120,8 +121,37 @@ describe('TechnologyRepository', () => {
         vendor: null,
         ownerTeam: null,
         componentName,
+        componentPackageManager: 'npm',
         userId: 'test-user'
       })).rejects.toMatchObject({ statusCode: 404 })
+    })
+
+    it('should not cross-link unrelated components that share a bare name but differ in group', async () => {
+      if (!ctx.neo4jAvailable) return
+      const componentName = `${PREFIX}ui`
+      await seed(ctx.driver, `
+        CREATE (:Component { purl: $purl1, name: $componentName, version: '4.10.0', packageManager: 'npm', group: '@nuxt' })
+        CREATE (:Component { purl: $purl2, name: $componentName, version: '4.1.10', packageManager: 'npm', group: '@vitest' })
+      `, { purl1: `pkg:npm/%40nuxt/${componentName}@4.10.0`, purl2: `pkg:npm/%40vitest/${componentName}@4.1.10`, componentName })
+
+      await repo.createFromComponent({
+        name: `${PREFIX}NuxtUI`,
+        type: 'library',
+        domain: null,
+        vendor: null,
+        ownerTeam: null,
+        componentName,
+        componentGroup: '@nuxt',
+        componentPackageManager: 'npm',
+        userId: 'test-user'
+      })
+
+      const { records } = await session.run(
+        `MATCH (c:Component {name: $componentName})-[:IS_VERSION_OF]->(t:Technology {name: $name}) RETURN c.group AS group`,
+        { componentName, name: `${PREFIX}NuxtUI` }
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0]!.get('group')).toBe('@nuxt')
     })
   })
 
@@ -321,8 +351,34 @@ describe('TechnologyRepository', () => {
         userId: 'user-1',
       })
 
-      expect(result.count).toBeGreaterThanOrEqual(1)
+      expect(result.count).toBe(2)
       expect(result.affectedSystems.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('linkComponentsByName should not cross-link unrelated components that share a bare name but differ in group', async () => {
+      if (!ctx.neo4jAvailable) return
+      await seed(ctx.driver, `
+        CREATE (t:Technology { name: $tech, type: 'library' })
+        CREATE (:Component { name: $comp, version: '4.10.0', packageManager: 'npm', group: '@nuxt' })
+        CREATE (:Component { name: $comp, version: '4.1.10', packageManager: 'npm', group: '@vitest' })
+      `, { tech: `${PREFIX}scoped-tech`, comp: `${PREFIX}ui` })
+
+      const result = await repo.linkComponentsByName({
+        technologyName: `${PREFIX}scoped-tech`,
+        componentName: `${PREFIX}ui`,
+        componentGroup: '@nuxt',
+        componentPackageManager: 'npm',
+        userId: 'user-1',
+      })
+
+      expect(result.count).toBe(1)
+
+      const { records } = await session.run(
+        `MATCH (c:Component {name: $comp})-[:IS_VERSION_OF]->(t:Technology {name: $tech}) RETURN c.group AS group`,
+        { comp: `${PREFIX}ui`, tech: `${PREFIX}scoped-tech` }
+      )
+      expect(records).toHaveLength(1)
+      expect(records[0]!.get('group')).toBe('@nuxt')
     })
 
     it('linkComponentsByName should create a LINK AuditLog entry', async () => {

--- a/test/server/services/technology.service.spec.ts
+++ b/test/server/services/technology.service.spec.ts
@@ -153,6 +153,18 @@ describe('TechnologyService', () => {
       expect(params.domain).toBeNull()
       expect(params.vendor).toBeNull()
       expect(params.ownerTeam).toBeNull()
+      expect(params.componentGroup).toBeNull()
+      expect(params.componentPackageManager).toBeNull()
+    })
+
+    it('should pass componentGroup and componentPackageManager through when provided, to disambiguate components sharing a bare name', async () => {
+      await service.createFromComponent({
+        name: 'React', type: 'framework', componentName: 'ui', componentGroup: '@nuxt', componentPackageManager: 'npm', userId: 'u1'
+      })
+
+      const params = vi.mocked(TechnologyRepository.prototype.createFromComponent).mock.calls[0][0]
+      expect(params.componentGroup).toBe('@nuxt')
+      expect(params.componentPackageManager).toBe('npm')
     })
 
     it('should coerce empty string optional fields to null', async () => {


### PR DESCRIPTION
## Description

Fixes a data-integrity bug found while investigating why the `Nuxt UI` technology
appeared to be both a direct and transitive dependency: the entire
component-to-technology linking chain (suggestion queue, create-from-component,
bulk link-by-name, single link, dismiss/undismiss) matched Components by bare
package `name` only. Unrelated packages sharing a name across different npm
scopes or ecosystems (e.g. `@nuxt/ui` vs `@vitest/ui`, npm `d3` vs `@types/d3`)
were being silently cross-linked into the same Technology, or hidden behind a
single merged row in the Component Link Queue.

Also folds in a related UX change from the same investigation: version
constraints can now be created directly from the Technology page (name
auto-generated from severity/scope/version-range, fields reordered by
relevance), and the constraint "description" field was relabeled "Rationale"
since severity/scope/versionRange now carry the mechanical meaning it used to.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Changes Made

- 7 Cypher queries (suggestions, count, create-from-component, link-by-name, link-component, dismiss/undismiss) now match/dedupe on `(name, group, packageManager)` instead of bare `name`. Also fixed a latent bug in `link-components-by-name.cypher` where the reported linked count was always `1` regardless of how many components actually got linked.
- `component.repository.ts` / `technology.repository.ts` / their services now thread `componentGroup` / `componentPackageManager` through to the queries above.
- 4 API handlers (`technologies.post`, `technologies/[name]/components.post`, `components/dismiss-link.post`, `components/undismiss-link.post`) accept the new optional fields; OpenAPI docs regenerated.
- `admin/component-links.vue`, `admin/dismissed-links.vue`, `LinkComponentModal.vue`, and `ComponentVersionsModal.vue`'s deep link now display group-qualified names (e.g. `@nuxt/ui` instead of bare `ui`) and pass group/packageManager through confirm/create/dismiss/restore/link actions.
- New regression tests reproduce the exact `@nuxt/ui` vs `@vitest/ui` collision against a live Neo4j test DB (suggestions stay separate rows; dismiss/undismiss/link only affect the targeted identity).
- Technology page: added an "Add Constraint" action that opens a version-constraint form scoped to the current technology, with an auto-generated (editable) name and fields ordered by relevance (Version Range → Severity/Scope → Subject Team → Name → Rationale). The central `/version-constraints` create/edit modals were reordered the same way for consistency.

## Data note

A live-database cleanup (run directly against Neo4j, not part of this diff)
already unlinked 9 previously mismatched components using this same identity
logic: `@unhead/vue`, `@floating-ui/vue`, `@iconify/vue` from `Vue`;
`@dxup/nuxt` from `Nuxt`; `@vitest/ui` from `Nuxt UI`; `@types/d3` from `d3`.
Each removal is recorded as an `UNLINK` AuditLog entry. Verified beforehand
that every affected system also directly uses the correct package, so no
team/system loses legitimate "uses this technology" status as a side effect.

## Testing

- `run_lint` — clean
- `run_tests` for `utils`, `services`, `repositories`, `api`, `app` layers, plus `test/schema` and `test/app/e2e` — all passing (1,141 tests total)
- `run_mdlint` — pre-existing, unrelated `CHANGELOG.md` findings only (not touched by this PR)
- `generate_docs` — `public/openapi.json` regenerated for the new request fields

## Checklist

- [x] I have run lint and fixed any issues
- [x] I have run the test suite and all tests pass
- [x] Documentation (OpenAPI) regenerated where needed
