### PR TITLE
feat(licenses): add "Direct only" toggle to License Inventory

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -24,7 +24,7 @@ categories:
       - 'config'
       - 'configuration'
 
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-template: '* $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 
 version-resolver:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- Add Background Jobs admin page (cancel/delete for import + health-refresh jobs) @localgod (#792)
+* Add Background Jobs admin page (cancel/delete for import + health-refresh jobs) @localgod (#792)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.78...v0.6.79
 
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps-dev): bump the development-dependencies group across 1 directory with 5 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#777)
+* chore(deps)(deps-dev): bump the development-dependencies group across 1 directory with 5 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#777)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.71...v0.6.72
 
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- Implement version sprawl detection and consolidation recommendations @localgod (#759)
+* Implement version sprawl detection and consolidation recommendations @localgod (#759)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.62...v0.6.63
 
@@ -57,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- feat: automated service and team compliance scorecard with per-check drill-down @localgod (#743)
+* feat: automated service and team compliance scorecard with per-check drill-down @localgod (#743)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.56...v0.6.57
 
@@ -65,7 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- Add shared search box across entity list pages @localgod (#734)
+* Add shared search box across entity list pages @localgod (#734)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.51...v0.6.52
 
@@ -73,7 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- No changes
+* No changes
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.48...v0.6.49
 
@@ -81,7 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix(sbom): correctly mark isDirect for Composer and other SPDX SBOMs (#722) @localgod (#725)
+* fix(sbom): correctly mark isDirect for Composer and other SPDX SBOMs (#722) @localgod (#725)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.46...v0.6.47
 
@@ -91,7 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps): bump the production-dependencies group across 1 directory with 2 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#688)
+* chore(deps)(deps): bump the production-dependencies group across 1 directory with 2 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#688)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.28...v0.6.29
 
@@ -99,7 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- Improve component detail dependency layout @localgod (#664)
+* Improve component detail dependency layout @localgod (#664)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.13...v0.6.14
 
@@ -109,7 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps-dev): bump @cucumber/gherkin from 39.1.0 to 40.0.0 @[dependabot[bot]](https://github.com/apps/dependabot) (#644)
+* chore(deps)(deps-dev): bump @cucumber/gherkin from 39.1.0 to 40.0.0 @[dependabot[bot]](https://github.com/apps/dependabot) (#644)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.6.6...v0.6.7
 
@@ -117,7 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- Add deps.dev package metadata overlay @localgod (#613)
+* Add deps.dev package metadata overlay @localgod (#613)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.48...v0.5.49
 
@@ -127,7 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps-dev): bump the development-dependencies group with 4 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#606)
+* chore(deps)(deps-dev): bump the development-dependencies group with 4 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#606)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.45...v0.5.46
 
@@ -137,7 +137,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps-dev): bump the development-dependencies group with 6 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#593)
+* chore(deps)(deps-dev): bump the development-dependencies group with 6 updates @[dependabot[bot]](https://github.com/apps/dependabot) (#593)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.41...v0.5.42
 
@@ -145,7 +145,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: move dependency scope from Component node to USES/DIRECT\_DEP edges @localgod (#582)
+* fix: move dependency scope from Component node to USES/DIRECT\_DEP edges @localgod (#582)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.36...v0.5.37
 
@@ -153,11 +153,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: make ownerTeam required in GitHub import dialog @localgod (#565)
+* fix: make ownerTeam required in GitHub import dialog @localgod (#565)
 
 ## 🔧 Maintenance
 
-- chore: release v0.5.28 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#564)
+* chore: release v0.5.28 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#564)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.28...v0.5.29
 
@@ -165,7 +165,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- feat: use Simple Icons for package manager types @localgod (#563)
+* feat: use Simple Icons for package manager types @localgod (#563)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.27...v0.5.28
 
@@ -175,7 +175,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(deps)(deps): bump devalue from 5.8.0 to 5.8.1 @[dependabot[bot]](https://github.com/apps/dependabot) (#506)
+* chore(deps)(deps): bump devalue from 5.8.0 to 5.8.1 @[dependabot[bot]](https://github.com/apps/dependabot) (#506)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.5.8...v0.5.9
 
@@ -185,7 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🚀 Features
 
-- fix: neo4j plugin fails fast on connection failure at startup @localgod (#492)
+* fix: neo4j plugin fails fast on connection failure at startup @localgod (#492)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.4.2...v0.5.0
 
@@ -193,7 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- feat: dependency graph, SBOM pipeline fixes, and component filtering @localgod (#476)
+* feat: dependency graph, SBOM pipeline fixes, and component filtering @localgod (#476)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.85...v0.1.86
 
@@ -203,7 +203,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(actions): bump dorny/paths-filter from 3 to 4 @[dependabot[bot]](https://github.com/apps/dependabot) (#463)
+* chore(actions): bump dorny/paths-filter from 3 to 4 @[dependabot[bot]](https://github.com/apps/dependabot) (#463)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.81...v0.1.82
 
@@ -213,7 +213,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.77 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#459)
+* chore: release v0.1.77 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#459)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.77...v0.1.78
 
@@ -221,7 +221,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- feat: environment-scoped technology approvals @localgod (#458)
+* feat: environment-scoped technology approvals @localgod (#458)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.76...v0.1.77
 
@@ -229,7 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: regenerate lockfile and fix CHANGELOG markdown lint errors @localgod (#330)
+* fix: regenerate lockfile and fix CHANGELOG markdown lint errors @localgod (#330)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.27...v0.1.28
 
@@ -237,11 +237,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- chore(deps): ignore next-auth >=4.23.0 in dependabot @localgod (#320)
+* chore(deps): ignore next-auth >=4.23.0 in dependabot @localgod (#320)
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.22 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#319)
+* chore: release v0.1.22 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#319)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.22...v0.1.23
 
@@ -249,11 +249,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: replace scp-action with inline SSH heredoc for compose file @localgod (#318)
+* fix: replace scp-action with inline SSH heredoc for compose file @localgod (#318)
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.21 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#317)
+* chore: release v0.1.21 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#317)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.21...v0.1.22
 
@@ -263,7 +263,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.19 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#313)
+* chore: release v0.1.19 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#313)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.20...v0.1.21
 
@@ -273,7 +273,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore(actions): bump actions/checkout from 4 to 6 @[dependabot[bot]](https://github.com/apps/dependabot) (#310)
+* chore(actions): bump actions/checkout from 4 to 6 @[dependabot[bot]](https://github.com/apps/dependabot) (#310)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.18...v0.1.19
 
@@ -283,7 +283,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.10 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#294)
+* chore: release v0.1.10 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#294)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.12...v0.1.13
 
@@ -291,11 +291,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- fix: add mobile top bar with sidebar trigger @localgod (#293)
+* fix: add mobile top bar with sidebar trigger @localgod (#293)
 
 ## 🔧 Maintenance
 
-- chore: release v0.1.9 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#292)
+* chore: release v0.1.9 [skip ci] @[github-actions[bot]](https://github.com/apps/github-actions) (#292)
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.9...v0.1.10
 
@@ -303,6 +303,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## What's Changed
 
-- No changes
+* No changes
 
 **Full Changelog**: https://github.com/localgod/polaris/compare/v0.1.8...v0.1.9

--- a/app/pages/licenses/index.vue
+++ b/app/pages/licenses/index.vue
@@ -1,9 +1,12 @@
 <template>
   <div class="space-y-6">
-    <UPageHeader
-      title="License Inventory"
-      description="Licenses discovered across all components"
-    />
+    <div class="flex items-center justify-between gap-3">
+      <UPageHeader
+        title="License Inventory"
+        description="Licenses discovered across all components"
+      />
+      <USwitch v-model="directOnly" label="Direct only" size="sm" />
+    </div>
 
     <UAlert
       v-if="error"
@@ -142,8 +145,13 @@ const columns: TableColumn<License>[] = [
 
 const { searchInput, debouncedSearch } = useTableSearch()
 
+// Page-wide toggle, defaulting to direct dependencies only — mirrors the
+// concept on the technology detail page. Switch it off to include licenses
+// that only appear via a transitive component.
+const directOnly = ref(true)
+
 const { sorting, page, pageSize, offset, sortBy, sortOrder } = usePaginatedSorting({
-  resetOn: [debouncedSearch]
+  resetOn: [debouncedSearch, directOnly]
 })
 
 // Pass individual refs/computeds as query values so each one is tracked
@@ -154,7 +162,8 @@ const { data, pending, error } = await useFetch<ApiResponse<License>>('/api/lice
     offset,
     sortBy,
     sortOrder,
-    search: debouncedSearch
+    search: debouncedSearch,
+    direct: directOnly
   }
 })
 

--- a/app/pages/technologies/index.vue
+++ b/app/pages/technologies/index.vue
@@ -26,13 +26,6 @@
             @click="viewMode = 'radar'"
           />
         </div>
-        <UButton
-          v-if="isSuperuser"
-          size="sm"
-          label="+ Create Technology"
-          icon="i-lucide-link"
-          to="/admin/component-links"
-        />
       </div>
     </div>
 

--- a/public/openapi.json
+++ b/public/openapi.json
@@ -2364,6 +2364,14 @@
           },
           {
             "in": "query",
+            "name": "direct",
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "When true, restrict componentCount to direct dependencies only and exclude licenses with none"
+          },
+          {
+            "in": "query",
             "name": "limit",
             "schema": {
               "type": "integer",
@@ -2429,7 +2437,7 @@
                               },
                               "componentCount": {
                                 "type": "integer",
-                                "description": "Number of components using this license"
+                                "description": "Number of components using this license (direct dependencies only when the `direct` filter is set)"
                               }
                             }
                           }

--- a/server/api/licenses.get.ts
+++ b/server/api/licenses.get.ts
@@ -34,6 +34,11 @@ import { licenseService } from '../services/singletons'
  *           type: string
  *         description: Search by license ID or name
  *       - in: query
+ *         name: direct
+ *         schema:
+ *           type: boolean
+ *         description: When true, restrict componentCount to direct dependencies only and exclude licenses with none
+ *       - in: query
  *         name: limit
  *         schema:
  *           type: integer
@@ -83,7 +88,7 @@ import { licenseService } from '../services/singletons'
  *                             description: Whether license is deprecated
  *                           componentCount:
  *                             type: integer
- *                             description: Number of components using this license
+ *                             description: Number of components using this license (direct dependencies only when the `direct` filter is set)
  *                     total:
  *                       type: integer
  *                       description: Total number of licenses
@@ -112,6 +117,7 @@ export default defineEventHandler(async (event): Promise<ApiResponse<License>> =
       osiApproved: query.osiApproved === 'true' ? true : query.osiApproved === 'false' ? false : undefined,
       deprecated: query.deprecated === 'true' ? true : query.deprecated === 'false' ? false : undefined,
       search: query.search as string | undefined,
+      directOnly: query.direct === 'true' ? true : undefined,
       sortBy: query.sortBy as string | undefined,
       sortOrder: (query.sortOrder as string)?.toLowerCase() === 'desc' ? 'desc' as const : 'asc' as const,
       limit,

--- a/server/database/queries/licenses/count.cypher
+++ b/server/database/queries/licenses/count.cypher
@@ -1,3 +1,9 @@
 MATCH (l:License)
 {{WHERE_CONDITIONS}}
+OPTIONAL MATCH (c:Component)-[:HAS_LICENSE]->(l)
+OPTIONAL MATCH (:System)-[u:USES]->(c)
+WITH l, c, coalesce(max(CASE WHEN u.isDirect = true THEN 1 ELSE 0 END), 0) = 1 as componentIsDirect
+WHERE c IS NULL OR $directOnly = false OR componentIsDirect
+WITH l, count(c) as componentCount
+WHERE $directOnly = false OR componentCount > 0
 RETURN count(l) as total

--- a/server/database/queries/licenses/find-all.cypher
+++ b/server/database/queries/licenses/find-all.cypher
@@ -1,7 +1,14 @@
+// $directOnly (boolean) — when true, only components with at least one
+// direct System-USES edge (u.isDirect = true) count toward componentCount,
+// and licenses left with zero such components are excluded entirely.
 MATCH (l:License)
 {{WHERE_CONDITIONS}}
 OPTIONAL MATCH (c:Component)-[:HAS_LICENSE]->(l)
-WITH l, count(DISTINCT c) as componentCount
+OPTIONAL MATCH (:System)-[u:USES]->(c)
+WITH l, c, coalesce(max(CASE WHEN u.isDirect = true THEN 1 ELSE 0 END), 0) = 1 as componentIsDirect
+WHERE c IS NULL OR $directOnly = false OR componentIsDirect
+WITH l, count(c) as componentCount
+WHERE $directOnly = false OR componentCount > 0
 RETURN
   l.id as id,
   l.name as name,

--- a/server/repositories/license.repository.ts
+++ b/server/repositories/license.repository.ts
@@ -47,6 +47,8 @@ export interface LicenseFilters {
   deprecated?: boolean
   allowed?: boolean
   search?: string
+  /** Restrict to licenses used by at least one direct dependency (USES {isDirect: true}) */
+  directOnly?: boolean
   limit?: number
   offset?: number
   sortBy?: string
@@ -384,6 +386,10 @@ export class LicenseRepository extends BaseRepository {
       conditions.push('(toLower(l.id) CONTAINS toLower($search) OR toLower(l.name) CONTAINS toLower($search))')
       params.search = filters.search
     }
+
+    // Always bound: find-all.cypher/count.cypher reference $directOnly directly
+    // (not via the WHERE_CONDITIONS placeholder), so it must always be present.
+    params.directOnly = filters.directOnly ?? false
 
     return { conditions, params }
   }

--- a/test/server/repositories/license.repository.spec.ts
+++ b/test/server/repositories/license.repository.spec.ts
@@ -948,4 +948,52 @@ describe('LicenseRepository', () => {
       expect(testLicenses[0].category).toBe('permissive')
     })
   })
+
+  describe('[contract] findAll()/count() with directOnly filter', () => {
+    it('counts only direct usage and excludes licenses with none when directOnly is true', async () => {
+      if (!ctx.neo4jAvailable) return
+
+      // MIT: used both directly and transitively across two systems
+      // GPL: used only transitively — must disappear when directOnly is true
+      await session.run(`
+        CREATE (mit:License { id: $mitId, name: 'MIT License', spdxId: 'MIT', category: 'permissive', deprecated: false, createdAt: datetime(), updatedAt: datetime() })
+        CREATE (gpl:License { id: $gplId, name: 'GPL 3.0', spdxId: 'GPL-3.0', category: 'copyleft', deprecated: false, createdAt: datetime(), updatedAt: datetime() })
+        CREATE (compDirect:Component { name: $compDirectName, version: '1.0.0', purl: $compDirectPurl })
+        CREATE (compTransitive:Component { name: $compTransitiveName, version: '1.0.0', purl: $compTransitivePurl })
+        CREATE (compGpl:Component { name: $compGplName, version: '1.0.0', purl: $compGplPurl })
+        CREATE (sys:System { name: $sysName })
+        CREATE (compDirect)-[:HAS_LICENSE]->(mit)
+        CREATE (compTransitive)-[:HAS_LICENSE]->(mit)
+        CREATE (compGpl)-[:HAS_LICENSE]->(gpl)
+        CREATE (sys)-[:USES { isDirect: true }]->(compDirect)
+        CREATE (sys)-[:USES { isDirect: false }]->(compTransitive)
+        CREATE (sys)-[:USES { isDirect: false }]->(compGpl)
+      `, {
+        mitId: `${PREFIX}MIT`,
+        gplId: `${PREFIX}GPL-3.0`,
+        compDirectName: `${PREFIX}comp-direct`,
+        compDirectPurl: `pkg:npm/${PREFIX}comp-direct@1.0.0`,
+        compTransitiveName: `${PREFIX}comp-transitive`,
+        compTransitivePurl: `pkg:npm/${PREFIX}comp-transitive@1.0.0`,
+        compGplName: `${PREFIX}comp-gpl`,
+        compGplPurl: `pkg:npm/${PREFIX}comp-gpl@1.0.0`,
+        sysName: `${PREFIX}sys`
+      })
+
+      // Off: both licenses present, MIT counts both its components
+      const allResult = await licenseRepo.findAll({ search: PREFIX })
+      const mitAll = allResult.find(l => l.id === `${PREFIX}MIT`)
+      const gplAll = allResult.find(l => l.id === `${PREFIX}GPL-3.0`)
+      expect(mitAll?.componentCount).toBe(2)
+      expect(gplAll?.componentCount).toBe(1)
+      expect(await licenseRepo.count({ search: PREFIX })).toBe(2)
+
+      // On: GPL (transitive-only) drops out entirely, MIT counts only its direct component
+      const directResult = await licenseRepo.findAll({ search: PREFIX, directOnly: true })
+      const mitDirect = directResult.find(l => l.id === `${PREFIX}MIT`)
+      expect(mitDirect?.componentCount).toBe(1)
+      expect(directResult.find(l => l.id === `${PREFIX}GPL-3.0`)).toBeUndefined()
+      expect(await licenseRepo.count({ search: PREFIX, directOnly: true })).toBe(1)
+    })
+  })
 })


### PR DESCRIPTION
## Description

Adds a "Direct only" toggle to the License Inventory page (`/licenses`), mirroring the toggle already on the technology detail page (`/technologies/[name]`). When enabled (the default), `componentCount` and the license list are restricted to components with at least one direct `System-USES` edge (`isDirect: true`); licenses whose only usage is transitive drop out of the list entirely. Toggle it off to see the full picture, matching the page's previous behavior.

Bundled from the same session (small, unrelated fixes made along the way):
- Removed the "+ Create Technology" button from `/technologies` — technology creation now only happens via the `/admin/component-links` queue.
- Fixed `release-drafter.yml`'s `change-template` bullet style (`-` → `*`) so future generated `CHANGELOG.md` entries stop failing markdownlint's MD004 list-style-consistency check against the rest of the file. Also ran `mdlint --fix` once to normalize the existing CHANGELOG.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Schema update (changes to database schemas)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration or build changes

## Changes Made

- Added a "Direct only" `USwitch` to the License Inventory page header, defaulting to on, resetting pagination when toggled.
- `/api/licenses` now accepts a `direct` query param (same convention as `/api/licenses/violations`).
- `licenses/find-all.cypher` and `licenses/count.cypher` filter `componentCount`/results by direct `USES` usage when `directOnly` is set.
- Regenerated `public/openapi.json` for the new `direct` param.
- Added a `[contract]` repository test covering both toggle states.

## Checklist

- [x] I have performed a self-review of my changes
- [x] I have run `npm run lint` and fixed any issues (no issues found)
- [x] I have run `npm run mdlint` and fixed any issues (no issues found)
- [x] Ran the full unit test suite by layer (utils/services/repositories/api/app/schema/e2e) — all passing
- [x] Verified the toggle live against the dev server (MIT: 47 direct vs 2210 including transitive)